### PR TITLE
feat: positional content arg for `td task add`

### DIFF
--- a/src/__tests__/skill.test.ts
+++ b/src/__tests__/skill.test.ts
@@ -171,7 +171,7 @@ describe('installer paths', () => {
         expect(content).toContain('description: Manage Todoist tasks')
         expect(content).toContain('# Todoist CLI (td)')
         expect(content).toContain('td today')
-        expect(content).toContain('td add')
+        expect(content).toContain('td task add')
     })
 })
 

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -12,7 +12,7 @@ export function registerAddCommand(program: Command): void {
     const addCmd = program
         .command('add [text]')
         .description(
-            'Quick add task with natural language (e.g., "Buy milk tomorrow p1 #Shopping")',
+            'Quick add with natural language (human shorthand; agents should use "task add")',
         )
         .option('--assignee <ref>', 'Assign to user (name, email, id:xxx, or "me")')
         .action(async (text: string | undefined, options: AddOptions) => {

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -430,9 +430,9 @@ export function registerTaskCommand(program: Command): void {
         })
 
     const addCmd = task
-        .command('add')
-        .description('Add a task with explicit flags')
-        .option('--content <text>', 'Task content (required)')
+        .command('add [content]')
+        .description('Add a task')
+        .option('--content <text>', 'Task content (legacy, prefer positional argument)')
         .option('--due <date>', 'Due date (natural language or YYYY-MM-DD)')
         .option('--deadline <date>', 'Deadline date (YYYY-MM-DD)')
         .option('--priority <p1-p4>', 'Priority level')
@@ -443,12 +443,16 @@ export function registerTaskCommand(program: Command): void {
         .option('--description <text>', 'Task description')
         .option('--assignee <ref>', 'Assign to user (name, email, id:xxx, or "me")')
         .option('--duration <time>', 'Duration (e.g., 30m, 1h, 2h15m)')
-        .action((options) => {
-            if (!options.content) {
+        .action((contentArg: string | undefined, options: AddOptions & { content?: string }) => {
+            if (contentArg && options.content) {
+                throw new Error('Cannot specify content both as argument and --content flag')
+            }
+            const content = contentArg || options.content
+            if (!content) {
                 addCmd.help()
                 return
             }
-            return addTask(options)
+            return addTask({ ...options, content })
         })
 
     const updateCmd = task

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ program
         'after',
         `
 Note for AI/LLM agents:
+  Use "td task add" (not "td add") to create tasks with structured flags.
   Use --json or --ndjson flags for unambiguous, parseable output.
   Default JSON shows essential fields; use --full for all fields.`,
     )

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -12,7 +12,7 @@ Use this skill when the user wants to interact with their Todoist tasks.
 - \`td inbox\` - Inbox tasks
 - \`td upcoming\` - Tasks due in next N days
 - \`td completed\` - Recently completed tasks
-- \`td add "task text"\` - Quick add with natural language
+- \`td task add "content"\` - Add a task
 - \`td task list\` - List tasks with filters
 - \`td task complete <ref>\` - Complete a task
 - \`td project list\` - List projects
@@ -60,12 +60,6 @@ Tasks can be referenced by:
 - p4 = Lowest priority (API value 1, default)
 
 ## Commands
-
-### Quick Add
-\`\`\`bash
-td add "Buy milk tomorrow p1 #Shopping"
-td add "Meeting with John at 3pm" --assignee "john@example.com"
-\`\`\`
 
 ### Today
 \`\`\`bash
@@ -120,12 +114,12 @@ td task complete id:123456
 td task complete "task name" --forever  # Stop recurrence
 td task uncomplete id:123456            # Reopen completed task
 
-# Add with explicit flags
-td task add --content "New task" --due "tomorrow" --priority p2
-td task add --content "Task" --deadline "2024-03-01" --project "Work"
-td task add --content "Task" --duration 1h --section id:456
-td task add --content "Task" --labels "urgent,review" --parent "Parent task"
-td task add --content "Task" --description "Details here" --assignee me
+# Add tasks
+td task add "New task" --due "tomorrow" --priority p2
+td task add "Task" --deadline "2024-03-01" --project "Work"
+td task add "Task" --duration 1h --section id:456
+td task add "Task" --labels "urgent,review" --parent "Parent task"
+td task add "Task" --description "Details here" --assignee me
 
 # Update
 td task update "task name" --due "next week"


### PR DESCRIPTION
## Overview

An AI agent reported confusion when trying to add tasks via the CLI. It took several iterations to get the invocation right. The root issues: `td add` looked like the simpler entry point but doesn't accept structured flags, and `td task add --content "..."` is unnecessarily verbose for the most common operation. This PR makes content a positional arg (`td task add "Buy milk" --due tomorrow`), steers agents away from `td add` in both the skill content and `--help` output, and keeps `--content` for backward compatibility.

## Summary

- `td task add "Buy milk" --due tomorrow` now works (content as positional arg)
- `--content` flag preserved for backward compatibility
- Clear error when both positional and `--content` are specified
- Removed `td add` from skill content to steer agents toward `td task add`
- Updated `td add` description and agent note in `--help` to clarify the distinction

## Test plan

- [x] Verify `td task add "text" --due tomorrow` works end-to-end
- [x] Verify `td task add --content "text"` still works
- [x] Verify `td task add "x" --content "y"` errors clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)