### PR TITLE
fix: use server-side filtering for task list commands

### DIFF
--- a/src/__tests__/inbox.test.ts
+++ b/src/__tests__/inbox.test.ts
@@ -15,6 +15,7 @@ function createMockApi() {
     return {
         getUser: vi.fn(),
         getTasks: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
+        getTasksByFilter: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
         getProject: vi.fn(),
         getProjects: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
         getSections: vi.fn().mockResolvedValue({ results: [] }),
@@ -104,11 +105,8 @@ describe('inbox command', () => {
             inboxProjectId: 'inbox-proj',
         })
         mockApi.getProject.mockResolvedValue({ id: 'inbox-proj', name: 'Inbox' })
-        mockApi.getTasks.mockResolvedValue({
-            results: [
-                { id: 'task-1', content: 'High', priority: 4, projectId: 'inbox-proj' },
-                { id: 'task-2', content: 'Low', priority: 1, projectId: 'inbox-proj' },
-            ],
+        mockApi.getTasksByFilter.mockResolvedValue({
+            results: [{ id: 'task-1', content: 'High', priority: 4, projectId: 'inbox-proj' }],
             nextCursor: null,
         })
 
@@ -116,5 +114,10 @@ describe('inbox command', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('High'))
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Low'))
+        expect(mockApi.getTasksByFilter).toHaveBeenCalledWith(
+            expect.objectContaining({
+                query: 'p1',
+            }),
+        )
     })
 })

--- a/src/__tests__/task-list.test.ts
+++ b/src/__tests__/task-list.test.ts
@@ -55,6 +55,7 @@ describe('listTasksForProject', () => {
     function createTestMockApi() {
         return {
             getTasks: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
+            getTasksByFilter: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
             getProject: vi.fn(),
             getSections: vi.fn().mockResolvedValue({ results: [] }),
             getProjects: vi.fn().mockResolvedValue({ results: [] }),
@@ -112,20 +113,19 @@ describe('listTasksForProject', () => {
                 priority: 4,
                 projectId: 'proj-1',
             },
-            {
-                id: 'task-2',
-                content: 'Low priority',
-                priority: 1,
-                projectId: 'proj-1',
-            },
         ]
-        mockApi.getTasks.mockResolvedValue({ results: tasks, nextCursor: null })
+        mockApi.getTasksByFilter.mockResolvedValue({ results: tasks, nextCursor: null })
         mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Work' })
 
         await listTasksForProject('proj-1', { priority: 'p1' })
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('High priority'))
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Low priority'))
+        expect(mockApi.getTasksByFilter).toHaveBeenCalledWith(
+            expect.objectContaining({
+                query: 'p1',
+            }),
+        )
     })
 
     it('outputs JSON when --json flag', async () => {

--- a/src/__tests__/task.test.ts
+++ b/src/__tests__/task.test.ts
@@ -1076,18 +1076,12 @@ describe('task list --label', () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
                     content: 'Work task',
                     labels: ['work'],
-                    projectId: 'proj-1',
-                },
-                {
-                    id: 'task-2',
-                    content: 'Home task',
-                    labels: ['home'],
                     projectId: 'proj-1',
                 },
                 {
@@ -1107,6 +1101,11 @@ describe('task list --label', () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Work task'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Both'))
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Home task'))
+        expect(mockApi.getTasksByFilter).toHaveBeenCalledWith(
+            expect.objectContaining({
+                query: '@work',
+            }),
+        )
         consoleSpy.mockRestore()
     })
 
@@ -1114,18 +1113,12 @@ describe('task list --label', () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
                     content: 'Work task',
                     labels: ['work'],
-                    projectId: 'proj-1',
-                },
-                {
-                    id: 'task-2',
-                    content: 'Home task',
-                    labels: ['home'],
                     projectId: 'proj-1',
                 },
                 {
@@ -1145,6 +1138,11 @@ describe('task list --label', () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Work task'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Urgent task'))
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Home task'))
+        expect(mockApi.getTasksByFilter).toHaveBeenCalledWith(
+            expect.objectContaining({
+                query: '(@work | @urgent)',
+            }),
+        )
         consoleSpy.mockRestore()
     })
 
@@ -1152,7 +1150,7 @@ describe('task list --label', () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-        mockApi.getTasks.mockResolvedValue({
+        mockApi.getTasksByFilter.mockResolvedValue({
             results: [
                 {
                     id: 'task-1',
@@ -1169,6 +1167,11 @@ describe('task list --label', () => {
         await program.parseAsync(['node', 'td', 'task', 'list', '--label', 'WORK'])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Work task'))
+        expect(mockApi.getTasksByFilter).toHaveBeenCalledWith(
+            expect.objectContaining({
+                query: '@WORK',
+            }),
+        )
         consoleSpy.mockRestore()
     })
 })
@@ -1662,13 +1665,6 @@ describe('task list --filter', () => {
                     priority: 4,
                     labels: [],
                 },
-                {
-                    id: 'task-2',
-                    content: 'Low priority',
-                    projectId: 'proj-1',
-                    priority: 1,
-                    labels: [],
-                },
             ],
             nextCursor: null,
         })
@@ -1690,6 +1686,11 @@ describe('task list --filter', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('High priority'))
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Low priority'))
+        expect(mockApi.getTasksByFilter).toHaveBeenCalledWith(
+            expect.objectContaining({
+                query: '(@work) & (p1)',
+            }),
+        )
         consoleSpy.mockRestore()
     })
 })


### PR DESCRIPTION
Fixes `td task list` to use server-side filtering instead of fetching 300 tasks and filtering client-side. This ensures tasks beyond the first 300 are returned when using filters, and significantly improves performance.

Server-side filters implemented:
- `--label`: Uses @label or (@label1 | @label2) for multiple labels
- `--priority`: Uses p1, p2, p3, p4 syntax
- `--due`: Uses today, overdue, or date expressions
- `--assignee me`: Uses "assigned to: me"
- `--assignee <email/name>`: Uses "assigned to: <email/name>"
- `--unassigned`: Uses !assigned
- `--workspace <name>`: Uses "workspace: <name>"
- `--personal`: Uses "workspace: personal"

Remaining client-side filters:
- `--assignee id:xxx`: Requires collaborator lookup, filtered client-side
- `--parent`: Can't be combined with filter queries

Optimizations:
- Only fetches all projects when listing across all projects
- For project-specific listings, only fetches the target project
- Avoids expensive getProjects() call when filtering by a single project

Multiple filters are combined with & (AND) operator. Combines --filter with built filters when both are provided.