### PR TITLE
chore(docs): Removed note about package not being published to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ A command-line interface for Todoist.
 
 ## Installation
 
-> **Note**: This package is not yet published to npm. Once published, install with:
->
 > ```bash
 > npm install -g @doist/todoist-cli
 > ```


### PR DESCRIPTION
Just removing the note in the README that says this isn't published on npm.
https://www.npmjs.com/package/@doist/todoist-cli