### PR TITLE
feat: auto-retry id-like task refs as direct ID lookups

### DIFF
--- a/src/lib/refs.ts
+++ b/src/lib/refs.ts
@@ -105,7 +105,13 @@ export async function resolveTaskRef(api: TodoistApi, ref: string): Promise<Task
             ),
         (t) => t.content,
         'task',
-    )
+    ).catch((err) => {
+        // If ref looks like a raw ID (numeric or alphanumeric mix), try as direct ID lookup
+        if (looksLikeRawId(ref)) {
+            return resolveTaskRef(api, `id:${ref}`)
+        }
+        throw err
+    })
 }
 
 export async function resolveProjectRef(api: TodoistApi, ref: string): Promise<Project> {


### PR DESCRIPTION
Fixes #46

- When `resolveTaskRef` fails to match a ref by name search and the ref looks like a raw Todoist ID (per `looksLikeRawId` from #49), automatically retry with `id:` prefix before erroring
- The `idPrefixHint` warnings from #49 no longer apply in this case. Since they still apply for other entity types, it has not been touched.

**Note**: Depends on #52 — this PR is built on top of server-side search/filtering improvements. While it could be made independent if is more easily merged after it. See ab3bdc21086f54dde7b081384a9f8231e00d3dbe for the changes specific to this PR.

## Test plan

- [x] Existing tests pass (675/675)
- [x] New test: alphanumeric ref auto-retries as direct ID lookup
- [x] New test: numeric ref auto-retries as direct ID lookup
- [x] New test: plain text ref does not auto-retry

