### PR TITLE
fix: use NPM_TOKEN for initial package publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,4 +43,6 @@ jobs:
         run: npm test
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove `--provenance` flag from npm publish command for initial publication
- Add `NODE_AUTH_TOKEN` environment variable using `NPM_TOKEN` from GitHub secrets
- This is required because npm provenance can only be enabled after the first publication

Once the initial publication is complete, we can switch back to using `--provenance` for future releases.

## Changes

- Modified `.github/workflows/publish.yml` to use `NPM_TOKEN` secret instead of provenance
- This allows the package to be published for the first time to npm registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)