### PR TITLE
fix: resolve td today missing tasks with specific times

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@doist/todoist-api-typescript": "6.2.1",
         "chalk": "5.6.2",
         "commander": "14.0.2",
+        "date-fns": "4.1.0",
         "marked": "15.0.12",
         "marked-terminal": "7.3.0",
         "open": "11.0.0",
@@ -1459,6 +1460,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/default-browser": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@doist/todoist-api-typescript": "6.2.1",
     "chalk": "5.6.2",
     "commander": "14.0.2",
+    "date-fns": "4.1.0",
     "marked": "15.0.12",
     "marked-terminal": "7.3.0",
     "open": "11.0.0",

--- a/src/__tests__/dates.test.ts
+++ b/src/__tests__/dates.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { formatDateHeader, getLocalDate } from '../lib/dates.js'
+import {
+    formatDateHeader,
+    getLocalDate,
+    isDueBefore,
+    isDueOnDate,
+    parseDueDateToDay,
+} from '../lib/dates.js'
 
 describe('getLocalDate', () => {
     it('returns today in YYYY-MM-DD format', () => {
@@ -10,40 +16,234 @@ describe('getLocalDate', () => {
         expect(result).toBe(expected)
     })
 
-    it('returns tomorrow with offset 1', () => {
+    it.each([
+        { offset: 1, description: 'tomorrow', comparison: '>' },
+        { offset: -1, description: 'yesterday', comparison: '<' },
+        { offset: 7, description: 'next week', comparison: '>' },
+        { offset: -7, description: 'last week', comparison: '<' },
+    ])('returns $description with offset $offset', ({ offset, comparison }) => {
         const today = getLocalDate(0)
-        const tomorrow = getLocalDate(1)
-        expect(tomorrow > today).toBe(true)
-    })
+        const result = getLocalDate(offset)
 
-    it('returns yesterday with offset -1', () => {
-        const today = getLocalDate(0)
-        const yesterday = getLocalDate(-1)
-        expect(yesterday < today).toBe(true)
+        if (comparison === '>') {
+            expect(result > today).toBe(true)
+        } else {
+            expect(result < today).toBe(true)
+        }
     })
 })
 
 describe('formatDateHeader', () => {
     const today = getLocalDate(0)
-    const tomorrow = getLocalDate(1)
-    const yesterday = getLocalDate(-1)
 
-    it('returns "Overdue" for past dates', () => {
-        expect(formatDateHeader(yesterday, today)).toBe('Overdue')
-        expect(formatDateHeader('2020-01-01', today)).toBe('Overdue')
-    })
-
-    it('returns "Today" for today', () => {
-        expect(formatDateHeader(today, today)).toBe('Today')
-    })
-
-    it('returns "Tomorrow" for tomorrow', () => {
-        expect(formatDateHeader(tomorrow, today)).toBe('Tomorrow')
+    it.each([
+        { dateOffset: -1, expected: 'Overdue', description: 'yesterday' },
+        { dateOffset: -7, expected: 'Overdue', description: 'last week' },
+        { date: '2020-01-01', expected: 'Overdue', description: 'old date' },
+        { dateOffset: 0, expected: 'Today', description: 'today' },
+        { dateOffset: 1, expected: 'Tomorrow', description: 'tomorrow' },
+    ])('returns "$expected" for $description', ({ dateOffset, date, expected }) => {
+        const testDate = date ?? getLocalDate(dateOffset ?? 0)
+        expect(formatDateHeader(testDate, today)).toBe(expected)
     })
 
     it('returns formatted date for future dates beyond tomorrow', () => {
         const futureDate = getLocalDate(5)
         const result = formatDateHeader(futureDate, today)
         expect(result).toMatch(/^[A-Z][a-z]{2} \d{1,2}$/)
+    })
+})
+
+describe('parseDueDateToDay', () => {
+    it.each([
+        { input: '2026-01-29', description: 'date-only format' },
+        { input: '2026-01-29T18:00:00', description: 'datetime format' },
+        { input: '2026-01-29T00:00:00', description: 'midnight' },
+        { input: '2026-01-29T23:59:59', description: 'end of day' },
+    ])('parses $description correctly', ({ input }) => {
+        const result = parseDueDateToDay(input)
+        expect(result.toISOString()).toMatch(/2026-01-29T00:00:00/)
+    })
+
+    it('normalizes different times on same day to identical dates', () => {
+        const times = ['09:00:00', '12:30:15', '18:00:00', '23:59:59']
+        const results = times.map((time) => parseDueDateToDay(`2026-01-29T${time}`))
+
+        // All should be identical
+        results.forEach((result) => {
+            expect(result.getTime()).toBe(results[0].getTime())
+        })
+    })
+})
+
+describe('isDueOnDate', () => {
+    it.each([
+        // Same date cases (should return true)
+        {
+            dueDate: '2026-01-29',
+            targetDate: '2026-01-29',
+            expected: true,
+            description: 'exact date match',
+        },
+        {
+            dueDate: '2026-01-29T18:00:00',
+            targetDate: '2026-01-29',
+            expected: true,
+            description: 'datetime on same date (evening)',
+        },
+        {
+            dueDate: '2026-01-29T09:00:00',
+            targetDate: '2026-01-29',
+            expected: true,
+            description: 'datetime on same date (morning)',
+        },
+        {
+            dueDate: '2026-01-29T00:00:00',
+            targetDate: '2026-01-29',
+            expected: true,
+            description: 'datetime on same date (midnight)',
+        },
+        {
+            dueDate: '2026-01-29T23:59:59',
+            targetDate: '2026-01-29',
+            expected: true,
+            description: 'datetime on same date (end of day)',
+        },
+        {
+            dueDate: '2026-01-31T23:00:00',
+            targetDate: '2026-01-31',
+            expected: true,
+            description: 'month end edge case',
+        },
+
+        // Different date cases (should return false)
+        {
+            dueDate: '2026-01-28',
+            targetDate: '2026-01-29',
+            expected: false,
+            description: 'day before',
+        },
+        {
+            dueDate: '2026-01-30',
+            targetDate: '2026-01-29',
+            expected: false,
+            description: 'day after',
+        },
+        {
+            dueDate: '2026-01-28T23:59:59',
+            targetDate: '2026-01-29',
+            expected: false,
+            description: 'late on day before',
+        },
+        {
+            dueDate: '2026-02-01T01:00:00',
+            targetDate: '2026-01-31',
+            expected: false,
+            description: 'month boundary edge case',
+        },
+        {
+            dueDate: '2025-01-29',
+            targetDate: '2026-01-29',
+            expected: false,
+            description: 'year boundary',
+        },
+    ])('returns $expected for $description', ({ dueDate, targetDate, expected }) => {
+        expect(isDueOnDate(dueDate, targetDate)).toBe(expected)
+    })
+})
+
+describe('isDueBefore', () => {
+    it.each([
+        // Before cases (should return true)
+        {
+            dueDate: '2026-01-28',
+            targetDate: '2026-01-29',
+            expected: true,
+            description: 'day before (date only)',
+        },
+        {
+            dueDate: '2026-01-28T18:00:00',
+            targetDate: '2026-01-29',
+            expected: true,
+            description: 'day before (with time)',
+        },
+        {
+            dueDate: '2026-01-28T23:59:59',
+            targetDate: '2026-01-29',
+            expected: true,
+            description: 'late on day before',
+        },
+        {
+            dueDate: '2025-12-31T23:59:59',
+            targetDate: '2026-01-01',
+            expected: true,
+            description: 'year boundary edge case',
+        },
+        {
+            dueDate: '2026-01-01',
+            targetDate: '2026-01-15',
+            expected: true,
+            description: 'multiple days before',
+        },
+
+        // Same date cases (should return false regardless of time)
+        {
+            dueDate: '2026-01-29',
+            targetDate: '2026-01-29',
+            expected: false,
+            description: 'same date (date only)',
+        },
+        {
+            dueDate: '2026-01-29T00:00:00',
+            targetDate: '2026-01-29',
+            expected: false,
+            description: 'same date (midnight)',
+        },
+        {
+            dueDate: '2026-01-29T18:00:00',
+            targetDate: '2026-01-29',
+            expected: false,
+            description: 'same date (evening)',
+        },
+        {
+            dueDate: '2026-01-29T23:59:59',
+            targetDate: '2026-01-29',
+            expected: false,
+            description: 'same date (end of day)',
+        },
+        {
+            dueDate: '2026-01-01T00:00:00',
+            targetDate: '2026-01-01',
+            expected: false,
+            description: 'same date (year boundary)',
+        },
+
+        // After cases (should return false)
+        {
+            dueDate: '2026-01-30',
+            targetDate: '2026-01-29',
+            expected: false,
+            description: 'day after (date only)',
+        },
+        {
+            dueDate: '2026-01-30T01:00:00',
+            targetDate: '2026-01-29',
+            expected: false,
+            description: 'day after (with time)',
+        },
+        {
+            dueDate: '2026-02-01',
+            targetDate: '2026-01-31',
+            expected: false,
+            description: 'month boundary',
+        },
+        {
+            dueDate: '2027-01-29',
+            targetDate: '2026-01-29',
+            expected: false,
+            description: 'year after',
+        },
+    ])('returns $expected for $description', ({ dueDate, targetDate, expected }) => {
+        expect(isDueBefore(dueDate, targetDate)).toBe(expected)
     })
 })

--- a/src/__tests__/today.test.ts
+++ b/src/__tests__/today.test.ts
@@ -110,6 +110,38 @@ describe('today command', () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Today task'))
     })
 
+    it('includes tasks with specific times in today section', async () => {
+        const program = createProgram()
+
+        mockApi.getTasks.mockResolvedValue({
+            results: [
+                {
+                    id: 'task-1',
+                    content: 'Meeting at 6pm',
+                    projectId: 'proj-1',
+                    due: { date: `${getToday()}T18:00:00`, string: 'today at 6pm' },
+                },
+                {
+                    id: 'task-2',
+                    content: 'Deadline at 9am',
+                    projectId: 'proj-1',
+                    due: { date: `${getToday()}T09:00:00`, string: 'today at 9am' },
+                },
+            ],
+            nextCursor: null,
+        })
+        mockApi.getProjects.mockResolvedValue({
+            results: [{ id: 'proj-1', name: 'Work' }],
+            nextCursor: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'today'])
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Today'))
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Meeting at 6pm'))
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Deadline at 9am'))
+    })
+
     it('shows "No tasks due today" when empty', async () => {
         const program = createProgram()
 

--- a/src/commands/today.ts
+++ b/src/commands/today.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import { Command } from 'commander'
 import { getApi, getCurrentUserId } from '../lib/api/core.js'
 import { CollaboratorCache, formatAssignee } from '../lib/collaborators.js'
-import { getLocalDate } from '../lib/dates.js'
+import { getLocalDate, isDueBefore, isDueOnDate } from '../lib/dates.js'
 import {
     formatNextCursorFooter,
     formatPaginatedJson,
@@ -73,8 +73,8 @@ export function registerTodayCommand(program: Command): void {
             )
             filteredTasks = filterResult.tasks
 
-            const overdue = filteredTasks.filter((t) => t.due && t.due.date < today)
-            const dueToday = filteredTasks.filter((t) => t.due?.date === today)
+            const overdue = filteredTasks.filter((t) => t.due && isDueBefore(t.due.date, today))
+            const dueToday = filteredTasks.filter((t) => t.due && isDueOnDate(t.due.date, today))
             const allTodayTasks = [...overdue, ...dueToday]
 
             if (options.json) {

--- a/src/commands/upcoming.ts
+++ b/src/commands/upcoming.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import { Command } from 'commander'
 import { getApi, getCurrentUserId, type Task } from '../lib/api/core.js'
 import { CollaboratorCache, formatAssignee } from '../lib/collaborators.js'
-import { formatDateHeader, getLocalDate } from '../lib/dates.js'
+import { formatDateHeader, getLocalDate, isDueBefore } from '../lib/dates.js'
 import {
     formatNextCursorFooter,
     formatPaginatedJson,
@@ -79,7 +79,9 @@ export function registerUpcomingCommand(program: Command): void {
             )
             filteredTasks = filterResult.tasks
 
-            const relevantTasks = filteredTasks.filter((t) => t.due && t.due.date < endDate)
+            const relevantTasks = filteredTasks.filter(
+                (t) => t.due && isDueBefore(t.due.date, endDate),
+            )
 
             if (options.json) {
                 console.log(
@@ -121,7 +123,7 @@ export function registerUpcomingCommand(program: Command): void {
             for (const task of relevantTasks) {
                 const dueDate = task.due?.date
                 if (!dueDate) continue // Skip tasks without due dates
-                if (dueDate < today) {
+                if (isDueBefore(dueDate, today)) {
                     overdue.push(task)
                 } else {
                     const list = byDate.get(dueDate) || []

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,14 +1,41 @@
+import { format, isBefore, isEqual, parseISO } from 'date-fns'
+
 export function getLocalDate(daysOffset = 0): string {
     const date = new Date()
     date.setDate(date.getDate() + daysOffset)
     return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
 }
 
+/**
+ * Parse a due date string (handles both date-only and datetime formats)
+ * and return a Date object set to start of day for date comparison
+ */
+export function parseDueDateToDay(dateStr: string): Date {
+    // Parse the date string (handles both YYYY-MM-DD and YYYY-MM-DDTHH:mm:ss formats)
+    const parsed = parseISO(dateStr)
+    // Return start of day to compare only dates, not times
+    return parseISO(format(parsed, 'yyyy-MM-dd'))
+}
+
+/**
+ * Check if a due date is on a specific day
+ */
+export function isDueOnDate(dueDate: string, targetDate: string): boolean {
+    return isEqual(parseDueDateToDay(dueDate), parseISO(targetDate))
+}
+
+/**
+ * Check if a due date is before a specific day
+ */
+export function isDueBefore(dueDate: string, targetDate: string): boolean {
+    return isBefore(parseDueDateToDay(dueDate), parseISO(targetDate))
+}
+
 export function formatDateHeader(dateStr: string, today: string): string {
-    if (dateStr < today) return 'Overdue'
-    if (dateStr === today) return 'Today'
+    if (isDueBefore(dateStr, today)) return 'Overdue'
+    if (isDueOnDate(dateStr, today)) return 'Today'
     const tomorrow = getLocalDate(1)
-    if (dateStr === tomorrow) return 'Tomorrow'
+    if (isDueOnDate(dateStr, tomorrow)) return 'Tomorrow'
     const [year, month, day] = dateStr.split('-').map(Number)
     return new Date(year, month - 1, day).toLocaleDateString('en-US', {
         month: 'short',

--- a/src/lib/task-list.ts
+++ b/src/lib/task-list.ts
@@ -8,6 +8,7 @@ import {
     type Section,
 } from './api/core.js'
 import { CollaboratorCache, formatAssignee } from './collaborators.js'
+import { isDueBefore, isDueOnDate } from './dates.js'
 import {
     formatError,
     formatNextCursorFooter,
@@ -274,11 +275,12 @@ export async function listTasksForProject(
     if (options.due) {
         const today = getLocalToday()
         if (options.due === 'today') {
-            filtered = filtered.filter((t) => t.due?.date === today)
+            filtered = filtered.filter((t) => t.due && isDueOnDate(t.due.date, today))
         } else if (options.due === 'overdue') {
-            filtered = filtered.filter((t) => t.due && t.due.date < today)
-        } else {
-            filtered = filtered.filter((t) => t.due?.date === options.due)
+            filtered = filtered.filter((t) => t.due && isDueBefore(t.due.date, today))
+        } else if (options.due) {
+            const targetDate = options.due
+            filtered = filtered.filter((t) => t.due && isDueOnDate(t.due.date, targetDate))
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #27 where `td today` command was missing tasks with specific times (e.g., "today at 6pm").

## Problem

The issue occurred because datetime strings like `"2026-01-29T18:00:00"` failed string comparison with date-only strings like `"2026-01-29"` in the filtering logic.

**Before:** Tasks with specific times were missing from `td today` output
**After:** All tasks due today appear correctly, regardless of whether they have specific times

## Solution

Use `date-fns` to do date comparisons, rather than rudimentary string comparisons. 

Closes #27

Co-Authored-By: Claude Sonnet 4 <noreply@anthropic.com>