### PR TITLE
📦 Add AUR packaging for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ A command-line interface for Todoist.
 > npm install -g @doist/todoist-cli
 > ```
 
+### Arch Linux (AUR)
+
+```bash
+yay -S todoist-cli-bin
+# or
+paru -S todoist-cli-bin
+```
+
 ### Local Setup (for now)
 
 ```bash

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,0 +1,28 @@
+# Maintainer: Your Name <your.email@example.com>
+pkgname=todoist-cli-bin
+pkgver=1.13.0
+pkgrel=1
+pkgdesc='Command-line interface for Todoist'
+arch=('any')
+url='https://github.com/Doist/todoist-cli'
+license=('MIT')
+depends=('nodejs>=20')
+provides=('todoist-cli')
+conflicts=('todoist-cli')
+source=("https://registry.npmjs.org/@doist/todoist-cli/-/todoist-cli-${pkgver}.tgz")
+sha256sums=('2b7864c3170d8515be1411e23ef995054805c58cd30a42b08299a3cc895e0b56')
+noextract=("todoist-cli-${pkgver}.tgz")
+
+package() {
+    npm install -g \
+        --prefix "${pkgdir}/usr" \
+        --cache "${srcdir}/npm-cache" \
+        "${srcdir}/todoist-cli-${pkgver}.tgz"
+
+    # Fix permissions
+    chmod -R go-w "${pkgdir}/usr"
+
+    # Non-deterministic files
+    find "${pkgdir}" -name 'package.json' -exec sed -i '/_where/d' {} +
+    find "${pkgdir}" -name '.package-lock.json' -delete
+}


### PR DESCRIPTION

Hey there! Not sure if this is the right place to ask, so feel free to close but would be awesome if you could publish the package to AUR.

This PR should add a PKGBUILD (`aur/PKGBUILD`) that installs `td` directly from the npm registry tarball.

This PR only adds the PKGBUILD to the repo (doesn't publish the package). You'd need to create an account on the AUR and submit the package there.