### PR TITLE
fix: add loading spinner to settings view

### DIFF
--- a/src/__tests__/settings.test.ts
+++ b/src/__tests__/settings.test.ts
@@ -14,6 +14,10 @@ vi.mock('../lib/api/filters.js', () => ({
     fetchFilters: vi.fn(),
 }))
 
+vi.mock('../lib/spinner.js', () => ({
+    withSpinner: vi.fn((_opts: unknown, fn: () => Promise<unknown>) => fn()),
+}))
+
 import { registerSettingsCommand } from '../commands/settings.js'
 import { getApi } from '../lib/api/core.js'
 import { fetchFilters } from '../lib/api/filters.js'

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -8,6 +8,7 @@ import {
     updateUserSettings,
 } from '../lib/api/user-settings.js'
 import { formatError } from '../lib/output.js'
+import { withSpinner } from '../lib/spinner.js'
 
 const DAY_NAMES: Record<number, string> = {
     1: 'Monday',
@@ -170,8 +171,14 @@ function formatSettingsForJson(
 }
 
 async function viewSettings(options: ViewOptions): Promise<void> {
-    const settings = await fetchUserSettings()
-    const startPageName = await resolveStartPageName(settings.startPage)
+    const { settings, startPageName } = await withSpinner(
+        { text: 'Loading settings...', color: 'blue' },
+        async () => {
+            const settings = await fetchUserSettings()
+            const startPageName = await resolveStartPageName(settings.startPage)
+            return { settings, startPageName }
+        },
+    )
 
     if (options.json) {
         console.log(JSON.stringify(formatSettingsForJson(settings, startPageName), null, 2))


### PR DESCRIPTION
## Summary
- Wrap `fetchUserSettings()` and `resolveStartPageName()` in `withSpinner()` so users see a "Loading settings..." spinner while data is fetched
- Previously the CLI appeared frozen during the settings fetch since it bypassed the spinner-wrapped API proxy

## Test plan
- [x] All 668 tests pass (`npm test`)
- [x] Type-check passes (`npm run type-check`)
- [ ] Manual: `node dist/index.js settings view` shows spinner while loading
- [ ] Manual: `node dist/index.js settings view --json` outputs JSON without spinner artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)