### PR TITLE
Add notification command for managing Todoist notifications

### DIFF
--- a/src/__tests__/notification.test.ts
+++ b/src/__tests__/notification.test.ts
@@ -1,0 +1,626 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Command } from 'commander'
+
+vi.mock('../lib/api.js', () => ({
+  fetchNotifications: vi.fn(),
+  markNotificationRead: vi.fn(),
+  markNotificationUnread: vi.fn(),
+  markAllNotificationsRead: vi.fn(),
+  acceptInvitation: vi.fn(),
+  rejectInvitation: vi.fn(),
+}))
+
+import {
+  fetchNotifications,
+  markNotificationRead,
+  markNotificationUnread,
+  markAllNotificationsRead,
+  acceptInvitation,
+  rejectInvitation,
+} from '../lib/api.js'
+import { registerNotificationCommand } from '../commands/notification.js'
+
+const mockFetchNotifications = vi.mocked(fetchNotifications)
+const mockMarkRead = vi.mocked(markNotificationRead)
+const mockMarkUnread = vi.mocked(markNotificationUnread)
+const mockMarkAllRead = vi.mocked(markAllNotificationsRead)
+const mockAccept = vi.mocked(acceptInvitation)
+const mockReject = vi.mocked(rejectInvitation)
+
+function createProgram() {
+  const program = new Command()
+  program.exitOverride()
+  registerNotificationCommand(program)
+  return program
+}
+
+function createShareInvite(overrides = {}) {
+  return {
+    id: 'notif-1',
+    type: 'share_invitation_sent' as const,
+    isUnread: true,
+    isDeleted: false,
+    createdAt: '2025-01-15T10:00:00Z',
+    fromUser: { id: 'user-1', name: 'Jane', email: 'jane@example.com' },
+    project: { id: 'proj-1', name: 'Project X' },
+    invitationId: 'inv-123',
+    invitationSecret: 'secret-abc',
+    ...overrides,
+  }
+}
+
+function createItemAssigned(overrides = {}) {
+  return {
+    id: 'notif-2',
+    type: 'item_assigned' as const,
+    isUnread: true,
+    isDeleted: false,
+    createdAt: '2025-01-14T08:00:00Z',
+    task: { id: 'task-1', content: 'Review PR #42' },
+    project: { id: 'proj-2', name: 'Work' },
+    ...overrides,
+  }
+}
+
+describe('notification list', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('lists notifications', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([
+      createShareInvite(),
+      createItemAssigned(),
+    ])
+
+    await program.parseAsync(['node', 'td', 'notification', 'list'])
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('share_invitation_sent')
+    )
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('item_assigned')
+    )
+    consoleSpy.mockRestore()
+  })
+
+  it('shows "No notifications." when empty', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([])
+
+    await program.parseAsync(['node', 'td', 'notification', 'list'])
+
+    expect(consoleSpy).toHaveBeenCalledWith('No notifications.')
+    consoleSpy.mockRestore()
+  })
+
+  it('filters unread with --unread', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([
+      createShareInvite({ isUnread: true }),
+      createItemAssigned({ id: 'notif-3', isUnread: false }),
+    ])
+
+    await program.parseAsync(['node', 'td', 'notification', 'list', '--unread'])
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('share_invitation_sent')
+    )
+    consoleSpy.mockRestore()
+  })
+
+  it('filters read with --read', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([
+      createShareInvite({ isUnread: true }),
+      createItemAssigned({ id: 'notif-3', isUnread: false }),
+    ])
+
+    await program.parseAsync(['node', 'td', 'notification', 'list', '--read'])
+
+    const output = consoleSpy.mock.calls[0][0]
+    expect(output).toContain('item_assigned')
+    expect(output).not.toContain('share_invitation_sent')
+    consoleSpy.mockRestore()
+  })
+
+  it('filters by type with --type', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([
+      createShareInvite({ id: 'n1' }),
+      createItemAssigned({ id: 'n2' }),
+      createShareInvite({ id: 'n3' }),
+    ])
+
+    await program.parseAsync([
+      'node',
+      'td',
+      'notification',
+      'list',
+      '--type',
+      'item_assigned',
+    ])
+
+    const output = consoleSpy.mock.calls[0][0]
+    expect(output).toContain('id:n2')
+    expect(output).not.toContain('id:n1')
+    expect(output).not.toContain('id:n3')
+    consoleSpy.mockRestore()
+  })
+
+  it('filters by multiple types with --type', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([
+      createShareInvite({ id: 'n1' }),
+      createItemAssigned({ id: 'n2' }),
+      { ...createShareInvite({ id: 'n3' }), type: 'note_added' as const },
+    ])
+
+    await program.parseAsync([
+      'node',
+      'td',
+      'notification',
+      'list',
+      '--type',
+      'item_assigned,note_added',
+    ])
+
+    const output = consoleSpy.mock.calls[0][0]
+    expect(output).toContain('id:n2')
+    expect(output).toContain('id:n3')
+    expect(output).not.toContain('id:n1')
+    consoleSpy.mockRestore()
+  })
+
+  it('throws when both --read and --unread specified', async () => {
+    const program = createProgram()
+
+    await expect(
+      program.parseAsync([
+        'node',
+        'td',
+        'notification',
+        'list',
+        '--read',
+        '--unread',
+      ])
+    ).rejects.toThrow('INVALID_OPTIONS')
+  })
+
+  it('respects --offset', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([
+      createShareInvite({ id: 'n1' }),
+      createShareInvite({ id: 'n2' }),
+      createShareInvite({ id: 'n3' }),
+    ])
+
+    await program.parseAsync([
+      'node',
+      'td',
+      'notification',
+      'list',
+      '--offset',
+      '1',
+      '--limit',
+      '1',
+    ])
+
+    const output = consoleSpy.mock.calls[0][0]
+    expect(output).toContain('id:n2')
+    expect(output).not.toContain('id:n1')
+    expect(output).not.toContain('id:n3')
+    consoleSpy.mockRestore()
+  })
+
+  it('respects --limit', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([
+      createShareInvite({ id: 'n1' }),
+      createShareInvite({ id: 'n2' }),
+      createShareInvite({ id: 'n3' }),
+    ])
+
+    await program.parseAsync([
+      'node',
+      'td',
+      'notification',
+      'list',
+      '--limit',
+      '2',
+    ])
+
+    const output = consoleSpy.mock.calls[0][0]
+    expect(output).toContain('id:n1')
+    expect(output).toContain('id:n2')
+    expect(output).not.toContain('id:n3')
+    consoleSpy.mockRestore()
+  })
+
+  it('outputs JSON with --json', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([createShareInvite()])
+
+    await program.parseAsync(['node', 'td', 'notification', 'list', '--json'])
+
+    const output = consoleSpy.mock.calls[0][0]
+    const parsed = JSON.parse(output)
+    expect(parsed.results).toBeDefined()
+    expect(parsed.results[0].type).toBe('share_invitation_sent')
+    expect(parsed.results[0].invitationSecret).toBeUndefined()
+    consoleSpy.mockRestore()
+  })
+
+  it('outputs NDJSON with --ndjson', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([
+      createShareInvite({ id: 'n1' }),
+      createShareInvite({ id: 'n2' }),
+    ])
+
+    await program.parseAsync(['node', 'td', 'notification', 'list', '--ndjson'])
+
+    const output = consoleSpy.mock.calls[0][0]
+    const lines = output.split('\n')
+    expect(lines).toHaveLength(2)
+    consoleSpy.mockRestore()
+  })
+
+  it('does not expose invitationSecret in JSON', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([createShareInvite()])
+
+    await program.parseAsync(['node', 'td', 'notification', 'list', '--json'])
+
+    const output = consoleSpy.mock.calls[0][0]
+    expect(output).not.toContain('invitationSecret')
+    expect(output).not.toContain('secret-abc')
+    consoleSpy.mockRestore()
+  })
+})
+
+describe('notification view', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows notification details', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([createShareInvite()])
+
+    await program.parseAsync([
+      'node',
+      'td',
+      'notification',
+      'view',
+      'id:notif-1',
+    ])
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('share_invitation_sent')
+    )
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Jane'))
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Project X')
+    )
+    consoleSpy.mockRestore()
+  })
+
+  it('shows actions for share invitation', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([createShareInvite()])
+
+    await program.parseAsync([
+      'node',
+      'td',
+      'notification',
+      'view',
+      'id:notif-1',
+    ])
+
+    expect(consoleSpy).toHaveBeenCalledWith('Actions:')
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('td notification accept')
+    )
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('td notification reject')
+    )
+    consoleSpy.mockRestore()
+  })
+
+  it('does not show actions for non-invitation', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([createItemAssigned()])
+
+    await program.parseAsync([
+      'node',
+      'td',
+      'notification',
+      'view',
+      'id:notif-2',
+    ])
+
+    const calls = consoleSpy.mock.calls.map((c) => c[0])
+    expect(calls).not.toContainEqual('Actions:')
+    consoleSpy.mockRestore()
+  })
+
+  it('outputs JSON with --json', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([createShareInvite()])
+
+    await program.parseAsync([
+      'node',
+      'td',
+      'notification',
+      'view',
+      'id:notif-1',
+      '--json',
+    ])
+
+    const output = consoleSpy.mock.calls[0][0]
+    const parsed = JSON.parse(output)
+    expect(parsed.type).toBe('share_invitation_sent')
+    expect(parsed.invitationSecret).toBeUndefined()
+    consoleSpy.mockRestore()
+  })
+
+  it('throws for non-existent notification', async () => {
+    const program = createProgram()
+
+    mockFetchNotifications.mockResolvedValue([])
+
+    await expect(
+      program.parseAsync([
+        'node',
+        'td',
+        'notification',
+        'view',
+        'id:nonexistent',
+      ])
+    ).rejects.toThrow('NOTIFICATION_NOT_FOUND')
+  })
+})
+
+describe('notification accept', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('accepts share invitation', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([createShareInvite()])
+    mockAccept.mockResolvedValue(undefined)
+    mockMarkRead.mockResolvedValue(undefined)
+
+    await program.parseAsync([
+      'node',
+      'td',
+      'notification',
+      'accept',
+      'id:notif-1',
+    ])
+
+    expect(mockAccept).toHaveBeenCalledWith('inv-123', 'secret-abc')
+    expect(mockMarkRead).toHaveBeenCalledWith('notif-1')
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Accepted invitation')
+    )
+    consoleSpy.mockRestore()
+  })
+
+  it('throws for non-invitation type', async () => {
+    const program = createProgram()
+
+    mockFetchNotifications.mockResolvedValue([createItemAssigned()])
+
+    await expect(
+      program.parseAsync(['node', 'td', 'notification', 'accept', 'id:notif-2'])
+    ).rejects.toThrow('item_assigned')
+  })
+
+  it('throws for non-existent notification', async () => {
+    const program = createProgram()
+
+    mockFetchNotifications.mockResolvedValue([])
+
+    await expect(
+      program.parseAsync([
+        'node',
+        'td',
+        'notification',
+        'accept',
+        'id:nonexistent',
+      ])
+    ).rejects.toThrow('NOTIFICATION_NOT_FOUND')
+  })
+})
+
+describe('notification reject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects share invitation', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([createShareInvite()])
+    mockReject.mockResolvedValue(undefined)
+    mockMarkRead.mockResolvedValue(undefined)
+
+    await program.parseAsync([
+      'node',
+      'td',
+      'notification',
+      'reject',
+      'id:notif-1',
+    ])
+
+    expect(mockReject).toHaveBeenCalledWith('inv-123', 'secret-abc')
+    expect(mockMarkRead).toHaveBeenCalledWith('notif-1')
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Rejected invitation')
+    )
+    consoleSpy.mockRestore()
+  })
+
+  it('throws for non-invitation type', async () => {
+    const program = createProgram()
+
+    mockFetchNotifications.mockResolvedValue([createItemAssigned()])
+
+    await expect(
+      program.parseAsync(['node', 'td', 'notification', 'reject', 'id:notif-2'])
+    ).rejects.toThrow('item_assigned')
+  })
+})
+
+describe('notification read', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('marks single notification as read', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([createShareInvite()])
+    mockMarkRead.mockResolvedValue(undefined)
+
+    await program.parseAsync([
+      'node',
+      'td',
+      'notification',
+      'read',
+      'id:notif-1',
+    ])
+
+    expect(mockMarkRead).toHaveBeenCalledWith('notif-1')
+    expect(consoleSpy).toHaveBeenCalledWith('Marked as read.')
+    consoleSpy.mockRestore()
+  })
+
+  it('warns without --yes for --all', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await program.parseAsync(['node', 'td', 'notification', 'read', '--all'])
+
+    expect(mockMarkAllRead).not.toHaveBeenCalled()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Use --all --yes to mark all notifications as read.'
+    )
+    consoleSpy.mockRestore()
+  })
+
+  it('marks all as read with --all --yes', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([
+      createShareInvite({ isUnread: true }),
+      createItemAssigned({ isUnread: true }),
+    ])
+    mockMarkAllRead.mockResolvedValue(undefined)
+
+    await program.parseAsync([
+      'node',
+      'td',
+      'notification',
+      'read',
+      '--all',
+      '--yes',
+    ])
+
+    expect(mockMarkAllRead).toHaveBeenCalled()
+    expect(consoleSpy).toHaveBeenCalledWith('Marked 2 notifications as read.')
+    consoleSpy.mockRestore()
+  })
+
+  it('throws when no id and no --all', async () => {
+    const program = createProgram()
+
+    await expect(
+      program.parseAsync(['node', 'td', 'notification', 'read'])
+    ).rejects.toThrow('MISSING_ID')
+  })
+})
+
+describe('notification unread', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('marks notification as unread', async () => {
+    const program = createProgram()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    mockFetchNotifications.mockResolvedValue([
+      createShareInvite({ isUnread: false }),
+    ])
+    mockMarkUnread.mockResolvedValue(undefined)
+
+    await program.parseAsync([
+      'node',
+      'td',
+      'notification',
+      'unread',
+      'id:notif-1',
+    ])
+
+    expect(mockMarkUnread).toHaveBeenCalledWith('notif-1')
+    expect(consoleSpy).toHaveBeenCalledWith('Marked as unread.')
+    consoleSpy.mockRestore()
+  })
+
+  it('throws for non-existent notification', async () => {
+    const program = createProgram()
+
+    mockFetchNotifications.mockResolvedValue([])
+
+    await expect(
+      program.parseAsync([
+        'node',
+        'td',
+        'notification',
+        'unread',
+        'id:nonexistent',
+      ])
+    ).rejects.toThrow('NOTIFICATION_NOT_FOUND')
+  })
+})

--- a/src/commands/notification.ts
+++ b/src/commands/notification.ts
@@ -1,0 +1,411 @@
+import { Command } from 'commander'
+import {
+  fetchNotifications,
+  markNotificationRead,
+  markNotificationUnread,
+  markAllNotificationsRead,
+  acceptInvitation,
+  rejectInvitation,
+  Notification,
+  NotificationType,
+} from '../lib/api.js'
+import {
+  formatPaginatedJson,
+  formatPaginatedNdjson,
+  formatError,
+} from '../lib/output.js'
+import { isIdRef, extractId } from '../lib/refs.js'
+import chalk from 'chalk'
+
+function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMin = Math.floor(diffMs / 60000)
+  const diffHour = Math.floor(diffMs / 3600000)
+  const diffDay = Math.floor(diffMs / 86400000)
+
+  if (diffMin < 1) return 'just now'
+  if (diffMin < 60) return `${diffMin}m ago`
+  if (diffHour < 24) return `${diffHour}h ago`
+  if (diffDay < 7) return `${diffDay}d ago`
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+function formatNotificationDetails(n: Notification): string {
+  switch (n.type) {
+    case 'share_invitation_sent':
+      return `${n.fromUser?.name || 'Someone'} invited you to "${n.project?.name || 'a project'}"`
+    case 'share_invitation_accepted':
+      return `${n.fromUser?.name || 'Someone'} accepted your invite to "${n.project?.name || 'a project'}"`
+    case 'share_invitation_rejected':
+      return `${n.fromUser?.name || 'Someone'} rejected your invite to "${n.project?.name || 'a project'}"`
+    case 'user_left_project':
+      return `${n.fromUser?.name || 'Someone'} left "${n.project?.name || 'a project'}"`
+    case 'user_removed_from_project':
+      return `You were removed from "${n.project?.name || 'a project'}"`
+    case 'item_assigned':
+      return `"${n.task?.content || 'A task'}" assigned to you${n.project?.name ? ` in ${n.project.name}` : ''}`
+    case 'item_completed':
+      return `"${n.task?.content || 'A task'}" was completed`
+    case 'item_uncompleted':
+      return `"${n.task?.content || 'A task'}" was uncompleted`
+    case 'note_added':
+      return `Comment on "${n.task?.content || 'a task'}"${n.fromUser?.name ? ` by ${n.fromUser.name}` : ''}`
+    case 'project_archived':
+      return `"${n.project?.name || 'A project'}" was archived`
+    case 'project_unarchived':
+      return `"${n.project?.name || 'A project'}" was unarchived`
+    case 'karma_daily_goal':
+      return 'Daily karma goal reached'
+    case 'karma_weekly_goal':
+      return 'Weekly karma goal reached'
+    case 'biz_trial_will_end':
+      return 'Business trial ending soon'
+    case 'biz_payment_failed':
+      return 'Payment failed'
+    case 'biz_account_disabled':
+      return 'Account disabled'
+    default:
+      return n.type
+  }
+}
+
+function stripInvitationSecret(
+  n: Notification
+): Omit<Notification, 'invitationSecret'> {
+  const { invitationSecret: _, ...rest } = n
+  return rest
+}
+
+interface ListOptions {
+  type?: string
+  unread?: boolean
+  read?: boolean
+  limit?: string
+  offset?: string
+  json?: boolean
+  ndjson?: boolean
+  full?: boolean
+}
+
+async function listNotifications(options: ListOptions): Promise<void> {
+  if (options.unread && options.read) {
+    throw new Error(
+      formatError('INVALID_OPTIONS', 'Cannot specify both --read and --unread')
+    )
+  }
+
+  // Note: All filtering (type, read state, pagination) is done client-side because
+  // the Todoist Sync API v9 live_notifications endpoint doesn't support server-side
+  // filtering or pagination - it returns all notifications in a single response.
+  let notifications = await fetchNotifications()
+
+  if (options.type) {
+    const types = options.type.split(',').map((t) => t.trim())
+    notifications = notifications.filter((n) => types.includes(n.type))
+  }
+
+  if (options.unread) {
+    notifications = notifications.filter((n) => n.isUnread)
+  } else if (options.read) {
+    notifications = notifications.filter((n) => !n.isUnread)
+  }
+
+  const totalCount = notifications.length
+  const offset = options.offset ? parseInt(options.offset, 10) : 0
+  const limit = options.limit ? parseInt(options.limit, 10) : 10
+  const hasMore = totalCount > offset + limit
+  notifications = notifications.slice(offset, offset + limit)
+
+  const sanitized = notifications.map(stripInvitationSecret)
+
+  if (options.json) {
+    console.log(
+      formatPaginatedJson(
+        { results: sanitized, nextCursor: null },
+        'notification',
+        options.full,
+        false
+      )
+    )
+    return
+  }
+
+  if (options.ndjson) {
+    console.log(
+      formatPaginatedNdjson(
+        { results: sanitized, nextCursor: null },
+        'notification',
+        options.full,
+        false
+      )
+    )
+    return
+  }
+
+  if (notifications.length === 0) {
+    console.log('No notifications.')
+    return
+  }
+
+  const blocks = notifications.map((n) => {
+    const unreadMarker = n.isUnread ? chalk.bold('●') : ' '
+    const details = formatNotificationDetails(n)
+    const line1 = n.isUnread
+      ? `${unreadMarker} ${chalk.bold(details)}`
+      : `${unreadMarker} ${details}`
+
+    const metaParts = [
+      chalk.dim(`id:${n.id}`),
+      chalk.cyan(n.type),
+      chalk.dim(formatRelativeTime(n.createdAt)),
+    ]
+    const line2 = `  ${metaParts.join('  ')}`
+
+    return `${line1}\n${line2}`
+  })
+
+  console.log(blocks.join('\n\n'))
+
+  if (hasMore) {
+    const nextOffset = offset + limit
+    console.log(
+      chalk.dim(
+        `\n... showing ${offset + 1}-${offset + notifications.length} of ${totalCount}. Use --offset ${nextOffset} to see more.`
+      )
+    )
+  }
+}
+
+async function resolveNotification(idRef: string): Promise<Notification> {
+  const notifications = await fetchNotifications()
+
+  let id: string
+  if (isIdRef(idRef)) {
+    id = extractId(idRef)
+  } else {
+    id = idRef
+  }
+
+  const notification = notifications.find((n) => n.id === id)
+  if (!notification) {
+    throw new Error(
+      formatError('NOTIFICATION_NOT_FOUND', `Notification not found: ${idRef}`)
+    )
+  }
+
+  return notification
+}
+
+interface ViewOptions {
+  json?: boolean
+}
+
+async function viewNotification(
+  idRef: string,
+  options: ViewOptions
+): Promise<void> {
+  const n = await resolveNotification(idRef)
+
+  if (options.json) {
+    console.log(JSON.stringify(stripInvitationSecret(n), null, 2))
+    return
+  }
+
+  console.log(`Type:       ${n.type}`)
+  if (n.fromUser?.name || n.fromUser?.email) {
+    const fromParts = [n.fromUser.name, n.fromUser.email].filter(Boolean)
+    console.log(`From:       ${fromParts.join(' - ')}`)
+  }
+  if (n.project?.name) {
+    console.log(`Project:    ${n.project.name}`)
+  }
+  if (n.task?.content) {
+    console.log(`Task:       ${n.task.content}`)
+  }
+  const date = new Date(n.createdAt)
+  console.log(
+    `Received:   ${formatRelativeTime(n.createdAt)} (${date.toLocaleString()})`
+  )
+  console.log(`Status:     ${n.isUnread ? 'Unread' : 'Read'}`)
+
+  console.log('')
+  console.log(formatNotificationDetails(n))
+
+  if (n.type === 'share_invitation_sent') {
+    console.log('')
+    console.log('Actions:')
+    console.log(`  td notification accept id:${n.id}`)
+    console.log(`  td notification reject id:${n.id}`)
+  }
+}
+
+async function acceptNotification(idRef: string): Promise<void> {
+  const n = await resolveNotification(idRef)
+
+  if (n.type !== 'share_invitation_sent') {
+    throw new Error(
+      formatError(
+        'INVALID_NOTIFICATION_TYPE',
+        `Cannot accept: notification is ${n.type}, not a share invitation`
+      )
+    )
+  }
+
+  if (!n.invitationId || !n.invitationSecret) {
+    throw new Error(
+      formatError(
+        'MISSING_INVITATION_DATA',
+        'Invitation data missing from notification'
+      )
+    )
+  }
+
+  await acceptInvitation(n.invitationId, n.invitationSecret)
+  await markNotificationRead(n.id)
+
+  console.log(
+    `Accepted invitation to "${n.project?.name ?? 'project'}" from ${n.fromUser?.name ?? 'unknown'}.`
+  )
+}
+
+async function rejectNotification(idRef: string): Promise<void> {
+  const n = await resolveNotification(idRef)
+
+  if (n.type !== 'share_invitation_sent') {
+    throw new Error(
+      formatError(
+        'INVALID_NOTIFICATION_TYPE',
+        `Cannot reject: notification is ${n.type}, not a share invitation`
+      )
+    )
+  }
+
+  if (!n.invitationId || !n.invitationSecret) {
+    throw new Error(
+      formatError(
+        'MISSING_INVITATION_DATA',
+        'Invitation data missing from notification'
+      )
+    )
+  }
+
+  await rejectInvitation(n.invitationId, n.invitationSecret)
+  await markNotificationRead(n.id)
+
+  console.log(
+    `Rejected invitation to "${n.project?.name ?? 'project'}" from ${n.fromUser?.name ?? 'unknown'}.`
+  )
+}
+
+interface ReadOptions {
+  all?: boolean
+  yes?: boolean
+}
+
+async function markRead(
+  idRef: string | undefined,
+  options: ReadOptions
+): Promise<void> {
+  if (options.all) {
+    if (!options.yes) {
+      console.log('Use --all --yes to mark all notifications as read.')
+      return
+    }
+    const notifications = await fetchNotifications()
+    const unreadCount = notifications.filter((n) => n.isUnread).length
+    await markAllNotificationsRead()
+    console.log(
+      `Marked ${unreadCount} notification${unreadCount === 1 ? '' : 's'} as read.`
+    )
+    return
+  }
+
+  if (!idRef) {
+    throw new Error(
+      formatError('MISSING_ID', 'Provide a notification ID or use --all')
+    )
+  }
+
+  const n = await resolveNotification(idRef)
+  await markNotificationRead(n.id)
+  console.log('Marked as read.')
+}
+
+async function markUnread(idRef: string): Promise<void> {
+  const n = await resolveNotification(idRef)
+  await markNotificationUnread(n.id)
+  console.log('Marked as unread.')
+}
+
+export function registerNotificationCommand(program: Command): void {
+  const notification = program
+    .command('notification')
+    .description('Manage notifications')
+
+  notification
+    .command('list')
+    .description('List notifications')
+    .option('--type <types>', 'Filter by type (comma-separated)')
+    .option('--unread', 'Only show unread notifications')
+    .option('--read', 'Only show read notifications')
+    .option('--limit <n>', 'Max notifications to show (default: 10)')
+    .option('--offset <n>', 'Skip first N notifications')
+    .option('--json', 'Output as JSON')
+    .option('--ndjson', 'Output as newline-delimited JSON')
+    .option('--full', 'Include all fields in JSON output')
+    .action(listNotifications)
+
+  const viewCmd = notification
+    .command('view [id]')
+    .description('View notification details')
+    .option('--json', 'Output as JSON')
+    .action((id, options) => {
+      if (!id) {
+        viewCmd.help()
+        return
+      }
+      return viewNotification(id, options)
+    })
+
+  const acceptCmd = notification
+    .command('accept [id]')
+    .description('Accept a share invitation')
+    .action((id) => {
+      if (!id) {
+        acceptCmd.help()
+        return
+      }
+      return acceptNotification(id)
+    })
+
+  const rejectCmd = notification
+    .command('reject [id]')
+    .description('Reject a share invitation')
+    .action((id) => {
+      if (!id) {
+        rejectCmd.help()
+        return
+      }
+      return rejectNotification(id)
+    })
+
+  notification
+    .command('read [id]')
+    .description('Mark notification(s) as read')
+    .option('--all', 'Mark all notifications as read')
+    .option('--yes', 'Confirm marking all as read')
+    .action((id, options) => markRead(id, options))
+
+  const unreadCmd = notification
+    .command('unread [id]')
+    .description('Mark notification as unread')
+    .action((id) => {
+      if (!id) {
+        unreadCmd.help()
+        return
+      }
+      return markUnread(id)
+    })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { registerSettingsCommand } from './commands/settings.js'
 import { registerAuthCommand } from './commands/auth.js'
 import { registerStatsCommand } from './commands/stats.js'
 import { registerFilterCommand } from './commands/filter.js'
+import { registerNotificationCommand } from './commands/notification.js'
 
 program
   .name('td')
@@ -48,6 +49,7 @@ registerSettingsCommand(program)
 registerAuthCommand(program)
 registerStatsCommand(program)
 registerFilterCommand(program)
+registerNotificationCommand(program)
 
 program.parseAsync().catch((err: Error) => {
   console.error(err.message)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -766,3 +766,229 @@ export async function completeTaskForever(taskId: string): Promise<void> {
 }
 
 export type { Task, PersonalProject, WorkspaceProject, Section, User }
+
+// Notification types and API (Sync API v9)
+
+export type NotificationType =
+  | 'share_invitation_sent'
+  | 'share_invitation_accepted'
+  | 'share_invitation_rejected'
+  | 'user_left_project'
+  | 'user_removed_from_project'
+  | 'item_assigned'
+  | 'item_completed'
+  | 'item_uncompleted'
+  | 'note_added'
+  | 'project_archived'
+  | 'project_unarchived'
+  | 'karma_daily_goal'
+  | 'karma_weekly_goal'
+  | 'biz_trial_will_end'
+  | 'biz_payment_failed'
+  | 'biz_account_disabled'
+  | string
+
+export interface NotificationUser {
+  id: string
+  name: string
+  email: string
+}
+
+export interface NotificationProject {
+  id: string
+  name: string
+}
+
+export interface NotificationTask {
+  id: string
+  content: string
+}
+
+export interface Notification {
+  id: string
+  type: NotificationType
+  isUnread: boolean
+  isDeleted: boolean
+  createdAt: string
+  fromUser?: NotificationUser
+  project?: NotificationProject
+  task?: NotificationTask
+  invitationId?: string
+  invitationSecret?: string
+}
+
+function parseNotification(n: Record<string, unknown>): Notification {
+  let fromUser: NotificationUser | undefined
+  if (n.from_uid) {
+    const fromUserData = n.from_user as Record<string, unknown> | undefined
+    fromUser = {
+      id: String(n.from_uid),
+      name: String(fromUserData?.full_name ?? fromUserData?.name ?? ''),
+      email: String(fromUserData?.email ?? ''),
+    }
+  }
+
+  let project: NotificationProject | undefined
+  if (n.project_id) {
+    project = {
+      id: String(n.project_id),
+      name: String(n.project_name ?? ''),
+    }
+  }
+
+  let task: NotificationTask | undefined
+  if (n.item_id) {
+    task = {
+      id: String(n.item_id),
+      content: String(n.item_content ?? ''),
+    }
+  }
+
+  return {
+    id: String(n.id),
+    type: (n.notification_type ?? n.type) as NotificationType,
+    isUnread: Boolean(n.is_unread),
+    isDeleted: Boolean(n.is_deleted),
+    createdAt: String(n.created_at ?? n.created ?? ''),
+    fromUser,
+    project,
+    task,
+    invitationId: n.invitation_id ? String(n.invitation_id) : undefined,
+    invitationSecret: n.invitation_secret
+      ? String(n.invitation_secret)
+      : undefined,
+  }
+}
+
+interface NotificationSyncResponse {
+  live_notifications?: Array<Record<string, unknown>>
+  live_notifications_last_read_id?: number
+  sync_status?: Record<string, string | { error_code: number; error: string }>
+  error?: string
+}
+
+async function executeSyncV9Command(
+  commands: SyncCommand[]
+): Promise<NotificationSyncResponse> {
+  const token = await getApiToken()
+  const response = await fetch('https://api.todoist.com/sync/v9/sync', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      commands: JSON.stringify(commands),
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Sync API error: ${response.status}`)
+  }
+
+  const data: NotificationSyncResponse = await response.json()
+  if (data.error) {
+    throw new Error(`Sync API error: ${data.error}`)
+  }
+
+  for (const cmd of commands) {
+    const status = data.sync_status?.[cmd.uuid]
+    if (status && typeof status === 'object' && 'error' in status) {
+      throw new Error(status.error)
+    }
+  }
+
+  return data
+}
+
+export async function fetchNotifications(): Promise<Notification[]> {
+  const token = await getApiToken()
+  const response = await fetch('https://api.todoist.com/sync/v9/sync', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      sync_token: '*',
+      resource_types: '["live_notifications"]',
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch notifications: ${response.status}`)
+  }
+
+  const data: NotificationSyncResponse = await response.json()
+  if (data.error) {
+    throw new Error(`Notifications API error: ${data.error}`)
+  }
+
+  const notifications = (data.live_notifications ?? [])
+    .map(parseNotification)
+    .filter((n: Notification) => !n.isDeleted)
+
+  notifications.sort(
+    (a: Notification, b: Notification) =>
+      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  )
+
+  return notifications
+}
+
+export async function markNotificationRead(id: string): Promise<void> {
+  const command: SyncCommand = {
+    type: 'live_notifications_mark_read',
+    uuid: generateUuid(),
+    args: { ids: [id] },
+  }
+  await executeSyncV9Command([command])
+}
+
+export async function markNotificationUnread(id: string): Promise<void> {
+  const command: SyncCommand = {
+    type: 'live_notifications_mark_unread',
+    uuid: generateUuid(),
+    args: { ids: [id] },
+  }
+  await executeSyncV9Command([command])
+}
+
+export async function markAllNotificationsRead(): Promise<void> {
+  const command: SyncCommand = {
+    type: 'live_notifications_mark_read_all',
+    uuid: generateUuid(),
+    args: {},
+  }
+  await executeSyncV9Command([command])
+}
+
+export async function acceptInvitation(
+  invitationId: string,
+  secret: string
+): Promise<void> {
+  const command: SyncCommand = {
+    type: 'accept_invitation',
+    uuid: generateUuid(),
+    args: {
+      invitation_id: Number(invitationId),
+      invitation_secret: secret,
+    },
+  }
+  await executeSyncV9Command([command])
+}
+
+export async function rejectInvitation(
+  invitationId: string,
+  secret: string
+): Promise<void> {
+  const command: SyncCommand = {
+    type: 'reject_invitation',
+    uuid: generateUuid(),
+    args: {
+      invitation_id: Number(invitationId),
+      invitation_secret: secret,
+    },
+  }
+  await executeSyncV9Command([command])
+}

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -217,6 +217,15 @@ const FILTER_ESSENTIAL_FIELDS = [
   'color',
   'isFavorite',
 ] as const
+const NOTIFICATION_ESSENTIAL_FIELDS = [
+  'id',
+  'type',
+  'isUnread',
+  'createdAt',
+  'fromUser',
+  'project',
+  'task',
+] as const
 
 function pickFields<T extends object>(
   item: T,
@@ -267,6 +276,9 @@ function addWebUrl<T extends { id: string }>(
     case 'reminder':
       url = ''
       break
+    case 'notification':
+      url = ''
+      break
   }
   return { ...item, webUrl: url }
 }
@@ -279,6 +291,7 @@ export type EntityType =
   | 'comment'
   | 'reminder'
   | 'filter'
+  | 'notification'
 
 function getEssentialFields(type: EntityType): readonly string[] {
   switch (type) {
@@ -296,6 +309,8 @@ function getEssentialFields(type: EntityType): readonly string[] {
       return REMINDER_ESSENTIAL_FIELDS
     case 'filter':
       return FILTER_ESSENTIAL_FIELDS
+    case 'notification':
+      return NOTIFICATION_ESSENTIAL_FIELDS
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `td notification` command group for managing Todoist notifications via Sync API v9
- Supports listing, viewing, marking read/unread, and accepting/rejecting share invitations
- Client-side filtering by type, read state, and pagination (API doesn't support server-side filtering)

## Subcommands
- `list` - List notifications with filtering (`--type`, `--read`, `--unread`, `--limit`, `--offset`)
- `view <id>` - View notification details
- `read <id>` / `read --all --yes` - Mark as read
- `unread <id>` - Mark as unread
- `accept <id>` - Accept share invitation
- `reject <id>` - Reject share invitation

## Test plan
- [x] All 550 tests pass
- [x] Manual testing of all subcommands
- [x] Verified filtering by type, read state, and pagination work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)