### PR TITLE
fix: use server-side filtering for today command

### DIFF
--- a/src/__tests__/today.test.ts
+++ b/src/__tests__/today.test.ts
@@ -23,6 +23,7 @@ const mockFetchWorkspaces = vi.mocked(fetchWorkspaces)
 function createMockApi() {
     return {
         getTasks: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
+        getTasksByFilter: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
         getProjects: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
     }
 }
@@ -63,7 +64,7 @@ describe('today command', () => {
     it('shows overdue tasks in Overdue section', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
@@ -88,7 +89,7 @@ describe('today command', () => {
     it('shows tasks due today in Today section', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
@@ -113,7 +114,7 @@ describe('today command', () => {
     it('includes tasks with specific times in today section', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
@@ -145,7 +146,7 @@ describe('today command', () => {
     it('shows "No tasks due today" when empty', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({ results: [], nextCursor: null })
+        mockApi.getTasksByFilter.mockResolvedValue({ results: [], nextCursor: null })
         mockApi.getProjects.mockResolvedValue({ results: [], nextCursor: null })
 
         await program.parseAsync(['node', 'td', 'today'])
@@ -156,7 +157,7 @@ describe('today command', () => {
     it('excludes tasks with future due dates', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
@@ -177,7 +178,7 @@ describe('today command', () => {
     it('outputs JSON with --json flag', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
@@ -200,7 +201,7 @@ describe('today command', () => {
     it('outputs NDJSON with --ndjson flag', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
@@ -228,7 +229,7 @@ describe('today command', () => {
     it('includes project names in output', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
@@ -252,7 +253,7 @@ describe('today command', () => {
     it('filters by --personal to show only personal project tasks', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
@@ -286,7 +287,7 @@ describe('today command', () => {
     it('filters by --workspace to show only workspace tasks', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
@@ -323,7 +324,7 @@ describe('today command', () => {
     it('throws error when both --workspace and --personal specified', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({ results: [], nextCursor: null })
+        mockApi.getTasksByFilter.mockResolvedValue({ results: [], nextCursor: null })
 
         await expect(
             program.parseAsync(['node', 'td', 'today', '--workspace', 'Acme', '--personal']),

--- a/src/commands/today.ts
+++ b/src/commands/today.ts
@@ -51,7 +51,12 @@ export function registerTodayCommand(program: Command): void {
                   : LIMITS.tasks
 
             const { results: tasks, nextCursor } = await paginate(
-                (cursor, limit) => api.getTasks({ cursor: cursor ?? undefined, limit }),
+                (cursor, limit) =>
+                    api.getTasksByFilter({
+                        query: 'today | overdue',
+                        cursor: cursor ?? undefined,
+                        limit,
+                    }),
                 { limit: targetLimit, startCursor: options.cursor },
             )
 


### PR DESCRIPTION
The 'today' command fetches the first 300 tasks by default, via getTasks(), then filters client-side for today's tasks. For accounts with 500+ tasks, relevant tasks may be scattered beyond position 300 and don't appear in the output.

Use getTasksByFilter() with 'today | overdue' query instead. This ensures only relevant tasks are fetched regardless of total task count, and is more efficient.

## Testing
- All 11 today command tests pass
- Live test returns all 14 tasks due today (previously would show 0 or very few)
- No changes to existing behavior or API