### PR TITLE
feat: expose workspaceId in project JSON output

### DIFF
--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -183,6 +183,7 @@ const PROJECT_ESSENTIAL_FIELDS = [
     'parentId',
     'viewStyle',
     'url',
+    'workspaceId',
 ] as const
 const LABEL_ESSENTIAL_FIELDS = ['id', 'name', 'color', 'isFavorite'] as const
 const SECTION_ESSENTIAL_FIELDS = ['id', 'name', 'projectId', 'sectionOrder', 'url'] as const


### PR DESCRIPTION
Add workspaceId to PROJECT_ESSENTIAL_FIELDS so that workspace projects include their workspace ID in JSON/NDJSON output. Personal projects won't have this field, matching the implementation from todoist-ai PR #262.

This allows scripts and agents to determine which workspace a project belongs to when using JSON output format.