### PR TITLE
feat: add Gemini CLI skill

### DIFF
--- a/src/__tests__/skill.test.ts
+++ b/src/__tests__/skill.test.ts
@@ -43,6 +43,7 @@ describe('skill command', () => {
             expect(consoleSpy).toHaveBeenCalledWith('  claude-code')
             expect(consoleSpy).toHaveBeenCalledWith('  codex')
             expect(consoleSpy).toHaveBeenCalledWith('  cursor')
+            expect(consoleSpy).toHaveBeenCalledWith('  gemini')
         })
     })
 
@@ -144,6 +145,12 @@ describe('skills registry', () => {
         expect(installer?.name).toBe('cursor')
     })
 
+    it('returns gemini installer', () => {
+        const installer = getInstaller('gemini')
+        expect(installer).toBeDefined()
+        expect(installer?.name).toBe('gemini')
+    })
+
     it('returns undefined for unknown agent', () => {
         const installer = getInstaller('unknown')
         expect(installer).toBeUndefined()
@@ -154,6 +161,7 @@ describe('skills registry', () => {
         expect(agents).toContain('claude-code')
         expect(agents).toContain('codex')
         expect(agents).toContain('cursor')
+        expect(agents).toContain('gemini')
     })
 })
 
@@ -162,6 +170,7 @@ describe('installer paths', () => {
         { agent: 'claude-code', dir: '.claude', desc: 'Claude Code skill for Todoist CLI' },
         { agent: 'codex', dir: '.codex', desc: 'Codex skill for Todoist CLI' },
         { agent: 'cursor', dir: '.cursor', desc: 'Cursor skill for Todoist CLI' },
+        { agent: 'gemini', dir: '.gemini', desc: 'Gemini CLI skill for Todoist CLI' },
     ] as const
 
     for (const { agent, dir, desc } of cases) {

--- a/src/lib/skills/index.ts
+++ b/src/lib/skills/index.ts
@@ -17,6 +17,11 @@ export const skillInstallers: Record<string, SkillInstaller> = {
         description: 'Cursor skill for Todoist CLI',
         dirName: '.cursor',
     }),
+    gemini: createInstaller({
+        name: 'gemini',
+        description: 'Gemini CLI skill for Todoist CLI',
+        dirName: '.gemini',
+    }),
 }
 
 export function getInstaller(agent: string): SkillInstaller | undefined {


### PR DESCRIPTION
## Summary
- Adds Gemini CLI as a supported skill installer, matching the existing factory pattern
- Installs to `~/.gemini/skills/todoist-cli/SKILL.md` (global) or `.gemini/skills/todoist-cli/SKILL.md` (local)
- Adds corresponding test coverage for the new agent

Closes #94

## Test plan
- [x] All 926 existing + new tests pass (`npm test`)
- [x] Build compiles cleanly (`npm run build`)
- [x] Manual: `td skill list` shows `gemini` in output
- [x] Manual: `td skill install gemini` installs to correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)