### PR TITLE
fix: prevent task creation in archived projects

### DIFF
--- a/src/__tests__/task.test.ts
+++ b/src/__tests__/task.test.ts
@@ -897,6 +897,30 @@ describe('task add', () => {
             ]),
         ).rejects.toThrow('The --project flag is required when using --parent with a task name.')
     })
+
+    it('throws error when project is archived', async () => {
+        const program = createProgram()
+
+        mockApi.getProjects.mockResolvedValue({
+            results: [{ id: 'proj-archived', name: 'Old Project', isArchived: true }],
+            nextCursor: null,
+        })
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'task',
+                'add',
+                '--content',
+                'Task',
+                '--project',
+                'Old Project',
+            ]),
+        ).rejects.toThrow('Cannot create task in archived project "Old Project"')
+
+        expect(mockApi.addTask).not.toHaveBeenCalled()
+    })
 })
 
 describe('task update', () => {

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -185,6 +185,9 @@ async function addTask(options: AddOptions): Promise<void> {
     let project = null
     if (options.project) {
         project = await resolveProjectRef(api, options.project)
+        if (project.isArchived) {
+            throw new Error(`Cannot create task in archived project "${project.name}"`)
+        }
         args.projectId = project.id
     }
 


### PR DESCRIPTION
Prevent silent failures when creating tasks in archived projects via `td task add --project <ref>`. Returns a clear error instead of allowing tasks to be created in archived projects. 

This ports the validation from [Doist/todoist-ai#284](https://github.com/Doist/todoist-ai/pull/284) to the CLI. Only applies to explicit `--project` flag; the quick-add path (`td add`) cannot pre-validate since the project is parsed by Todoist's backend.

All tests pass and error message is shown clearly to users.