### PR TITLE
feat: add skill install command for coding agent integrations

### DIFF
--- a/src/__tests__/skill.test.ts
+++ b/src/__tests__/skill.test.ts
@@ -1,0 +1,182 @@
+import { access, mkdir, mkdtemp, readFile, rm, unlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Command } from 'commander'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('chalk', () => ({
+    default: {
+        green: vi.fn((text) => text),
+        dim: vi.fn((text) => text),
+        bold: vi.fn((text) => text),
+        red: vi.fn((text) => text),
+    },
+}))
+
+import { registerSkillCommand } from '../commands/skill.js'
+import { claudeCodeInstaller } from '../lib/skills/claude-code.js'
+import { getInstaller, listAgents } from '../lib/skills/index.js'
+
+function createProgram() {
+    const program = new Command()
+    program.exitOverride()
+    registerSkillCommand(program)
+    return program
+}
+
+describe('skill command', () => {
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        consoleSpy.mockRestore()
+    })
+
+    describe('list subcommand', () => {
+        it('lists available agents', async () => {
+            const program = createProgram()
+            await program.parseAsync(['node', 'td', 'skill', 'list'])
+
+            expect(consoleSpy).toHaveBeenCalledWith('Available agents:')
+            expect(consoleSpy).toHaveBeenCalledWith('  claude-code')
+        })
+    })
+
+    describe('install subcommand', () => {
+        it('shows help when no agent provided', async () => {
+            const program = createProgram()
+
+            await expect(program.parseAsync(['node', 'td', 'skill', 'install'])).rejects.toThrow()
+        })
+
+        it('errors for unknown agent', async () => {
+            const program = createProgram()
+
+            await expect(
+                program.parseAsync(['node', 'td', 'skill', 'install', 'unknown-agent']),
+            ).rejects.toThrow('Unknown agent: unknown-agent')
+        })
+    })
+
+    describe('uninstall subcommand', () => {
+        it('shows help when no agent provided', async () => {
+            const program = createProgram()
+
+            await expect(program.parseAsync(['node', 'td', 'skill', 'uninstall'])).rejects.toThrow()
+        })
+
+        it('errors for unknown agent', async () => {
+            const program = createProgram()
+
+            await expect(
+                program.parseAsync(['node', 'td', 'skill', 'uninstall', 'unknown-agent']),
+            ).rejects.toThrow('Unknown agent: unknown-agent')
+        })
+    })
+})
+
+describe('skills registry', () => {
+    it('returns claude-code installer', () => {
+        const installer = getInstaller('claude-code')
+        expect(installer).toBeDefined()
+        expect(installer?.name).toBe('claude-code')
+    })
+
+    it('returns undefined for unknown agent', () => {
+        const installer = getInstaller('unknown')
+        expect(installer).toBeUndefined()
+    })
+
+    it('lists available agents', () => {
+        const agents = listAgents()
+        expect(agents).toContain('claude-code')
+    })
+})
+
+describe('claudeCodeInstaller', () => {
+    it('has correct name and description', () => {
+        expect(claudeCodeInstaller.name).toBe('claude-code')
+        expect(claudeCodeInstaller.description).toBe('Claude Code skill for Todoist CLI')
+    })
+
+    it('generates skill file with YAML frontmatter', () => {
+        const content = claudeCodeInstaller.generateContent()
+
+        expect(content).toContain('---')
+        expect(content).toContain('name: todoist')
+        expect(content).toContain('description: Manage Todoist tasks')
+        expect(content).toContain('# Todoist CLI (td)')
+        expect(content).toContain('td today')
+        expect(content).toContain('td add')
+    })
+
+    it('returns global path containing .claude/skills', () => {
+        const globalPath = claudeCodeInstaller.getInstallPath(false)
+        expect(globalPath).toContain('.claude')
+        expect(globalPath).toContain('skills')
+        expect(globalPath).toContain('todoist-cli')
+        expect(globalPath).toContain('SKILL.md')
+    })
+
+    it('returns local path containing cwd', () => {
+        const localPath = claudeCodeInstaller.getInstallPath(true)
+        expect(localPath).toContain('.claude')
+        expect(localPath).toContain('skills')
+        expect(localPath).toContain('todoist-cli')
+        expect(localPath).toContain('SKILL.md')
+        expect(localPath).toContain(process.cwd())
+    })
+
+    describe('install/uninstall operations', () => {
+        let testDir: string
+        let skillFile: string
+
+        beforeEach(async () => {
+            testDir = await mkdtemp(join(tmpdir(), 'skill-test-'))
+            skillFile = join(testDir, 'SKILL.md')
+        })
+
+        afterEach(async () => {
+            await rm(testDir, { recursive: true, force: true })
+        })
+
+        it('creates directory structure and writes file', async () => {
+            const content = claudeCodeInstaller.generateContent()
+            const targetDir = join(testDir, 'nested', 'dir')
+            const targetFile = join(targetDir, 'SKILL.md')
+
+            await mkdir(targetDir, { recursive: true })
+            await writeFile(targetFile, content, 'utf-8')
+
+            const written = await readFile(targetFile, 'utf-8')
+            expect(written).toContain('name: todoist')
+        })
+
+        it('detects existing file', async () => {
+            await writeFile(skillFile, 'test', 'utf-8')
+
+            try {
+                await access(skillFile)
+                expect(true).toBe(true)
+            } catch {
+                expect(false).toBe(true)
+            }
+        })
+
+        it('removes file correctly', async () => {
+            await writeFile(skillFile, 'test', 'utf-8')
+            await unlink(skillFile)
+
+            try {
+                await access(skillFile)
+                expect(false).toBe(true)
+            } catch {
+                expect(true).toBe(true)
+            }
+        })
+    })
+})

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -1,0 +1,108 @@
+import chalk from 'chalk'
+import { Command } from 'commander'
+import { formatError } from '../lib/output.js'
+import { getInstaller, listAgents, skillInstallers } from '../lib/skills/index.js'
+
+interface InstallOptions {
+    local?: boolean
+    force?: boolean
+}
+
+interface UninstallOptions {
+    local?: boolean
+}
+
+async function installSkill(agent: string, options: InstallOptions): Promise<void> {
+    const installer = getInstaller(agent)
+    if (!installer) {
+        const available = listAgents().join(', ')
+        throw new Error(
+            formatError('UNKNOWN_AGENT', `Unknown agent: ${agent}`, [
+                `Available agents: ${available}`,
+            ]),
+        )
+    }
+
+    const local = options.local ?? false
+    const force = options.force ?? false
+
+    await installer.install(local, force)
+
+    const filepath = installer.getInstallPath(local)
+    console.log(chalk.green('✓'), `Installed ${installer.name} skill`)
+    console.log(chalk.dim(filepath))
+}
+
+async function uninstallSkill(agent: string, options: UninstallOptions): Promise<void> {
+    const installer = getInstaller(agent)
+    if (!installer) {
+        const available = listAgents().join(', ')
+        throw new Error(
+            formatError('UNKNOWN_AGENT', `Unknown agent: ${agent}`, [
+                `Available agents: ${available}`,
+            ]),
+        )
+    }
+
+    const local = options.local ?? false
+
+    await installer.uninstall(local)
+
+    console.log(chalk.green('✓'), `Uninstalled ${installer.name} skill`)
+}
+
+async function listSkills(): Promise<void> {
+    const agents = listAgents()
+
+    console.log(chalk.bold('Available agents:'))
+    console.log('')
+
+    for (const agentName of agents) {
+        const installer = skillInstallers[agentName]
+        const globalInstalled = await installer.isInstalled(false)
+        const localInstalled = await installer.isInstalled(true)
+
+        const status: string[] = []
+        if (globalInstalled) status.push('global')
+        if (localInstalled) status.push('local')
+
+        const statusStr =
+            status.length > 0 ? chalk.green(`[${status.join(', ')}]`) : chalk.dim('[not installed]')
+
+        console.log(`  ${agentName}`)
+        console.log(`    ${chalk.dim(installer.description)}`)
+        console.log(`    ${statusStr}`)
+        console.log('')
+    }
+}
+
+export function registerSkillCommand(program: Command): void {
+    const skill = program.command('skill').description('Manage coding agent skills/integrations')
+
+    const installCmd = skill
+        .command('install [agent]')
+        .description('Install skill for a coding agent')
+        .option('--local', 'Install in current project instead of global')
+        .option('--force', 'Overwrite existing skill file')
+        .action((agent, options) => {
+            if (!agent) {
+                installCmd.help()
+                return
+            }
+            return installSkill(agent, options)
+        })
+
+    const uninstallCmd = skill
+        .command('uninstall [agent]')
+        .description('Uninstall skill for a coding agent')
+        .option('--local', 'Remove from current project instead of global')
+        .action((agent, options) => {
+            if (!agent) {
+                uninstallCmd.help()
+                return
+            }
+            return uninstallSkill(agent, options)
+        })
+
+    skill.command('list').description('List supported agents and install status').action(listSkills)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { registerProjectCommand } from './commands/project.js'
 import { registerReminderCommand } from './commands/reminder.js'
 import { registerSectionCommand } from './commands/section.js'
 import { registerSettingsCommand } from './commands/settings.js'
+import { registerSkillCommand } from './commands/skill.js'
 import { registerStatsCommand } from './commands/stats.js'
 import { registerTaskCommand } from './commands/task.js'
 import { registerTodayCommand } from './commands/today.js'
@@ -52,6 +53,7 @@ registerAuthCommand(program)
 registerStatsCommand(program)
 registerFilterCommand(program)
 registerNotificationCommand(program)
+registerSkillCommand(program)
 
 program.parseAsync().catch((err: Error) => {
     console.error(err.message)

--- a/src/lib/skills/claude-code.ts
+++ b/src/lib/skills/claude-code.ts
@@ -1,0 +1,80 @@
+import { access, mkdir, readdir, rmdir, unlink, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { SKILL_CONTENT, SKILL_DESCRIPTION, SKILL_NAME } from './content.js'
+import type { SkillInstaller } from './types.js'
+
+function generateSkillFile(): string {
+    const frontmatter = `---
+name: ${SKILL_NAME}
+description: ${SKILL_DESCRIPTION}
+---
+
+`
+    return frontmatter + SKILL_CONTENT
+}
+
+function getGlobalPath(): string {
+    return join(homedir(), '.claude', 'skills', 'todoist-cli', 'SKILL.md')
+}
+
+function getLocalPath(): string {
+    return join(process.cwd(), '.claude', 'skills', 'todoist-cli', 'SKILL.md')
+}
+
+export const claudeCodeInstaller: SkillInstaller = {
+    name: 'claude-code',
+    description: 'Claude Code skill for Todoist CLI',
+
+    getInstallPath(local: boolean): string {
+        return local ? getLocalPath() : getGlobalPath()
+    },
+
+    generateContent(): string {
+        return generateSkillFile()
+    },
+
+    async isInstalled(local: boolean): Promise<boolean> {
+        const filepath = this.getInstallPath(local)
+        try {
+            await access(filepath)
+            return true
+        } catch {
+            return false
+        }
+    },
+
+    async install(local: boolean, force: boolean): Promise<void> {
+        const filepath = this.getInstallPath(local)
+
+        const exists = await this.isInstalled(local)
+        if (exists && !force) {
+            throw new Error(`Skill file already exists at ${filepath}. Use --force to overwrite.`)
+        }
+
+        const dir = dirname(filepath)
+        await mkdir(dir, { recursive: true })
+        await writeFile(filepath, this.generateContent(), 'utf-8')
+    },
+
+    async uninstall(local: boolean): Promise<void> {
+        const filepath = this.getInstallPath(local)
+
+        const exists = await this.isInstalled(local)
+        if (!exists) {
+            throw new Error(`Skill file not found at ${filepath}`)
+        }
+
+        await unlink(filepath)
+
+        const dir = dirname(filepath)
+        try {
+            const files = await readdir(dir)
+            if (files.length === 0) {
+                await rmdir(dir)
+            }
+        } catch {
+            // Ignore errors when cleaning up empty directory
+        }
+    },
+}

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -1,0 +1,120 @@
+export const SKILL_NAME = 'todoist'
+export const SKILL_DESCRIPTION =
+    'Manage Todoist tasks, projects, labels, and comments via the td CLI'
+
+export const SKILL_CONTENT = `# Todoist CLI (td)
+
+Use this skill when the user wants to interact with their Todoist tasks.
+
+## Quick Reference
+
+- \`td today\` - Tasks due today and overdue
+- \`td inbox\` - Inbox tasks
+- \`td add "task text"\` - Quick add with natural language
+- \`td task list\` - List tasks with filters
+- \`td task complete <ref>\` - Complete a task
+- \`td project list\` - List projects
+- \`td label list\` - List labels
+
+## Output Formats
+
+All list commands support:
+- \`--json\` - JSON output (essential fields)
+- \`--ndjson\` - Newline-delimited JSON (streaming)
+- \`--full\` - Include all fields in JSON
+- \`--raw\` - Disable markdown rendering
+
+## Task References
+
+Tasks can be referenced by:
+- Name (fuzzy matched within context)
+- \`id:xxx\` - Explicit task ID
+
+## Commands
+
+### Quick Add
+\`\`\`bash
+td add "Buy milk tomorrow p1 #Shopping"
+td add "Meeting with John at 3pm" --assignee "john@example.com"
+\`\`\`
+
+### Today & Inbox
+\`\`\`bash
+td today                    # Due today + overdue
+td today --json             # JSON output
+td inbox                    # Inbox tasks
+\`\`\`
+
+### Task Management
+\`\`\`bash
+td task list --project "Work"
+td task list --label "urgent" --priority p1
+td task list --due today
+td task list --filter "today | overdue"
+td task view "task name"
+td task complete "task name"
+td task complete id:123456
+td task complete "task name" --forever  # Stop recurrence
+td task add --content "New task" --due "tomorrow" --priority p2
+td task update "task name" --due "next week"
+td task move "task name" --project "Personal"
+td task delete "task name" --yes
+\`\`\`
+
+### Projects
+\`\`\`bash
+td project list
+td project view "Project Name"
+td project create --name "New Project" --color "blue"
+td project update "Project Name" --favorite
+td project archive "Project Name"
+td project delete "Project Name" --yes
+\`\`\`
+
+### Labels
+\`\`\`bash
+td label list
+td label create --name "urgent" --color "red"
+td label update "urgent" --color "orange"
+td label delete "urgent" --yes
+\`\`\`
+
+### Comments
+\`\`\`bash
+td comment list --task "task name"
+td comment add --task "task name" --content "Comment text"
+\`\`\`
+
+### Sections
+\`\`\`bash
+td section list --project "Work"
+td section create --project "Work" --name "In Progress"
+\`\`\`
+
+## Priority Mapping
+
+- p1 = Highest priority (API value 4)
+- p2 = High priority (API value 3)
+- p3 = Medium priority (API value 2)
+- p4 = Lowest priority (API value 1, default)
+
+## Examples
+
+### Daily workflow
+\`\`\`bash
+td today --json | jq '.results | length'  # Count today's tasks
+td inbox --limit 5                          # Quick inbox check
+\`\`\`
+
+### Filter by multiple criteria
+\`\`\`bash
+td task list --project "Work" --label "urgent" --priority p1
+td task list --filter "today & #Work"
+\`\`\`
+
+### Complete tasks efficiently
+\`\`\`bash
+td task complete "Review PR"
+td task complete id:123456789
+\`\`\`
+`

--- a/src/lib/skills/index.ts
+++ b/src/lib/skills/index.ts
@@ -1,0 +1,16 @@
+import { claudeCodeInstaller } from './claude-code.js'
+import type { SkillInstaller } from './types.js'
+
+export const skillInstallers: Record<string, SkillInstaller> = {
+    'claude-code': claudeCodeInstaller,
+}
+
+export function getInstaller(agent: string): SkillInstaller | undefined {
+    return skillInstallers[agent]
+}
+
+export function listAgents(): string[] {
+    return Object.keys(skillInstallers)
+}
+
+export type { SkillInstaller } from './types.js'

--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -1,0 +1,9 @@
+export interface SkillInstaller {
+    name: string
+    description: string
+    getInstallPath(local: boolean): string
+    generateContent(): string
+    isInstalled(local: boolean): Promise<boolean>
+    install(local: boolean, force: boolean): Promise<void>
+    uninstall(local: boolean): Promise<void>
+}


### PR DESCRIPTION
## Summary
- Add `td skill install <agent>` command to install skill files for coding agents
- Support for Claude Code with `claude-code` agent (installs SKILL.md with Todoist CLI documentation)
- Extensible architecture for future agent support

## Commands
```bash
td skill list                         # List agents + install status
td skill install claude-code          # Install globally (~/.claude/skills/)
td skill install claude-code --local  # Install in project (./.claude/skills/)
td skill install claude-code --force  # Overwrite existing
td skill uninstall claude-code        # Remove global
td skill uninstall claude-code --local
```

## Test plan
- [x] `npm run build` compiles successfully
- [x] `npm test` passes (580 tests)
- [x] `td skill list` shows available agents
- [x] `td skill install claude-code` creates skill file
- [x] `td skill install claude-code` errors without `--force` when file exists
- [x] `td skill uninstall claude-code` removes skill file

🤖 Generated with [Claude Code](https://claude.com/claude-code)