### PR TITLE
feat: restore provenance publishing after initial publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,4 @@ jobs:
         run: npm test
 
       - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

Now that the package has been successfully published to npm for the first time, we can enable provenance-based publishing for all future releases.

## Changes

- Restored `--provenance` flag to npm publish command
- Removed `NODE_AUTH_TOKEN` environment variable 
- This provides better security and transparency for package consumers

## Context

This follows the initial publication in PR #12. npm provenance can only be enabled after the first publication, which is why we temporarily used `NPM_TOKEN` for the initial publish and now switch back to the more secure provenance-based approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)