### PR TITLE
feat(activity): add markdown output mode for activity logs

### DIFF
--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -224,6 +224,7 @@ td activity --since 2024-01-01 --until 2024-01-31
 td activity --type task --event completed
 td activity --project "Work"
 td activity --by me
+td activity --markdown                        # LLM-friendly Markdown output
 \`\`\`
 
 ### Notifications


### PR DESCRIPTION
## Summary
- add `--markdown` output mode to `td activity`
- keep existing default text output and `--json` / `--ndjson` behavior unchanged
- enforce output-format exclusivity across `--markdown`, `--json`, and `--ndjson`
- add tests for markdown output and conflicting-format validation
- update skill docs with a `td activity --markdown` example

## Why now

We want a simple LLM-friendly export path immediately, without changing the existing human-scannable terminal output.

## Limitations vs Todoist Web

This CLI implementation intentionally ships a simpler format for now. Compared to the Todoist Web markdown export:

- uses a simpler event/object/content line format instead of the richer sentence-template formatter
- uses YYYY-MM-DD day headers instead of localized/relative day labels
- does not yet mirror all of web's text-normalization nuances

These are known and acceptable for this iteration. We plan to iterate and bring CLI output closer to the web export format in an upcoming follow-up.

## Follow-ups

- hard-cap `--all` to avoid unbounded fetch/memory behavior: #84

## Validation

- `npm test -- src/__tests__/activity.test.ts`
- pre-push hook test suite passed during push
