### PR TITLE
feat: add --progress-jsonl flag for machine-readable progress reporting

### DIFF
--- a/src/__tests__/progress.test.ts
+++ b/src/__tests__/progress.test.ts
@@ -1,0 +1,357 @@
+import fs from 'node:fs'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProgressEvent } from '../lib/progress.js'
+import { getProgressTracker, ProgressTracker, resetProgressTracker } from '../lib/progress.js'
+
+// Mock fs module
+vi.mock('fs', () => ({
+    default: {
+        createWriteStream: vi.fn(),
+    },
+}))
+
+describe('ProgressTracker', () => {
+    let originalArgv: string[]
+    let originalStderr: typeof process.stderr
+    let mockStderr: { write: ReturnType<typeof vi.fn> }
+    let mockWriteStream: { write: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn> }
+
+    beforeEach(() => {
+        originalArgv = [...process.argv]
+        originalStderr = process.stderr
+
+        // Mock stderr
+        mockStderr = {
+            write: vi.fn(),
+        }
+        Object.defineProperty(process, 'stderr', {
+            value: mockStderr,
+            configurable: true,
+        })
+
+        // Mock write stream
+        mockWriteStream = {
+            write: vi.fn(),
+            close: vi.fn(),
+        }
+        vi.mocked(fs.createWriteStream).mockReturnValue(
+            mockWriteStream as unknown as fs.WriteStream,
+        )
+
+        vi.clearAllMocks()
+        resetProgressTracker()
+    })
+
+    afterEach(() => {
+        process.argv = originalArgv
+        Object.defineProperty(process, 'stderr', {
+            value: originalStderr,
+            configurable: true,
+        })
+        vi.clearAllMocks()
+        resetProgressTracker()
+    })
+
+    describe('initialization and enabling', () => {
+        it.each([
+            ['disabled by default', ['node', 'td', 'today'], false],
+            [
+                'enabled with --progress-jsonl flag',
+                ['node', 'td', 'today', '--progress-jsonl'],
+                true,
+            ],
+            [
+                'enabled with --progress-jsonl=path flag',
+                ['node', 'td', 'today', '--progress-jsonl=/tmp/progress.jsonl'],
+                true,
+            ],
+            [
+                'enabled with --progress-jsonl path as separate arg',
+                ['node', 'td', 'today', '--progress-jsonl', '/tmp/progress.jsonl'],
+                true,
+            ],
+        ])('should be %s', (_description, argv, expectedEnabled) => {
+            process.argv = argv
+            const tracker = new ProgressTracker()
+            expect(tracker.isEnabled()).toBe(expectedEnabled)
+        })
+    })
+
+    describe('output destinations', () => {
+        it('should output to stderr by default', () => {
+            process.argv = ['node', 'td', 'today', '--progress-jsonl']
+            const tracker = new ProgressTracker()
+
+            tracker.emit({ type: 'start', command: 'today' })
+
+            expect(mockStderr.write).toHaveBeenCalledWith(
+                expect.stringMatching(/"type":"start".*"command":"today"/),
+            )
+        })
+
+        it('should create file when path is provided with equals', () => {
+            process.argv = ['node', 'td', 'today', '--progress-jsonl=/tmp/progress.jsonl']
+            const tracker = new ProgressTracker()
+
+            expect(fs.createWriteStream).toHaveBeenCalledWith('/tmp/progress.jsonl', { flags: 'a' })
+
+            tracker.emit({ type: 'start', command: 'today' })
+            expect(mockWriteStream.write).toHaveBeenCalled()
+        })
+
+        it('should create file when path is provided as separate arg', () => {
+            process.argv = ['node', 'td', 'today', '--progress-jsonl', '/tmp/progress.jsonl']
+            const _tracker = new ProgressTracker()
+
+            expect(fs.createWriteStream).toHaveBeenCalledWith('/tmp/progress.jsonl', { flags: 'a' })
+        })
+
+        it('should fall back to stderr if file creation fails', () => {
+            process.argv = ['node', 'td', 'today', '--progress-jsonl=/invalid/path']
+            vi.mocked(fs.createWriteStream).mockImplementation(() => {
+                throw new Error('Permission denied')
+            })
+
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+            const tracker = new ProgressTracker()
+            tracker.emit({ type: 'start', command: 'today' })
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Warning: Could not create progress file'),
+            )
+            expect(mockStderr.write).toHaveBeenCalled()
+
+            consoleSpy.mockRestore()
+        })
+    })
+
+    describe('event emission', () => {
+        let tracker: ProgressTracker
+
+        beforeEach(() => {
+            process.argv = ['node', 'td', 'today', '--progress-jsonl']
+            tracker = new ProgressTracker()
+        })
+
+        it('should emit start events', () => {
+            tracker.emitStart('today')
+
+            expect(mockStderr.write).toHaveBeenCalledWith(
+                expect.stringMatching(/"type":"start".*"command":"today".*"timestamp"/),
+            )
+        })
+
+        it('should emit api_call events', () => {
+            tracker.emitApiCall('getTasks', 'cursor123')
+
+            expect(mockStderr.write).toHaveBeenCalledWith(
+                expect.stringMatching(
+                    /"type":"api_call".*"endpoint":"getTasks".*"cursor":"cursor123"/,
+                ),
+            )
+        })
+
+        it('should emit api_call events without cursor', () => {
+            tracker.emitApiCall('getUser')
+
+            expect(mockStderr.write).toHaveBeenCalledWith(
+                expect.stringMatching(/"type":"api_call".*"endpoint":"getUser"/),
+            )
+        })
+
+        it('should emit api_response events', () => {
+            tracker.emitApiResponse(50, true, 'nextCursor123')
+
+            expect(mockStderr.write).toHaveBeenCalledWith(
+                expect.stringMatching(
+                    /"type":"api_response".*"count":50.*"has_more":true.*"next_cursor":"nextCursor123"/,
+                ),
+            )
+        })
+
+        it('should emit api_response events without next cursor', () => {
+            tracker.emitApiResponse(30, false)
+
+            expect(mockStderr.write).toHaveBeenCalledWith(
+                expect.stringMatching(/"type":"api_response".*"count":30.*"has_more":false/),
+            )
+        })
+
+        it('should emit complete events', () => {
+            tracker.emitComplete()
+
+            expect(mockStderr.write).toHaveBeenCalledWith(
+                expect.stringMatching(/"type":"complete".*"timestamp"/),
+            )
+        })
+
+        it('should emit error events', () => {
+            tracker.emitError('UNAUTHORIZED', 'Invalid token')
+
+            expect(mockStderr.write).toHaveBeenCalledWith(
+                expect.stringMatching(
+                    /"type":"error".*"error_code":"UNAUTHORIZED".*"message":"Invalid token"/,
+                ),
+            )
+        })
+
+        it('should emit error events with minimal info', () => {
+            tracker.emitError()
+
+            expect(mockStderr.write).toHaveBeenCalledWith(
+                expect.stringMatching(/"type":"error".*"timestamp"/),
+            )
+        })
+
+        it('should not emit events when disabled', () => {
+            resetProgressTracker()
+            process.argv = ['node', 'td', 'today'] // No --progress-jsonl flag
+            const disabledTracker = new ProgressTracker()
+
+            disabledTracker.emitStart('today')
+            expect(mockStderr.write).not.toHaveBeenCalled()
+        })
+
+        it('should include valid ISO timestamps', () => {
+            tracker.emitStart('today')
+
+            const writeCall = vi.mocked(mockStderr.write).mock.calls[0][0] as string
+            const eventData = JSON.parse(writeCall) as ProgressEvent
+
+            expect(eventData.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+            expect(new Date(eventData.timestamp).toISOString()).toBe(eventData.timestamp)
+        })
+
+        it('should emit properly formatted JSONL', () => {
+            tracker.emitStart('today')
+            tracker.emitComplete()
+
+            const calls = vi.mocked(mockStderr.write).mock.calls
+            expect(calls).toHaveLength(2)
+
+            for (const call of calls) {
+                const line = call[0] as string
+                expect(line).toMatch(/^\{.*\}\n$/) // Valid JSON + newline
+                expect(() => JSON.parse(line.trim())).not.toThrow()
+            }
+        })
+    })
+
+    describe('cleanup', () => {
+        it('should close file stream when calling close()', () => {
+            process.argv = ['node', 'td', 'today', '--progress-jsonl=/tmp/progress.jsonl']
+            const tracker = new ProgressTracker()
+
+            tracker.close()
+
+            expect(mockWriteStream.close).toHaveBeenCalled()
+            expect(tracker.isEnabled()).toBe(false)
+        })
+
+        it('should handle close() when using stderr', () => {
+            process.argv = ['node', 'td', 'today', '--progress-jsonl']
+            const tracker = new ProgressTracker()
+
+            // Should not throw
+            tracker.close()
+            expect(tracker.isEnabled()).toBe(false)
+        })
+    })
+})
+
+describe('global progress tracker', () => {
+    let originalArgv: string[]
+
+    beforeEach(() => {
+        originalArgv = [...process.argv]
+        resetProgressTracker()
+        vi.clearAllMocks()
+    })
+
+    afterEach(() => {
+        process.argv = originalArgv
+        resetProgressTracker()
+    })
+
+    it('should return singleton instance', () => {
+        process.argv = ['node', 'td', 'today', '--progress-jsonl']
+
+        const tracker1 = getProgressTracker()
+        const tracker2 = getProgressTracker()
+
+        expect(tracker1).toBe(tracker2)
+    })
+
+    it('should create new instance after reset', () => {
+        process.argv = ['node', 'td', 'today', '--progress-jsonl']
+
+        const tracker1 = getProgressTracker()
+        resetProgressTracker()
+        const tracker2 = getProgressTracker()
+
+        expect(tracker1).not.toBe(tracker2)
+    })
+
+    it('should respect argv changes between instances', () => {
+        // First instance - disabled
+        process.argv = ['node', 'td', 'today']
+        const tracker1 = getProgressTracker()
+        expect(tracker1.isEnabled()).toBe(false)
+
+        // Reset and create new instance with flag
+        resetProgressTracker()
+        process.argv = ['node', 'td', 'today', '--progress-jsonl']
+        const tracker2 = getProgressTracker()
+        expect(tracker2.isEnabled()).toBe(true)
+    })
+})
+
+describe('edge cases and integration', () => {
+    let originalArgv: string[]
+    let mockStderr: { write: ReturnType<typeof vi.fn> }
+
+    beforeEach(() => {
+        originalArgv = [...process.argv]
+
+        mockStderr = {
+            write: vi.fn(),
+        }
+        Object.defineProperty(process, 'stderr', {
+            value: mockStderr,
+            configurable: true,
+        })
+
+        resetProgressTracker()
+        vi.clearAllMocks()
+    })
+
+    afterEach(() => {
+        process.argv = originalArgv
+        resetProgressTracker()
+    })
+
+    it.each([
+        ['flag in middle of arguments', ['node', 'td', '--progress-jsonl', 'today', '--json']],
+        ['flag at end of arguments', ['node', 'td', 'today', '--json', '--progress-jsonl']],
+        ['flag with empty path argument', ['node', 'td', 'today', '--progress-jsonl', '']],
+        ['flag followed by another flag', ['node', 'td', 'today', '--progress-jsonl', '--json']],
+    ])('should handle %s', (_description, argv) => {
+        process.argv = argv
+        const tracker = new ProgressTracker()
+        expect(tracker.isEnabled()).toBe(true)
+    })
+
+    it('should handle multiple progress-jsonl flags (last one wins)', () => {
+        process.argv = [
+            'node',
+            'td',
+            '--progress-jsonl=/tmp/first',
+            '--progress-jsonl=/tmp/second',
+            'today',
+        ]
+        const _tracker = new ProgressTracker()
+
+        expect(fs.createWriteStream).toHaveBeenLastCalledWith('/tmp/second', { flags: 'a' })
+    })
+})

--- a/src/__tests__/spinner.test.ts
+++ b/src/__tests__/spinner.test.ts
@@ -118,32 +118,14 @@ describe('withSpinner', () => {
         expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
     })
 
-    it('should not show spinner with --json flag', async () => {
-        process.argv = ['node', 'td', 'auth', 'status', '--json']
-
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue' },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-    })
-
-    it('should not show spinner with --ndjson flag', async () => {
-        process.argv = ['node', 'td', 'auth', 'status', '--ndjson']
-
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue' },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-    })
-
-    it('should not show spinner with --no-spinner flag', async () => {
-        process.argv = ['node', 'td', 'auth', 'status', '--no-spinner']
+    it.each([
+        ['--json', ['node', 'td', 'auth', 'status', '--json']],
+        ['--ndjson', ['node', 'td', 'auth', 'status', '--ndjson']],
+        ['--no-spinner', ['node', 'td', 'auth', 'status', '--no-spinner']],
+        ['--progress-jsonl', ['node', 'td', 'today', '--progress-jsonl']],
+        ['--progress-jsonl=path', ['node', 'td', 'today', '--progress-jsonl=/tmp/progress.jsonl']],
+    ])('should not show spinner with %s flag', async (_flagName, argv) => {
+        process.argv = argv
 
         const result = await withSpinner(
             { text: 'Testing...', color: 'blue' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ program
     .description('Todoist CLI')
     .version(packageJson.version)
     .option('--no-spinner', 'Disable loading animations')
+    .option('--progress-jsonl [path]', 'Output progress events as JSONL to stderr or file')
     .addHelpText(
         'after',
         `

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -1,0 +1,134 @@
+import fs from 'node:fs'
+
+export type ProgressEvent = {
+    type: 'start' | 'api_call' | 'api_response' | 'complete' | 'error'
+    timestamp: string
+    command?: string
+    endpoint?: string
+    cursor?: string | null
+    count?: number
+    has_more?: boolean
+    next_cursor?: string | null
+    error_code?: string
+    message?: string
+}
+
+export class ProgressTracker {
+    private enabled = false
+    private outputStream: fs.WriteStream | typeof process.stderr | null = null
+
+    constructor() {
+        this.checkAndInitialize()
+    }
+
+    private checkAndInitialize() {
+        const args = process.argv
+
+        // Find all --progress-jsonl flags and use the last one
+        const progressIndices = args
+            .map((arg, index) => ({ arg, index }))
+            .filter(({ arg }) => arg.startsWith('--progress-jsonl'))
+
+        if (progressIndices.length === 0) {
+            return
+        }
+
+        this.enabled = true
+
+        // Use the last occurrence
+        const { arg, index: progressIndex } = progressIndices[progressIndices.length - 1]
+
+        // Handle both --progress-jsonl and --progress-jsonl=path formats
+        let outputPath: string | undefined
+
+        if (arg.includes('=')) {
+            // Format: --progress-jsonl=/path/to/file
+            outputPath = arg.split('=', 2)[1]
+        } else if (progressIndex + 1 < args.length && !args[progressIndex + 1].startsWith('-')) {
+            // Format: --progress-jsonl /path/to/file
+            outputPath = args[progressIndex + 1]
+        }
+
+        if (outputPath) {
+            try {
+                this.outputStream = fs.createWriteStream(outputPath, { flags: 'a' })
+            } catch (_error) {
+                // Fall back to stderr if file creation fails
+                console.error(
+                    `Warning: Could not create progress file ${outputPath}, falling back to stderr`,
+                )
+                this.outputStream = process.stderr
+            }
+        } else {
+            this.outputStream = process.stderr
+        }
+    }
+
+    isEnabled(): boolean {
+        return this.enabled
+    }
+
+    emit(event: Omit<ProgressEvent, 'timestamp'>): void {
+        if (!this.enabled || !this.outputStream) {
+            return
+        }
+
+        const progressEvent: ProgressEvent = {
+            ...event,
+            timestamp: new Date().toISOString(),
+        }
+
+        const line = `${JSON.stringify(progressEvent)}\n`
+        this.outputStream.write(line)
+    }
+
+    emitStart(command: string): void {
+        this.emit({ type: 'start', command })
+    }
+
+    emitApiCall(endpoint: string, cursor?: string | null): void {
+        this.emit({ type: 'api_call', endpoint, cursor })
+    }
+
+    emitApiResponse(count: number, hasMore: boolean, nextCursor?: string | null): void {
+        this.emit({
+            type: 'api_response',
+            count,
+            has_more: hasMore,
+            next_cursor: nextCursor,
+        })
+    }
+
+    emitComplete(): void {
+        this.emit({ type: 'complete' })
+    }
+
+    emitError(errorCode?: string, message?: string): void {
+        this.emit({ type: 'error', error_code: errorCode, message })
+    }
+
+    close(): void {
+        if (this.outputStream && this.outputStream !== process.stderr) {
+            ;(this.outputStream as fs.WriteStream).close()
+        }
+        this.enabled = false
+        this.outputStream = null
+    }
+}
+
+// Global singleton instance
+let progressTracker: ProgressTracker | null = null
+
+export function getProgressTracker(): ProgressTracker {
+    if (!progressTracker) {
+        progressTracker = new ProgressTracker()
+    }
+    return progressTracker
+}
+
+export function resetProgressTracker(): void {
+    if (progressTracker) {
+        progressTracker.close()
+    }
+    progressTracker = null
+}

--- a/src/lib/spinner.ts
+++ b/src/lib/spinner.ts
@@ -57,13 +57,16 @@ class LoadingSpinner {
             return true
         }
 
-        // Check process arguments for JSON output flags and --no-spinner
+        // Check process arguments for flags that should disable spinner
         const args = process.argv
-        if (args.includes('--json') || args.includes('--ndjson') || args.includes('--no-spinner')) {
-            return true
-        }
+        const spinnerDisablingFlags = ['--json', '--ndjson', '--no-spinner', '--progress-jsonl']
 
-        return false
+        // Check for both exact matches and prefix matches (to handle --flag=value variants)
+        return spinnerDisablingFlags.some(
+            (flag) =>
+                args.includes(flag) || // exact match
+                args.some((arg) => arg.startsWith(`${flag}=`)), // prefix match with equals
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Implements the `--progress-jsonl` feature requested in #29, adding machine-readable progress reporting to help tools distinguish between empty results, errors, and in-progress operations.

### Key Features

- **Global flag**: `--progress-jsonl [path]` with flexible output (stderr or file)
- **API tracking**: Comprehensive API call/response tracking with pagination metadata  
- **Error reporting**: Automatic error event emission for failed operations
- **Spinner integration**: Automatically disables spinner when progress tracking is enabled
- **Non-invasive**: Zero changes required to existing commands - leverages API proxy pattern

### Implementation Details

- **Core system**: New `ProgressTracker` class with singleton pattern and flexible output destinations
- **API integration**: Enhanced existing proxy in `lib/api/core.ts` to emit progress events
- **Event types**: `start`, `api_call`, `api_response`, `complete`, `error` with full metadata
- **Output format**: Proper JSONL with ISO timestamps and comprehensive event data

### Example Output

```jsonl
{"type":"api_call","endpoint":"getTasks","cursor":null,"timestamp":"2026-01-29T16:53:32.210Z"}
{"type":"api_response","count":200,"has_more":true,"next_cursor":"qjY5MzYxODYyNjA.EgWG4ZUzM2bZYk5w","timestamp":"2026-01-29T16:53:33.749Z"}
{"type":"api_call","endpoint":"getTasks","cursor":"qjY5MzYxODYyNjA.EgWG4ZUzM2bZYk5w","timestamp":"2026-01-29T16:53:33.754Z"}
{"type":"api_response","count":63,"has_more":false,"next_cursor":null,"timestamp":"2026-01-29T16:53:34.571Z"}
```

## Manual Testing Commands

```bash
# Basic stderr output
node dist/index.js today --progress-jsonl

# File output  
node dist/index.js today --progress-jsonl=/tmp/progress.jsonl

# Compatibility with JSON output
node dist/index.js today --json --progress-jsonl
```

**Closes #29**

🤖 Generated with [Claude Code](https://claude.com/claude-code)