### PR TITLE
fix: use server-side filtering for upcoming command and fix date formatting

### DIFF
--- a/src/__tests__/upcoming.test.ts
+++ b/src/__tests__/upcoming.test.ts
@@ -15,6 +15,7 @@ const mockGetApi = vi.mocked(getApi)
 function createMockApi() {
     return {
         getTasks: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
+        getTasksByFilter: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
         getProjects: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
     }
 }
@@ -50,19 +51,13 @@ describe('upcoming command', () => {
     it('defaults to 7 days', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
                     content: 'Task in range',
                     projectId: 'proj-1',
                     due: { date: getDateOffset(3) },
-                },
-                {
-                    id: 'task-2',
-                    content: 'Task out of range',
-                    projectId: 'proj-1',
-                    due: { date: getDateOffset(10) },
                 },
             ],
             nextCursor: null,
@@ -81,19 +76,13 @@ describe('upcoming command', () => {
     it('accepts custom days argument', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
                     content: 'Task day 2',
                     projectId: 'proj-1',
                     due: { date: getDateOffset(2) },
-                },
-                {
-                    id: 'task-2',
-                    content: 'Task day 5',
-                    projectId: 'proj-1',
-                    due: { date: getDateOffset(5) },
                 },
             ],
             nextCursor: null,
@@ -112,7 +101,7 @@ describe('upcoming command', () => {
     it('always includes overdue tasks', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
@@ -137,7 +126,7 @@ describe('upcoming command', () => {
     it('shows Today header for today tasks', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
@@ -161,7 +150,7 @@ describe('upcoming command', () => {
     it('shows Tomorrow header for tomorrow tasks', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
@@ -185,7 +174,7 @@ describe('upcoming command', () => {
     it('shows empty message when no tasks', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({ results: [], nextCursor: null })
+        mockApi.getTasksByFilter.mockResolvedValue({ results: [], nextCursor: null })
         mockApi.getProjects.mockResolvedValue({ results: [], nextCursor: null })
 
         await program.parseAsync(['node', 'td', 'upcoming'])
@@ -196,7 +185,7 @@ describe('upcoming command', () => {
     it('shows singular "day" for 1 day', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({ results: [], nextCursor: null })
+        mockApi.getTasksByFilter.mockResolvedValue({ results: [], nextCursor: null })
         mockApi.getProjects.mockResolvedValue({ results: [], nextCursor: null })
 
         await program.parseAsync(['node', 'td', 'upcoming', '1'])
@@ -207,7 +196,7 @@ describe('upcoming command', () => {
     it('outputs JSON with --json flag', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
@@ -230,7 +219,7 @@ describe('upcoming command', () => {
     it('outputs NDJSON with --ndjson flag', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
@@ -258,7 +247,7 @@ describe('upcoming command', () => {
     it('groups tasks by date with counts', async () => {
         const program = createProgram()
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',

--- a/src/commands/upcoming.ts
+++ b/src/commands/upcoming.ts
@@ -55,13 +55,17 @@ export function registerUpcomingCommand(program: Command): void {
                   ? parseInt(options.limit, 10)
                   : LIMITS.tasks
 
+            const today = getLocalDate(0)
+
             const { results: tasks, nextCursor } = await paginate(
-                (cursor, limit) => api.getTasks({ cursor: cursor ?? undefined, limit }),
+                (cursor, limit) =>
+                    api.getTasksByFilter({
+                        query: `due before: ${days} days`,
+                        cursor: cursor ?? undefined,
+                        limit,
+                    }),
                 { limit: targetLimit, startCursor: options.cursor },
             )
-
-            const today = getLocalDate(0)
-            const endDate = getLocalDate(days)
 
             let filteredTasks = tasks
             if (!options.anyAssignee) {
@@ -79,9 +83,7 @@ export function registerUpcomingCommand(program: Command): void {
             )
             filteredTasks = filterResult.tasks
 
-            const relevantTasks = filteredTasks.filter(
-                (t) => t.due && isDueBefore(t.due.date, endDate),
-            )
+            const relevantTasks = filteredTasks
 
             if (options.json) {
                 console.log(

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -36,7 +36,9 @@ export function formatDateHeader(dateStr: string, today: string): string {
     if (isDueOnDate(dateStr, today)) return 'Today'
     const tomorrow = getLocalDate(1)
     if (isDueOnDate(dateStr, tomorrow)) return 'Tomorrow'
-    const [year, month, day] = dateStr.split('-').map(Number)
+    // Extract just the date part (YYYY-MM-DD) in case dateStr contains a time
+    const dateOnly = dateStr.split('T')[0]
+    const [year, month, day] = dateOnly.split('-').map(Number)
     return new Date(year, month - 1, day).toLocaleDateString('en-US', {
         month: 'short',
         day: 'numeric',

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -34,7 +34,9 @@ export function formatPriority(priority: number): string {
 }
 
 export function formatDueDate(dateStr: string): string {
-    const date = new Date(`${dateStr}T00:00:00`)
+    // Extract just the date part (YYYY-MM-DD) in case dateStr contains a time
+    const dateOnly = dateStr.split('T')[0]
+    const date = new Date(`${dateOnly}T00:00:00`)
     return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }
 


### PR DESCRIPTION
Use server-side filtering via getTasksByFilter() with 'due before: {days} days' query instead of client-side filtering with getTasks(). This ensures all relevant tasks are fetched regardless of total task count.

## Changes
- Modified src/commands/upcoming.ts to use server-side filtering
- Removed redundant client-side date filtering (isDueBefore had identical semantics as server filter)
- Fixed date formatting in formatDueDate() and formatDateHeader() to handle recurring tasks with specific times
- Updated all 11 tests to mock getTasksByFilter

## Problem Fixed
- Accounts with 500+ tasks weren't seeing all upcoming tasks due to pagination limit applied before filtering
- Recurring tasks with specific times (e.g. 'every day at 7am') displayed as 'Invalid Date'

## Testing
- All 11 upcoming command tests pass
- Live test shows proper date headers (no more 'Invalid Date')
- More efficient: fewer API calls and less data transferred