### PR TITLE
Add OAuth login with PKCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,21 @@ This makes the `td` command available globally.
 
 ## Setup
 
-Get your Todoist API token from [Todoist Settings > Integrations > Developer](https://todoist.com/app/settings/integrations/developer), then:
+```bash
+td login
+```
+
+This opens your browser to authenticate with Todoist. Once approved, the token is saved automatically.
+
+### Alternative methods
+
+**Manual token:** Get your API token from [Todoist Settings > Integrations > Developer](https://todoist.com/app/settings/integrations/developer):
 
 ```bash
 td login token "your-token"
 ```
 
-Alternatively, set an environment variable:
+**Environment variable:**
 
 ```bash
 export TODOIST_API_TOKEN="your-token"

--- a/src/__tests__/login.test.ts
+++ b/src/__tests__/login.test.ts
@@ -14,10 +14,42 @@ vi.mock('chalk', () => ({
   },
 }))
 
+// Mock PKCE module
+vi.mock('../lib/pkce.js', () => ({
+  generateCodeVerifier: vi.fn(() => 'test_code_verifier'),
+  generateCodeChallenge: vi.fn(() => 'test_code_challenge'),
+  generateState: vi.fn(() => 'test_state'),
+}))
+
+// Mock OAuth server
+vi.mock('../lib/oauth-server.js', () => ({
+  startCallbackServer: vi.fn(),
+  OAUTH_REDIRECT_URI: 'http://localhost:8765/callback',
+}))
+
+// Mock OAuth module
+vi.mock('../lib/oauth.js', () => ({
+  buildAuthorizationUrl: vi.fn(
+    () => 'https://todoist.com/oauth/authorize?test=1'
+  ),
+  exchangeCodeForToken: vi.fn(),
+}))
+
+// Mock open module
+vi.mock('open', () => ({
+  default: vi.fn(),
+}))
+
 import { saveApiToken } from '../lib/auth.js'
+import { startCallbackServer } from '../lib/oauth-server.js'
+import { exchangeCodeForToken } from '../lib/oauth.js'
 import { registerLoginCommand } from '../commands/login.js'
+import open from 'open'
 
 const mockSaveApiToken = vi.mocked(saveApiToken)
+const mockStartCallbackServer = vi.mocked(startCallbackServer)
+const mockExchangeCodeForToken = vi.mocked(exchangeCodeForToken)
+const mockOpen = vi.mocked(open)
 
 function createProgram() {
   const program = new Command()
@@ -31,8 +63,6 @@ describe('login command', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-
-    // Mock console.log to capture output
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
   })
 
@@ -45,15 +75,11 @@ describe('login command', () => {
       const program = createProgram()
       const token = 'some_token_123456789'
 
-      // Mock successful token save
       mockSaveApiToken.mockResolvedValue(undefined)
 
       await program.parseAsync(['node', 'td', 'login', 'token', token])
 
-      // Verify token was saved
       expect(mockSaveApiToken).toHaveBeenCalledWith(token)
-
-      // Verify success message
       expect(consoleSpy).toHaveBeenCalledWith(
         '✓',
         'API token saved successfully!'
@@ -67,7 +93,6 @@ describe('login command', () => {
       const program = createProgram()
       const token = 'some_token_123456789'
 
-      // Mock save failure
       mockSaveApiToken.mockRejectedValue(new Error('Permission denied'))
 
       await expect(
@@ -94,14 +119,60 @@ describe('login command', () => {
 
       expect(mockSaveApiToken).toHaveBeenCalledWith(expectedToken)
     })
+  })
 
-    it('shows help when no arguments provided', async () => {
+  describe('OAuth flow', () => {
+    it('completes OAuth flow successfully', async () => {
+      const program = createProgram()
+      const authCode = 'oauth_auth_code_123'
+      const accessToken = 'oauth_access_token_456'
+
+      mockStartCallbackServer.mockResolvedValue(authCode)
+      mockExchangeCodeForToken.mockResolvedValue(accessToken)
+      mockSaveApiToken.mockResolvedValue(undefined)
+      mockOpen.mockResolvedValue({} as any)
+
+      await program.parseAsync(['node', 'td', 'login'])
+
+      expect(mockOpen).toHaveBeenCalledWith(
+        'https://todoist.com/oauth/authorize?test=1'
+      )
+      expect(mockStartCallbackServer).toHaveBeenCalledWith('test_state')
+      expect(mockExchangeCodeForToken).toHaveBeenCalledWith(
+        authCode,
+        'test_code_verifier'
+      )
+      expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken)
+      expect(consoleSpy).toHaveBeenCalledWith('✓', 'Successfully logged in!')
+    })
+
+    it('handles OAuth callback server error', async () => {
       const program = createProgram()
 
-      // This should show help for the login command
-      await expect(
-        program.parseAsync(['node', 'td', 'login'])
-      ).rejects.toThrow() // Commander throws when required argument is missing
+      mockStartCallbackServer.mockRejectedValue(
+        new Error('OAuth callback timed out')
+      )
+      mockOpen.mockResolvedValue({} as any)
+
+      await expect(program.parseAsync(['node', 'td', 'login'])).rejects.toThrow(
+        'OAuth callback timed out'
+      )
+
+      expect(mockSaveApiToken).not.toHaveBeenCalled()
+    })
+
+    it('handles token exchange error', async () => {
+      const program = createProgram()
+
+      mockStartCallbackServer.mockResolvedValue('auth_code')
+      mockExchangeCodeForToken.mockRejectedValue(
+        new Error('Token exchange failed: 400')
+      )
+      mockOpen.mockResolvedValue({} as any)
+
+      await expect(program.parseAsync(['node', 'td', 'login'])).rejects.toThrow(
+        'Token exchange failed'
+      )
 
       expect(mockSaveApiToken).not.toHaveBeenCalled()
     })

--- a/src/__tests__/pkce.test.ts
+++ b/src/__tests__/pkce.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import {
+  generateCodeVerifier,
+  generateCodeChallenge,
+  generateState,
+} from '../lib/pkce.js'
+
+describe('PKCE utilities', () => {
+  describe('generateCodeVerifier', () => {
+    it('generates a 64-character string', () => {
+      const verifier = generateCodeVerifier()
+      expect(verifier).toHaveLength(64)
+    })
+
+    it('only contains valid characters', () => {
+      const verifier = generateCodeVerifier()
+      expect(verifier).toMatch(/^[A-Za-z0-9\-._~]+$/)
+    })
+
+    it('generates unique values', () => {
+      const verifier1 = generateCodeVerifier()
+      const verifier2 = generateCodeVerifier()
+      expect(verifier1).not.toBe(verifier2)
+    })
+  })
+
+  describe('generateCodeChallenge', () => {
+    it('generates base64url-encoded SHA256 hash', () => {
+      const verifier = 'test_verifier_1234567890'
+      const challenge = generateCodeChallenge(verifier)
+
+      // base64url has no padding and uses - and _ instead of + and /
+      expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/)
+    })
+
+    it('produces consistent output for same input', () => {
+      const verifier = 'consistent_verifier_123'
+      const challenge1 = generateCodeChallenge(verifier)
+      const challenge2 = generateCodeChallenge(verifier)
+      expect(challenge1).toBe(challenge2)
+    })
+
+    it('produces different output for different input', () => {
+      const challenge1 = generateCodeChallenge('verifier1')
+      const challenge2 = generateCodeChallenge('verifier2')
+      expect(challenge1).not.toBe(challenge2)
+    })
+  })
+
+  describe('generateState', () => {
+    it('generates a 32-character hex string', () => {
+      const state = generateState()
+      expect(state).toHaveLength(32)
+      expect(state).toMatch(/^[0-9a-f]+$/)
+    })
+
+    it('generates unique values', () => {
+      const state1 = generateState()
+      const state2 = generateState()
+      expect(state1).not.toBe(state2)
+    })
+  })
+})

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,26 +1,52 @@
 import { Command } from 'commander'
 import { saveApiToken } from '../lib/auth.js'
+import {
+  generateCodeVerifier,
+  generateCodeChallenge,
+  generateState,
+} from '../lib/pkce.js'
+import { startCallbackServer } from '../lib/oauth-server.js'
+import { buildAuthorizationUrl, exchangeCodeForToken } from '../lib/oauth.js'
 import chalk from 'chalk'
+import open from 'open'
 
 async function loginWithToken(token: string): Promise<void> {
-  try {
-    // Save token to config
-    await saveApiToken(token.trim())
+  await saveApiToken(token.trim())
+  console.log(chalk.green('✓'), 'API token saved successfully!')
+  console.log(chalk.dim('Token saved to ~/.config/todoist-cli/config.json'))
+}
 
-    console.log(chalk.green('✓'), 'API token saved successfully!')
-    console.log(chalk.dim('Token saved to ~/.config/todoist-cli/config.json'))
-  } catch (error: any) {
-    throw error
-  }
+async function loginWithOAuth(): Promise<void> {
+  const codeVerifier = generateCodeVerifier()
+  const codeChallenge = generateCodeChallenge(codeVerifier)
+  const state = generateState()
+
+  console.log('Opening browser for Todoist authorization...')
+
+  const authUrl = buildAuthorizationUrl(codeChallenge, state)
+  const callbackPromise = startCallbackServer(state)
+
+  await open(authUrl)
+  console.log(chalk.dim('Waiting for authorization...'))
+
+  const code = await callbackPromise
+  console.log(chalk.dim('Exchanging code for token...'))
+
+  const accessToken = await exchangeCodeForToken(code, codeVerifier)
+  await saveApiToken(accessToken)
+
+  console.log(chalk.green('✓'), 'Successfully logged in!')
+  console.log(chalk.dim('Token saved to ~/.config/todoist-cli/config.json'))
 }
 
 export function registerLoginCommand(program: Command): void {
   const login = program
     .command('login')
     .description('Authenticate with Todoist')
+    .action(loginWithOAuth)
 
   login
     .command('token <token>')
-    .description('Save API token to config file')
+    .description('Save API token to config file (manual authentication)')
     .action(loginWithToken)
 }

--- a/src/lib/oauth-server.ts
+++ b/src/lib/oauth-server.ts
@@ -1,0 +1,165 @@
+import {
+  createServer,
+  Server,
+  IncomingMessage,
+  ServerResponse,
+} from 'node:http'
+
+const PORT = 8765
+const TIMEOUT_MS = 3 * 60 * 1000 // 3 minutes
+
+interface CallbackResult {
+  code: string
+  state: string
+}
+
+const SUCCESS_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Todoist CLI - Authenticated</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+            background: #f5f5f5;
+        }
+        .container {
+            text-align: center;
+            padding: 2rem;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .checkmark { font-size: 3rem; color: #4caf50; }
+        h1 { color: #333; margin: 1rem 0; }
+        p { color: #666; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="checkmark">✓</div>
+        <h1>Successfully authenticated!</h1>
+        <p>You can close this window and return to the terminal.</p>
+    </div>
+</body>
+</html>
+`
+
+const ERROR_HTML = (message: string) => `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Todoist CLI - Error</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+            background: #f5f5f5;
+        }
+        .container {
+            text-align: center;
+            padding: 2rem;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .error { font-size: 3rem; color: #f44336; }
+        h1 { color: #333; margin: 1rem 0; }
+        p { color: #666; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="error">✗</div>
+        <h1>Authentication failed</h1>
+        <p>${message}</p>
+    </div>
+</body>
+</html>
+`
+
+export function startCallbackServer(expectedState: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let server: Server | null = null
+    let timeoutId: NodeJS.Timeout | null = null
+
+    const cleanup = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+        timeoutId = null
+      }
+      if (server) {
+        server.close()
+        server = null
+      }
+    }
+
+    const handleRequest = (req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url || '/', `http://localhost:${PORT}`)
+
+      if (url.pathname !== '/callback') {
+        res.writeHead(404)
+        res.end('Not found')
+        return
+      }
+
+      const code = url.searchParams.get('code')
+      const state = url.searchParams.get('state')
+      const error = url.searchParams.get('error')
+
+      if (error) {
+        res.writeHead(400, { 'Content-Type': 'text/html' })
+        res.end(ERROR_HTML(error))
+        cleanup()
+        reject(new Error(`OAuth error: ${error}`))
+        return
+      }
+
+      if (!code || !state) {
+        res.writeHead(400, { 'Content-Type': 'text/html' })
+        res.end(ERROR_HTML('Missing code or state parameter'))
+        cleanup()
+        reject(new Error('Missing code or state parameter'))
+        return
+      }
+
+      if (state !== expectedState) {
+        res.writeHead(400, { 'Content-Type': 'text/html' })
+        res.end(ERROR_HTML('Invalid state parameter (possible CSRF attack)'))
+        cleanup()
+        reject(new Error('Invalid state parameter'))
+        return
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/html' })
+      res.end(SUCCESS_HTML)
+      cleanup()
+      resolve(code)
+    }
+
+    server = createServer(handleRequest)
+
+    server.on('error', (err) => {
+      cleanup()
+      reject(err)
+    })
+
+    server.listen(PORT, () => {
+      timeoutId = setTimeout(() => {
+        cleanup()
+        reject(new Error('OAuth callback timed out'))
+      }, TIMEOUT_MS)
+    })
+  })
+}
+
+export const OAUTH_REDIRECT_URI = `http://localhost:${PORT}/callback`

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -1,0 +1,54 @@
+import { OAUTH_REDIRECT_URI } from './oauth-server.js'
+
+const TODOIST_CLIENT_ID = '04863cc1e3584830a578622f50224d5b'
+const OAUTH_AUTHORIZE_URL = 'https://todoist.com/oauth/authorize'
+const OAUTH_TOKEN_URL = 'https://todoist.com/oauth/access_token'
+const OAUTH_SCOPES = 'data:read_write,data:delete,project:delete'
+
+export function buildAuthorizationUrl(
+  codeChallenge: string,
+  state: string
+): string {
+  const params = new URLSearchParams({
+    client_id: TODOIST_CLIENT_ID,
+    scope: OAUTH_SCOPES,
+    state: state,
+    redirect_uri: OAUTH_REDIRECT_URI,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+  })
+  return `${OAUTH_AUTHORIZE_URL}?${params.toString()}`
+}
+
+interface TokenResponse {
+  access_token: string
+  token_type: string
+}
+
+export async function exchangeCodeForToken(
+  code: string,
+  codeVerifier: string
+): Promise<string> {
+  const body = new URLSearchParams({
+    client_id: TODOIST_CLIENT_ID,
+    code: code,
+    code_verifier: codeVerifier,
+    redirect_uri: OAUTH_REDIRECT_URI,
+  })
+
+  const response = await fetch(OAUTH_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: body.toString(),
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`Token exchange failed: ${response.status} ${text}`)
+  }
+
+  const data: TokenResponse = await response.json()
+  return data.access_token
+}

--- a/src/lib/pkce.ts
+++ b/src/lib/pkce.ts
@@ -1,0 +1,23 @@
+import { randomBytes, createHash } from 'node:crypto'
+
+const VERIFIER_CHARSET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~'
+const VERIFIER_LENGTH = 64
+
+export function generateCodeVerifier(): string {
+  const bytes = randomBytes(VERIFIER_LENGTH)
+  let verifier = ''
+  for (let i = 0; i < VERIFIER_LENGTH; i++) {
+    verifier += VERIFIER_CHARSET[bytes[i] % VERIFIER_CHARSET.length]
+  }
+  return verifier
+}
+
+export function generateCodeChallenge(verifier: string): string {
+  const hash = createHash('sha256').update(verifier).digest()
+  return hash.toString('base64url')
+}
+
+export function generateState(): string {
+  return randomBytes(16).toString('hex')
+}


### PR DESCRIPTION
## Summary
- `td login` now opens browser for OAuth authorization (PKCE flow, no secrets required)
- `td login token <token>` preserved for manual authentication
- Local callback server on `localhost:8765` receives OAuth response
- Updated README with new login instructions

## Test plan

Prerequisites: Run `npm link` (as instructed in README) and `npm run build` to have the `td` command available with these changes.

- [ ] Run `td login` and complete OAuth flow in browser
- [ ] Verify token is saved to `~/.config/todoist-cli/config.json`
- [ ] Run `td today` to verify authentication works
- [ ] Test timeout by not completing OAuth flow within 3 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)