### PR TITLE
Refactor login command to auth with status/logout subcommands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ src/
   index.ts              # entry point, registers all commands
   commands/             # one file per command group
     add.ts              # td add (quick add)
+    auth.ts             # td auth (login, token, status, logout)
     today.ts            # td today
     inbox.ts            # td inbox
     task.ts             # td task <action>
@@ -38,7 +39,7 @@ src/
     section.ts          # td section <action>
   lib/
     api.ts              # API client wrapper, type exports
-    auth.ts             # token loading (env var or config file)
+    auth.ts             # token loading/saving (env var or config file)
     output.ts           # formatting utilities
     refs.ts             # id: prefix parsing utilities
     task-list.ts        # shared task listing logic

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This makes the `td` command available globally.
 ## Setup
 
 ```bash
-td login
+td auth login
 ```
 
 This opens your browser to authenticate with Todoist. Once approved, the token is saved automatically.
@@ -35,13 +35,20 @@ This opens your browser to authenticate with Todoist. Once approved, the token i
 **Manual token:** Get your API token from [Todoist Settings > Integrations > Developer](https://todoist.com/app/settings/integrations/developer):
 
 ```bash
-td login token "your-token"
+td auth token "your-token"
 ```
 
 **Environment variable:**
 
 ```bash
 export TODOIST_API_TOKEN="your-token"
+```
+
+### Auth commands
+
+```bash
+td auth status   # check if authenticated
+td auth logout   # remove saved token
 ```
 
 ## Usage

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { registerWorkspaceCommand } from './commands/workspace.js'
 import { registerActivityCommand } from './commands/activity.js'
 import { registerReminderCommand } from './commands/reminder.js'
 import { registerSettingsCommand } from './commands/settings.js'
-import { registerLoginCommand } from './commands/login.js'
+import { registerAuthCommand } from './commands/auth.js'
 import { registerStatsCommand } from './commands/stats.js'
 import { registerFilterCommand } from './commands/filter.js'
 
@@ -45,7 +45,7 @@ registerWorkspaceCommand(program)
 registerActivityCommand(program)
 registerReminderCommand(program)
 registerSettingsCommand(program)
-registerLoginCommand(program)
+registerAuthCommand(program)
 registerStatsCommand(program)
 registerFilterCommand(program)
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir } from 'fs/promises'
+import { readFile, writeFile, mkdir, unlink } from 'fs/promises'
 import { homedir } from 'os'
 import { join, dirname } from 'path'
 
@@ -58,4 +58,22 @@ export async function saveApiToken(token: string): Promise<void> {
 
   // Write config file with proper formatting
   await writeFile(CONFIG_PATH, JSON.stringify(newConfig, null, 2) + '\n')
+}
+
+export async function clearApiToken(): Promise<void> {
+  let config: Config = {}
+  try {
+    const content = await readFile(CONFIG_PATH, 'utf-8')
+    config = JSON.parse(content)
+  } catch {
+    return // Config doesn't exist, nothing to clear
+  }
+
+  delete config.api_token
+
+  if (Object.keys(config).length === 0) {
+    await unlink(CONFIG_PATH)
+  } else {
+    await writeFile(CONFIG_PATH, JSON.stringify(config, null, 2) + '\n')
+  }
 }


### PR DESCRIPTION
## Summary
- Rename `td login` → `td auth login`
- Rename `td login token` → `td auth token`  
- Add `td auth status` to show current auth state and user info
- Add `td auth logout` to remove stored token

## Test plan
- [x] `npm run build` passes
- [x] `npm run type-check` passes
- [x] `npm test` passes (522 tests)
- [x] Manual test: `td auth --help` shows all subcommands
- [x] Manual test: `td auth status` shows authenticated user

🤖 Generated with [Claude Code](https://claude.com/claude-code)