### PR TITLE
feat: add --accessible flag for screen reader and color-blind users

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ td task view https://app.todoist.com/app/task/buy-milk-8Jx4mVr72kPn3QwB  # paste
 
 Run `td --help` or `td <command> --help` for more options.
 
+## Accessibility
+
+For users who rely on screen readers or cannot distinguish colors, use the `--accessible` flag or set `TD_ACCESSIBLE=1` to add text labels to color-coded output:
+
+```bash
+td today --accessible
+# or
+export TD_ACCESSIBLE=1
+td today
+```
+
+When active, due dates get a `due:` prefix, deadlines get a `deadline:` prefix, durations get a `~` prefix, and favorite items get a `★` suffix. Default output without the flag is unchanged.
+
 ## Shell Completions
 
 Tab completion is available for bash, zsh, and fish:

--- a/src/commands/filter.ts
+++ b/src/commands/filter.ts
@@ -17,6 +17,7 @@ import {
     formatPaginatedJson,
     formatPaginatedNdjson,
     formatTaskRow,
+    isAccessible,
 } from '../lib/output.js'
 import { LIMITS, paginate } from '../lib/pagination.js'
 import { isIdRef, lenientIdRef, looksLikeRawId, parseTodoistUrl } from '../lib/refs.js'
@@ -56,7 +57,9 @@ async function listFilters(options: PaginatedViewOptions): Promise<void> {
 
     for (const filter of filters) {
         const id = chalk.dim(`id:${filter.id}`)
-        const name = filter.isFavorite ? chalk.yellow(filter.name) : filter.name
+        const name = filter.isFavorite
+            ? chalk.yellow(`${filter.name}${isAccessible() ? ' ★' : ''}`)
+            : filter.name
         const query = chalk.dim(`"${filter.query}"`)
         console.log(`${id}  ${name}  ${query}`)
         if (options.showUrls) {

--- a/src/commands/label.ts
+++ b/src/commands/label.ts
@@ -11,6 +11,7 @@ import {
     formatPaginatedJson,
     formatPaginatedNdjson,
     formatTaskRow,
+    isAccessible,
 } from '../lib/output.js'
 import { LIMITS, paginate } from '../lib/pagination.js'
 import { isIdRef, lenientIdRef, looksLikeRawId, parseTodoistUrl } from '../lib/refs.js'
@@ -77,7 +78,9 @@ async function listLabels(options: PaginatedViewOptions): Promise<void> {
 
     for (const label of labels) {
         const id = chalk.dim(label.id)
-        const name = label.isFavorite ? chalk.yellow(`@${label.name}`) : `@${label.name}`
+        const name = label.isFavorite
+            ? chalk.yellow(`@${label.name}${isAccessible() ? ' ★' : ''}`)
+            : `@${label.name}`
         console.log(`${id}  ${name}`)
         if (options.showUrls) {
             console.log(`  ${chalk.dim(labelUrl(label.id))}`)

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -20,6 +20,7 @@ import {
     formatPaginatedJson,
     formatPaginatedNdjson,
     formatTaskRow,
+    isAccessible,
 } from '../lib/output.js'
 import { LIMITS, paginate } from '../lib/pagination.js'
 import { resolveFolderRef, resolveProjectRef, resolveWorkspaceRef } from '../lib/refs.js'
@@ -71,7 +72,9 @@ async function listProjects(options: ListOptions): Promise<void> {
         const personalOnly = projects.filter((p) => !isWorkspaceProject(p))
         for (const project of personalOnly) {
             const id = chalk.dim(project.id)
-            let name = project.isFavorite ? chalk.yellow(project.name) : project.name
+            let name = project.isFavorite
+                ? chalk.yellow(`${project.name}${isAccessible() ? ' ★' : ''}`)
+                : project.name
             if (project.isShared) {
                 name = `${name} ${chalk.dim('[shared]')}`
             }
@@ -109,7 +112,9 @@ async function listProjects(options: ListOptions): Promise<void> {
         }
         for (const project of personalProjects) {
             const id = chalk.dim(project.id)
-            let name = project.isFavorite ? chalk.yellow(project.name) : project.name
+            let name = project.isFavorite
+                ? chalk.yellow(`${project.name}${isAccessible() ? ' ★' : ''}`)
+                : project.name
             if (project.isShared) {
                 name = `${name} ${chalk.dim('[shared]')}`
             }
@@ -138,7 +143,9 @@ async function listProjects(options: ListOptions): Promise<void> {
         console.log(chalk.bold(workspaceName))
         for (const project of wprojects) {
             const id = chalk.dim(project.id)
-            const name = project.isFavorite ? chalk.yellow(project.name) : project.name
+            const name = project.isFavorite
+                ? chalk.yellow(`${project.name}${isAccessible() ? ' ★' : ''}`)
+                : project.name
             console.log(`  ${id}  ${name}`)
             if (options.showUrls) {
                 console.log(`    ${chalk.dim(projectUrl(project.id))}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ program
     .option('--no-spinner', 'Disable loading animations')
     .option('--progress-jsonl [path]', 'Output progress events as JSONL to stderr or file')
     .option('-v, --verbose', 'Increase output verbosity (repeat up to 4x: -v, -vv, -vvv, -vvvv)')
+    .option('--accessible', 'Add text labels to color-coded output (also: TD_ACCESSIBLE=1)')
     .addHelpText(
         'after',
         `

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -49,6 +49,7 @@ Most list commands also support:
 - \`--no-spinner\` - Disable loading animations
 - \`--progress-jsonl\` - Machine-readable progress events (JSONL to stderr)
 - \`-v, --verbose\` - Verbose output to stderr (repeat: -v info, -vv detail, -vvv debug, -vvvv trace)
+- \`--accessible\` - Add text labels to color-coded output (due:/deadline:/~ prefixes, ★ for favorites). Also: \`TD_ACCESSIBLE=1\`
 
 ## References
 


### PR DESCRIPTION
## Summary

- Adds `--accessible` global flag and `TD_ACCESSIBLE=1` env var that adds text labels to color-coded output, so all information is usable without color vision
- When active: due dates get `due:` prefix, deadlines get `deadline:` prefix, durations get `~` prefix, and favorites get `★` suffix
- Default output (without the flag) is unchanged

Closes #91

## Test plan

- [x] `npm test` — all 921 tests pass (7 new tests for accessible mode)
- [x] `npm run type-check` — clean
- [x] `npm run format` — clean
- [ ] `td today --accessible` — verify `due:` and `deadline:` prefixes appear
- [ ] `td today` (no flag) — verify output is unchanged
- [ ] `TD_ACCESSIBLE=1 td today` — verify env var works
- [ ] `td label list --accessible` with a favorited label — verify `★` appears
- [ ] `td project list --accessible` with a favorited project — verify `★` appears
- [ ] `NO_COLOR=1 td today --accessible` — verify readable without color

🤖 Generated with [Claude Code](https://claude.com/claude-code)