### PR TITLE
chore: Ensures CI checks done on *all* PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,7 @@
 name: Lint
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,7 @@
 name: Tests
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
Currently linting and tests are done when: 
- a commit happens on `main`
- A PR with `main` as its base is opened

Neither of these are really right.

- We don't need to run the test/linting on main separately because you can only commit to main via PR, and the CI checks are done on PRs
- A PR whose base is not main would not have the checks done, they should be.