### PR TITLE
fix: normalize dates to UTC midnight for timezone-independent comparisons

### DIFF
--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,4 +1,4 @@
-import { format, isBefore, isEqual, parseISO } from 'date-fns'
+import { isBefore, isEqual, parseISO } from 'date-fns'
 
 export function getLocalDate(daysOffset = 0): string {
     const date = new Date()
@@ -11,24 +11,22 @@ export function getLocalDate(daysOffset = 0): string {
  * and return a Date object set to start of day for date comparison
  */
 export function parseDueDateToDay(dateStr: string): Date {
-    // Parse the date string (handles both YYYY-MM-DD and YYYY-MM-DDTHH:mm:ss formats)
     const parsed = parseISO(dateStr)
-    // Return start of day to compare only dates, not times
-    return parseISO(format(parsed, 'yyyy-MM-dd'))
+    return new Date(Date.UTC(parsed.getFullYear(), parsed.getMonth(), parsed.getDate()))
 }
 
 /**
  * Check if a due date is on a specific day
  */
 export function isDueOnDate(dueDate: string, targetDate: string): boolean {
-    return isEqual(parseDueDateToDay(dueDate), parseISO(targetDate))
+    return isEqual(parseDueDateToDay(dueDate), parseDueDateToDay(targetDate))
 }
 
 /**
  * Check if a due date is before a specific day
  */
 export function isDueBefore(dueDate: string, targetDate: string): boolean {
-    return isBefore(parseDueDateToDay(dueDate), parseISO(targetDate))
+    return isBefore(parseDueDateToDay(dueDate), parseDueDateToDay(targetDate))
 }
 
 export function formatDateHeader(dateStr: string, today: string): string {


### PR DESCRIPTION
## Summary

- `parseDueDateToDay` was returning dates at local midnight instead of UTC midnight. This caused 4 unit tests to fail because `.toISOString()` exposed the timezone offset (e.g. `2026-01-29T03:00:00.000Z` instead of `2026-01-29T00:00:00.000Z`).
- The runtime behavior was never affected: `isDueOnDate` and `isDueBefore` compared local midnight vs local midnight (via `parseISO`), so the offsets cancelled out and comparisons were always correct. The entire flow (today, upcoming) worked correctly — just by accident.
- The bug was introduced in https://github.com/Doist/todoist-cli/pull/30, authored from UTC+0. At UTC+0, local midnight _is_ UTC midnight, so `.toISOString()` returns `T00:00:00` and the tests pass. At UTC-3 (or any negative offset), local midnight shifts forward in UTC, causing the 4 test assertions to fail.
- The fix normalizes to UTC midnight using `Date.UTC()` and uses `parseDueDateToDay` on both sides of comparisons, making the correctness explicit and timezone-independent.

Manually verified `td today` and `td upcoming` produce correct output after the fix.

## Test plan

- [x] `npx vitest run src/__tests__/dates.test.ts` — all 41 tests pass (including the 4 previously failing)
- [x] Full test suite — all 668 tests pass (via pre-push hook)
- [x] `td today` — correctly shows overdue and today sections
- [x] `td upcoming 3` — correctly shows overdue, tomorrow, and future date headers