### PR TITLE
Add local sync cache with warm benchmark script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,11 @@
     "": {
       "name": "@doist/todoist-cli",
       "version": "1.18.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@doist/todoist-api-typescript": "6.5.0",
+        "@libsql/client": "0.15.15",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
         "commander": "14.0.2",
@@ -678,6 +680,182 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@libsql/client": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.15.15.tgz",
+      "integrity": "sha512-twC0hQxPNHPKfeOv3sNT6u2pturQjLcI+CnpTM0SjRpocEGgfiZ7DWKXLNnsothjyJmDqEsBQJ5ztq9Wlu470w==",
+      "license": "MIT",
+      "dependencies": {
+        "@libsql/core": "^0.15.14",
+        "@libsql/hrana-client": "^0.7.0",
+        "js-base64": "^3.7.5",
+        "libsql": "^0.5.22",
+        "promise-limit": "^2.7.0"
+      }
+    },
+    "node_modules/@libsql/core": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.15.15.tgz",
+      "integrity": "sha512-C88Z6UKl+OyuKKPwz224riz02ih/zHYI3Ho/LAcVOgjsunIRZoBw7fjRfaH9oPMmSNeQfhGklSG2il1URoOIsA==",
+      "license": "MIT",
+      "dependencies": {
+        "js-base64": "^3.7.5"
+      }
+    },
+    "node_modules/@libsql/darwin-arm64": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.5.22.tgz",
+      "integrity": "sha512-4B8ZlX3nIDPndfct7GNe0nI3Yw6ibocEicWdC4fvQbSs/jdq/RC2oCsoJxJ4NzXkvktX70C1J4FcmmoBy069UA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/darwin-x64": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.5.22.tgz",
+      "integrity": "sha512-ny2HYWt6lFSIdNFzUFIJ04uiW6finXfMNJ7wypkAD8Pqdm6nAByO+Fdqu8t7sD0sqJGeUCiOg480icjyQ2/8VA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/hrana-client": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.7.0.tgz",
+      "integrity": "sha512-OF8fFQSkbL7vJY9rfuegK1R7sPgQ6kFMkDamiEccNUvieQ+3urzfDFI616oPl8V7T9zRmnTkSjMOImYCAVRVuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@libsql/isomorphic-fetch": "^0.3.1",
+        "@libsql/isomorphic-ws": "^0.1.5",
+        "js-base64": "^3.7.5",
+        "node-fetch": "^3.3.2"
+      }
+    },
+    "node_modules/@libsql/isomorphic-fetch": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.3.1.tgz",
+      "integrity": "sha512-6kK3SUK5Uu56zPq/Las620n5aS9xJq+jMBcNSOmjhNf/MUvdyji4vrMTqD7ptY7/4/CAVEAYDeotUz60LNQHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@libsql/isomorphic-ws": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-ws/-/isomorphic-ws-0.1.5.tgz",
+      "integrity": "sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ws": "^8.5.4",
+        "ws": "^8.13.0"
+      }
+    },
+    "node_modules/@libsql/linux-arm-gnueabihf": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.5.22.tgz",
+      "integrity": "sha512-3Uo3SoDPJe/zBnyZKosziRGtszXaEtv57raWrZIahtQDsjxBVjuzYQinCm9LRCJCUT5t2r5Z5nLDPJi2CwZVoA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm-musleabihf": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm-musleabihf/-/linux-arm-musleabihf-0.5.22.tgz",
+      "integrity": "sha512-LCsXh07jvSojTNJptT9CowOzwITznD+YFGGW+1XxUr7fS+7/ydUrpDfsMX7UqTqjm7xG17eq86VkWJgHJfvpNg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-gnu": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.5.22.tgz",
+      "integrity": "sha512-KSdnOMy88c9mpOFKUEzPskSaF3VLflfSUCBwas/pn1/sV3pEhtMF6H8VUCd2rsedwoukeeCSEONqX7LLnQwRMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-musl": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.5.22.tgz",
+      "integrity": "sha512-mCHSMAsDTLK5YH//lcV3eFEgiR23Ym0U9oEvgZA0667gqRZg/2px+7LshDvErEKv2XZ8ixzw3p1IrBzLQHGSsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-gnu": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.5.22.tgz",
+      "integrity": "sha512-kNBHaIkSg78Y4BqAdgjcR2mBilZXs4HYkAmi58J+4GRwDQZh5fIUWbnQvB9f95DkWUIGVeenqLRFY2pcTmlsew==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-musl": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.5.22.tgz",
+      "integrity": "sha512-UZ4Xdxm4pu3pQXjvfJiyCzZop/9j/eA2JjmhMaAhe3EVLH2g11Fy4fwyUp9sT1QJYR1kpc2JLuybPM0kuXv/Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/win32-x64-msvc": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.5.22.tgz",
+      "integrity": "sha512-Fj0j8RnBpo43tVZUVoNK6BV/9AtDUM5S7DF3LB4qTYg1LMSZqi3yeCneUTLJD6XomQJlZzbI4mst89yspVSAnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@neon-rs/load": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
+      "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
+      "license": "MIT"
+    },
     "node_modules/@pnpm/tabtab": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/@pnpm/tabtab/-/tabtab-0.5.4.tgz",
@@ -1124,10 +1302,18 @@
       "version": "25.0.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1487,6 +1673,15 @@
         "node": ">=20"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -1561,6 +1756,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -1755,6 +1959,29 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
@@ -1769,6 +1996,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fsevents": {
@@ -1979,6 +2218,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/js-base64": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/lefthook": {
       "version": "1.10.10",
       "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.10.10.tgz",
@@ -2142,6 +2387,38 @@
         "win32"
       ]
     },
+    "node_modules/libsql": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.5.22.tgz",
+      "integrity": "sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==",
+      "cpu": [
+        "x64",
+        "arm64",
+        "wasm32",
+        "arm"
+      ],
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "@neon-rs/load": "^0.0.4",
+        "detect-libc": "2.0.2"
+      },
+      "optionalDependencies": {
+        "@libsql/darwin-arm64": "0.5.22",
+        "@libsql/darwin-x64": "0.5.22",
+        "@libsql/linux-arm-gnueabihf": "0.5.22",
+        "@libsql/linux-arm-musleabihf": "0.5.22",
+        "@libsql/linux-arm64-gnu": "0.5.22",
+        "@libsql/linux-arm64-musl": "0.5.22",
+        "@libsql/linux-x64-gnu": "0.5.22",
+        "@libsql/linux-x64-musl": "0.5.22",
+        "@libsql/win32-x64-msvc": "0.5.22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2260,6 +2537,26 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
@@ -2273,6 +2570,24 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/object-assign": {
@@ -2419,6 +2734,12 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
+      "license": "ISC"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -2712,7 +3033,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {
@@ -2899,6 +3219,15 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2931,6 +3260,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/wsl-utils": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "dist"
   ],
   "dependencies": {
+    "@libsql/client": "0.15.15",
     "@doist/todoist-api-typescript": "6.5.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",

--- a/scripts/benchmark-sync-cache-warm.mjs
+++ b/scripts/benchmark-sync-cache-warm.mjs
@@ -1,0 +1,265 @@
+import { existsSync, writeFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { spawnSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(scriptDir, '..')
+
+const DB_PATH = process.env.TD_BENCH_DB_PATH ?? '/tmp/todoist-cli-read-bench-present.db'
+const runsEnv = Number.parseInt(process.env.TD_BENCH_RUNS ?? '5', 10)
+const RUNS = Number.isFinite(runsEnv) && runsEnv > 0 ? runsEnv : 5
+
+const OFF_ENV = {
+    TD_SYNC_DISABLE: '1',
+}
+
+const ON_ENV = {
+    TD_SYNC_DISABLE: '0',
+    TD_SYNC_DB_PATH: DB_PATH,
+    TD_SYNC_TTL_SECONDS: process.env.TD_SYNC_TTL_SECONDS ?? '3600',
+}
+
+function runTd(args, envOverrides) {
+    const start = process.hrtime.bigint()
+    const result = spawnSync('node', ['dist/index.js', ...args], {
+        cwd: repoRoot,
+        env: { ...process.env, ...envOverrides },
+        encoding: 'utf8',
+    })
+    const end = process.hrtime.bigint()
+    const elapsedMs = Number((end - start) / 1000000n)
+
+    if (result.status !== 0) {
+        throw new Error(
+            [
+                `td ${args.join(' ')} failed (status=${result.status})`,
+                `stdout:\n${(result.stdout || '').trim()}`,
+                `stderr:\n${(result.stderr || '').trim()}`,
+            ].join('\n'),
+        )
+    }
+
+    return { ms: elapsedMs, stdout: result.stdout }
+}
+
+function stats(values) {
+    const sorted = [...values].sort((a, b) => a - b)
+    const sum = values.reduce((acc, value) => acc + value, 0)
+    const avg = sum / values.length
+    const median =
+        sorted.length % 2 === 1
+            ? sorted[Math.floor(sorted.length / 2)]
+            : (sorted[sorted.length / 2 - 1] + sorted[sorted.length / 2]) / 2
+    return {
+        avg,
+        median,
+        min: sorted[0],
+        max: sorted[sorted.length - 1],
+    }
+}
+
+function fmtStats(label, values) {
+    const s = stats(values)
+    return `${label} avg=${s.avg.toFixed(1)} ms median=${s.median.toFixed(1)} ms min=${s.min} ms max=${s.max} ms`
+}
+
+function outputSignature(output) {
+    try {
+        const parsed = JSON.parse(output)
+        if (parsed && typeof parsed === 'object' && Array.isArray(parsed.results)) {
+            const ids = parsed.results
+                .map((item) => (item && typeof item === 'object' ? item.id : undefined))
+                .filter((id) => typeof id === 'string')
+            const sample = ids.slice(0, 10).join(',')
+            const nextCursor = parsed.nextCursor === null ? 'null' : String(parsed.nextCursor)
+            return `json results=${parsed.results.length} next=${nextCursor} ids10=${sample}${ids.length > 10 ? ',...' : ''}`
+        }
+
+        if (Array.isArray(parsed)) {
+            const ids = parsed
+                .map((item) => (item && typeof item === 'object' ? item.id : undefined))
+                .filter((id) => typeof id === 'string')
+            const sample = ids.slice(0, 10).join(',')
+            return `json-array count=${parsed.length} ids10=${sample}${ids.length > 10 ? ',...' : ''}`
+        }
+
+        if (parsed && typeof parsed === 'object') {
+            return `json-object keys=${Object.keys(parsed).sort().join(',')}`
+        }
+
+        return `json-scalar type=${typeof parsed}`
+    } catch {
+        const hash = createHash('sha256').update(output).digest('hex').slice(0, 16)
+        return `text bytes=${Buffer.byteLength(output, 'utf8')} sha256=${hash}`
+    }
+}
+
+function parseJsonOutput(output, commandLabel) {
+    try {
+        return JSON.parse(output)
+    } catch {
+        throw new Error(`Expected JSON output from ${commandLabel}`)
+    }
+}
+
+function firstIdFromResults(parsed, commandLabel) {
+    const results = parsed?.results
+    if (!Array.isArray(results) || results.length === 0) return null
+    const first = results[0]
+    if (!first || typeof first !== 'object' || typeof first.id !== 'string') {
+        throw new Error(`Unexpected JSON shape for ${commandLabel}`)
+    }
+    return first.id
+}
+
+function prewarmDbAndLoadRefs() {
+    console.log(`Using persistent warm DB: ${DB_PATH}`)
+
+    // Ensure current user id is cached for local today/upcoming assignee filtering.
+    runTd(['activity', '--by', 'me', '--json', '--limit', '1'], ON_ENV)
+
+    const taskListWarm = runTd(['task', 'list', '--json', '--limit', '50'], ON_ENV)
+    const workspaceListWarm = runTd(['workspace', 'list', '--json'], ON_ENV)
+    const projectListWarm = runTd(['project', 'list', '--json', '--limit', '50'], ON_ENV)
+
+    const taskId = firstIdFromResults(parseJsonOutput(taskListWarm.stdout, 'task list'), 'task list')
+    const projectId = firstIdFromResults(
+        parseJsonOutput(projectListWarm.stdout, 'project list'),
+        'project list',
+    )
+
+    const workspaceParsed = workspaceListWarm.stdout.trim()
+        ? parseJsonOutput(workspaceListWarm.stdout, 'workspace list')
+        : { results: [] }
+    const workspaceId = firstIdFromResults(workspaceParsed, 'workspace list')
+
+    return {
+        taskId,
+        projectId,
+        workspaceId,
+        dbExists: existsSync(DB_PATH),
+    }
+}
+
+function benchmarkCase({ title, args }) {
+    const beforeTimes = []
+    const afterTimes = []
+
+    let beforeOutput = ''
+    let afterOutput = ''
+
+    for (let i = 0; i < RUNS; i += 1) {
+        const run = runTd(args, OFF_ENV)
+        beforeTimes.push(run.ms)
+        if (i === 0) beforeOutput = run.stdout
+    }
+
+    for (let i = 0; i < RUNS; i += 1) {
+        const run = runTd(args, ON_ENV)
+        afterTimes.push(run.ms)
+        if (i === 0) afterOutput = run.stdout
+    }
+
+    const beforeAvg = stats(beforeTimes).avg
+    const afterAvg = stats(afterTimes).avg
+    const fasterByMs = beforeAvg - afterAvg
+    const speedupPct = beforeAvg === 0 ? 0 : (fasterByMs / beforeAvg) * 100
+
+    const beforeSig = outputSignature(beforeOutput)
+    const afterSig = outputSignature(afterOutput)
+
+    return {
+        title,
+        args,
+        beforeTimes,
+        afterTimes,
+        fasterByMs,
+        speedupPct,
+        beforeSig,
+        afterSig,
+        signatureMatch: beforeSig === afterSig,
+    }
+}
+
+function main() {
+    const refs = prewarmDbAndLoadRefs()
+
+    const cases = [
+        { title: 'today --json', args: ['today', '--json'] },
+        { title: 'upcoming --json', args: ['upcoming', '--json'] },
+        { title: 'inbox --json --limit 50', args: ['inbox', '--json', '--limit', '50'] },
+        { title: 'task list --json --limit 50', args: ['task', 'list', '--json', '--limit', '50'] },
+        { title: 'task view id:<task> --json', args: ['task', 'view', `id:${refs.taskId}`, '--json'] },
+        {
+            title: 'task list --project id:<project> --json --limit 50',
+            args: ['task', 'list', '--project', `id:${refs.projectId}`, '--json', '--limit', '50'],
+        },
+        {
+            title: 'project view id:<project> --json',
+            args: ['project', 'view', `id:${refs.projectId}`, '--json'],
+        },
+        { title: 'filter list --json', args: ['filter', 'list', '--json'] },
+    ]
+
+    if (refs.workspaceId) {
+        cases.push(
+            { title: 'workspace list --json', args: ['workspace', 'list', '--json'] },
+            {
+                title: 'workspace view id:<workspace>',
+                args: ['workspace', 'view', `id:${refs.workspaceId}`],
+            },
+            {
+                title: 'task list --workspace id:<workspace> --json --limit 50',
+                args: [
+                    'task',
+                    'list',
+                    '--workspace',
+                    `id:${refs.workspaceId}`,
+                    '--json',
+                    '--limit',
+                    '50',
+                ],
+            },
+        )
+    }
+
+    const results = []
+    for (const benchCase of cases) {
+        const result = benchmarkCase(benchCase)
+        results.push(result)
+
+        console.log(`\n=== ${result.title} ===`)
+        console.log(fmtStats('sync_off', result.beforeTimes))
+        console.log(fmtStats('sync_on_warm', result.afterTimes))
+        console.log(
+            `speedup=${result.speedupPct.toFixed(1)}% (${result.fasterByMs.toFixed(1)} ms faster)`,
+        )
+        console.log(`signature off: ${result.beforeSig}`)
+        console.log(`signature on:  ${result.afterSig}`)
+        console.log(`signature_match=${result.signatureMatch}`)
+    }
+
+    const summary = {
+        generatedAt: new Date().toISOString(),
+        dbPath: DB_PATH,
+        dbExists: refs.dbExists,
+        runsPerCase: RUNS,
+        cases: results.map((r) => ({
+            title: r.title,
+            args: r.args,
+            syncOffAvgMs: Number(stats(r.beforeTimes).avg.toFixed(1)),
+            syncOnWarmAvgMs: Number(stats(r.afterTimes).avg.toFixed(1)),
+            fasterByMs: Number(r.fasterByMs.toFixed(1)),
+            speedupPct: Number(r.speedupPct.toFixed(1)),
+            signatureMatch: r.signatureMatch,
+        })),
+    }
+
+    const summaryPath = '/tmp/todoist-cache-benchmark-summary.json'
+    writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8')
+    console.log(`\nSummary written to ${summaryPath}`)
+}
+
+main()

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -5,6 +5,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('../lib/auth.js', () => ({
     saveApiToken: vi.fn(),
     clearApiToken: vi.fn(),
+    getSyncSettings: vi.fn().mockResolvedValue({
+        enabled: false,
+        ttlSeconds: 60,
+        dbPath: '/tmp/todoist-cli-cache-test.db',
+    }),
 }))
 
 // Mock the api module

--- a/src/__tests__/sync-engine.test.ts
+++ b/src/__tests__/sync-engine.test.ts
@@ -1,0 +1,231 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetCacheDbForTests } from '../lib/sync/db.js'
+import { ensureFresh, markResourcesDirty } from '../lib/sync/engine.js'
+
+const require = createRequire(import.meta.url)
+const hasLibsqlClient = (() => {
+    try {
+        require.resolve('@libsql/client')
+        return true
+    } catch {
+        return false
+    }
+})()
+
+const describeIfLibsql = hasLibsqlClient ? describe : describe.skip
+
+function taskRaw(id: string, content: string): Record<string, unknown> {
+    return {
+        id,
+        content,
+        description: '',
+        project_id: 'proj-1',
+        section_id: null,
+        parent_id: null,
+        labels: [],
+        priority: 1,
+        checked: 0,
+        is_deleted: 0,
+        responsible_uid: null,
+        due: null,
+    }
+}
+
+function projectRaw(): Record<string, unknown> {
+    return {
+        id: 'proj-1',
+        name: 'Inbox',
+        color: 'grey',
+        is_favorite: 0,
+        is_shared: 0,
+        is_archived: 0,
+        parent_id: null,
+        view_style: 'list',
+    }
+}
+
+function syncResponse(overrides: Partial<Record<string, unknown>> = {}): Response {
+    const body = {
+        sync_token: 'token-1',
+        items: [],
+        projects: [],
+        sections: [],
+        labels: [],
+        users: [],
+        filters: [],
+        workspaces: [],
+        folders: [],
+        ...overrides,
+    }
+    return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+    })
+}
+
+describeIfLibsql('sync engine', () => {
+    let tempDir: string
+    let originalFetch: typeof fetch
+
+    beforeEach(async () => {
+        tempDir = await mkdtemp(join(tmpdir(), 'todoist-cli-sync-'))
+        originalFetch = globalThis.fetch
+
+        process.env.TD_SYNC_ENABLE_IN_TESTS = '1'
+        process.env.TD_SYNC_DB_PATH = join(tempDir, 'cache.db')
+        process.env.TD_SYNC_TTL_SECONDS = '60'
+        process.env.TODOIST_API_TOKEN = 'token-a'
+        delete process.env.TD_SYNC_DISABLE
+
+        resetCacheDbForTests()
+    })
+
+    afterEach(async () => {
+        resetCacheDbForTests()
+        globalThis.fetch = originalFetch
+
+        delete process.env.TD_SYNC_ENABLE_IN_TESTS
+        delete process.env.TD_SYNC_DB_PATH
+        delete process.env.TD_SYNC_TTL_SECONDS
+        delete process.env.TODOIST_API_TOKEN
+        delete process.env.TD_SYNC_DISABLE
+
+        await rm(tempDir, { recursive: true, force: true })
+    })
+
+    it('runs initial full sync and stores token/data', async () => {
+        const fetchMock = vi.fn().mockResolvedValueOnce(
+            syncResponse({
+                sync_token: 'sync-a',
+                items: [taskRaw('task-1', 'First task')],
+                projects: [projectRaw()],
+            }),
+        )
+        globalThis.fetch = fetchMock as unknown as typeof fetch
+
+        const repo = await ensureFresh(['items', 'projects'])
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(repo).not.toBeNull()
+        expect(await repo?.getSyncToken()).toBe('sync-a')
+        expect((await repo?.listTasks())?.map((task) => task.id)).toEqual(['task-1'])
+        expect((await repo?.listProjects())?.map((project) => project.id)).toEqual(['proj-1'])
+    })
+
+    it('applies incremental upsert + delete deltas', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(
+                syncResponse({
+                    sync_token: 'sync-a',
+                    items: [taskRaw('task-1', 'Old title'), taskRaw('task-2', 'Remove me')],
+                    projects: [projectRaw()],
+                }),
+            )
+            .mockResolvedValueOnce(
+                syncResponse({
+                    sync_token: 'sync-b',
+                    items: [taskRaw('task-1', 'New title'), { id: 'task-2', is_deleted: 1 }],
+                }),
+            )
+        globalThis.fetch = fetchMock as unknown as typeof fetch
+
+        const firstRepo = await ensureFresh(['items'])
+        expect(firstRepo).not.toBeNull()
+
+        await markResourcesDirty(['items'])
+        const secondRepo = await ensureFresh(['items'])
+
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+        const tasks = await secondRepo?.listTasks()
+        expect(tasks?.map((task) => `${task.id}:${task.content}`)).toEqual(['task-1:New title'])
+        expect(await secondRepo?.getSyncToken()).toBe('sync-b')
+    })
+
+    it('forces sync immediately when dirty even before TTL expiry', async () => {
+        process.env.TD_SYNC_TTL_SECONDS = '3600'
+
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(
+                syncResponse({
+                    sync_token: 'sync-a',
+                    items: [taskRaw('task-1', 'First')],
+                    projects: [projectRaw()],
+                }),
+            )
+            .mockResolvedValueOnce(
+                syncResponse({
+                    sync_token: 'sync-b',
+                    items: [taskRaw('task-1', 'After dirty')],
+                }),
+            )
+        globalThis.fetch = fetchMock as unknown as typeof fetch
+
+        await ensureFresh(['items'])
+        await ensureFresh(['items'])
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+
+        await markResourcesDirty(['items'])
+        const repo = await ensureFresh(['items'])
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+        expect((await repo?.listTasks())?.[0]?.content).toBe('After dirty')
+    })
+
+    it('clears cache when token fingerprint changes and reboots from full sync', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(
+                syncResponse({
+                    sync_token: 'sync-a',
+                    items: [taskRaw('task-1', 'Token A task')],
+                    projects: [projectRaw()],
+                }),
+            )
+            .mockResolvedValueOnce(
+                syncResponse({
+                    sync_token: 'sync-b',
+                    items: [taskRaw('task-2', 'Token B task')],
+                    projects: [projectRaw()],
+                }),
+            )
+        globalThis.fetch = fetchMock as unknown as typeof fetch
+
+        await ensureFresh(['items'])
+        process.env.TODOIST_API_TOKEN = 'token-b'
+        const repo = await ensureFresh(['items'])
+
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+        expect((await repo?.listTasks())?.map((task) => task.id)).toEqual(['task-2'])
+    })
+
+    it('serves stale cached data on sync failure when snapshot exists', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(
+                syncResponse({
+                    sync_token: 'sync-a',
+                    items: [taskRaw('task-1', 'Warm cache')],
+                    projects: [projectRaw()],
+                }),
+            )
+            .mockResolvedValueOnce(new Response('server error', { status: 500 }))
+            .mockResolvedValueOnce(new Response('server error', { status: 500 }))
+        globalThis.fetch = fetchMock as unknown as typeof fetch
+
+        await ensureFresh(['items'])
+        await markResourcesDirty(['items'])
+
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        const repo = await ensureFresh(['items'])
+        expect((await repo?.listTasks())?.[0]?.content).toBe('Warm cache')
+
+        await ensureFresh(['items'])
+        expect(errorSpy).toHaveBeenCalledTimes(1)
+        errorSpy.mockRestore()
+    })
+})

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -7,6 +7,7 @@ import { clearApiToken, saveApiToken } from '../lib/auth.js'
 import { buildAuthorizationUrl, exchangeCodeForToken } from '../lib/oauth.js'
 import { startCallbackServer } from '../lib/oauth-server.js'
 import { generateCodeChallenge, generateCodeVerifier, generateState } from '../lib/pkce.js'
+import { clearSyncCache } from '../lib/sync/engine.js'
 
 function promptHiddenInput(prompt: string): Promise<string> {
     return new Promise((resolve) => {
@@ -86,6 +87,7 @@ async function showStatus(): Promise<void> {
 }
 
 async function logout(): Promise<void> {
+    await clearSyncCache()
     await clearApiToken()
     console.log(chalk.green('✓'), 'Logged out')
     console.log(chalk.dim('Token removed from ~/.config/todoist-cli/config.json'))

--- a/src/lib/api/notifications.ts
+++ b/src/lib/api/notifications.ts
@@ -1,4 +1,5 @@
 import { getApiToken } from '../auth.js'
+import { markResourcesDirty } from '../sync/engine.js'
 import { executeSyncCommand, generateUuid, type SyncCommand } from './core.js'
 
 export type NotificationType =
@@ -168,6 +169,7 @@ export async function acceptInvitation(invitationId: string, secret: string): Pr
         },
     }
     await executeSyncCommand([command])
+    await markResourcesDirty(['projects', 'workspaces'])
 }
 
 export async function rejectInvitation(invitationId: string, secret: string): Promise<void> {
@@ -180,4 +182,5 @@ export async function rejectInvitation(invitationId: string, secret: string): Pr
         },
     }
     await executeSyncCommand([command])
+    await markResourcesDirty(['projects', 'workspaces'])
 }

--- a/src/lib/api/reminders.ts
+++ b/src/lib/api/reminders.ts
@@ -1,4 +1,5 @@
 import { getApiToken } from '../auth.js'
+import { markResourcesDirty } from '../sync/engine.js'
 import { executeSyncCommand, generateUuid, type SyncCommand, type SyncResponse } from './core.js'
 
 export interface ReminderDue {
@@ -83,6 +84,7 @@ export async function addReminder(args: AddReminderArgs): Promise<string> {
     }
 
     const result = await executeSyncCommand([command])
+    await markResourcesDirty(['items'])
     return result.temp_id_mapping?.[tempId] ?? tempId
 }
 
@@ -105,6 +107,7 @@ export async function updateReminder(id: string, args: UpdateReminderArgs): Prom
     }
 
     await executeSyncCommand([command])
+    await markResourcesDirty(['items'])
 }
 
 export async function deleteReminder(id: string): Promise<void> {
@@ -115,4 +118,5 @@ export async function deleteReminder(id: string): Promise<void> {
     }
 
     await executeSyncCommand([command])
+    await markResourcesDirty(['items'])
 }

--- a/src/lib/api/stats.ts
+++ b/src/lib/api/stats.ts
@@ -1,4 +1,5 @@
 import { getApiToken } from '../auth.js'
+import { markResourcesDirty } from '../sync/engine.js'
 import { executeSyncCommand, generateUuid, type SyncCommand } from './core.js'
 
 export interface Streak {
@@ -115,4 +116,5 @@ export async function updateGoals(args: UpdateGoalsArgs): Promise<void> {
     }
 
     await executeSyncCommand([command])
+    await markResourcesDirty(['users'])
 }

--- a/src/lib/api/user-settings.ts
+++ b/src/lib/api/user-settings.ts
@@ -1,4 +1,5 @@
 import { getApiToken } from '../auth.js'
+import { markResourcesDirty } from '../sync/engine.js'
 import { executeSyncCommand, generateUuid, type SyncCommand } from './core.js'
 
 interface UserSettingsSyncResponse {
@@ -125,4 +126,5 @@ export async function updateUserSettings(args: UpdateUserSettingsArgs): Promise<
     }
 
     await executeSyncCommand(commands)
+    await markResourcesDirty(['users'])
 }

--- a/src/lib/api/workspaces.ts
+++ b/src/lib/api/workspaces.ts
@@ -1,4 +1,5 @@
 import { getApiToken } from '../auth.js'
+import { ensureFresh } from '../sync/engine.js'
 
 export interface Workspace {
     id: string
@@ -28,6 +29,12 @@ async function fetchWorkspaceData(): Promise<{
     workspaces: Workspace[]
     folders: WorkspaceFolder[]
 }> {
+    const repo = await ensureFresh(['workspaces', 'folders'])
+    if (repo) {
+        const [workspaces, folders] = await Promise.all([repo.listWorkspaces(), repo.listFolders()])
+        return { workspaces, folders }
+    }
+
     if (workspaceCache !== null && folderCache !== null) {
         return { workspaces: workspaceCache, folders: folderCache }
     }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,29 +1,60 @@
 import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, isAbsolute, join } from 'node:path'
 
 const CONFIG_PATH = join(homedir(), '.config', 'todoist-cli', 'config.json')
+const DEFAULT_CACHE_DB_PATH = join(homedir(), '.config', 'todoist-cli', 'cache.db')
+const DEFAULT_SYNC_TTL_SECONDS = 60
+
+interface SyncConfig {
+    enabled?: boolean
+    ttl_seconds?: number
+    db_path?: string
+}
 
 interface Config {
     api_token?: string
+    sync?: SyncConfig
+}
+
+export interface SyncSettings {
+    enabled: boolean
+    ttlSeconds: number
+    dbPath: string
+}
+
+function resolveHomePath(pathValue: string): string {
+    if (pathValue === '~') return homedir()
+    if (pathValue.startsWith('~/')) {
+        return join(homedir(), pathValue.slice(2))
+    }
+    return pathValue
+}
+
+async function readConfig(): Promise<Config> {
+    try {
+        const content = await readFile(CONFIG_PATH, 'utf-8')
+        return JSON.parse(content) as Config
+    } catch {
+        return {}
+    }
+}
+
+async function writeConfig(config: Config): Promise<void> {
+    const configDir = dirname(CONFIG_PATH)
+    await mkdir(configDir, { recursive: true })
+    await writeFile(CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`)
 }
 
 export async function getApiToken(): Promise<string> {
-    // Priority 1: Environment variable
     const envToken = process.env.TODOIST_API_TOKEN
     if (envToken) {
         return envToken
     }
 
-    // Priority 2: Config file
-    try {
-        const content = await readFile(CONFIG_PATH, 'utf-8')
-        const config: Config = JSON.parse(content)
-        if (config.api_token) {
-            return config.api_token
-        }
-    } catch {
-        // Config file doesn't exist or is invalid
+    const config = await readConfig()
+    if (config.api_token) {
+        return config.api_token
     }
 
     throw new Error(
@@ -32,41 +63,63 @@ export async function getApiToken(): Promise<string> {
 }
 
 export async function saveApiToken(token: string): Promise<void> {
-    // Validate token (non-empty, reasonable length)
     if (!token || token.trim().length < 10) {
         throw new Error('Invalid token: Token must be at least 10 characters')
     }
 
-    // Ensure config directory exists
-    const configDir = dirname(CONFIG_PATH)
-    await mkdir(configDir, { recursive: true })
+    const existingConfig = await readConfig()
 
-    // Read existing config to preserve other settings
-    let existingConfig: Config = {}
-    try {
-        const content = await readFile(CONFIG_PATH, 'utf-8')
-        existingConfig = JSON.parse(content)
-    } catch {
-        // Config doesn't exist - start fresh
-    }
-
-    // Update config with new token
     const newConfig: Config = {
         ...existingConfig,
         api_token: token.trim(),
     }
 
-    // Write config file with proper formatting
-    await writeFile(CONFIG_PATH, `${JSON.stringify(newConfig, null, 2)}\n`)
+    await writeConfig(newConfig)
+}
+
+function parsePositiveInt(value: string | undefined): number | null {
+    if (value === undefined) return null
+    const parsed = Number.parseInt(value, 10)
+    if (!Number.isFinite(parsed) || parsed <= 0) return null
+    return parsed
+}
+
+export async function getSyncSettings(): Promise<SyncSettings> {
+    const config = await readConfig()
+    const configSync = config.sync ?? {}
+
+    const configEnabled = configSync.enabled ?? true
+    const envDisabled = process.env.TD_SYNC_DISABLE === '1'
+    const enabled = !envDisabled && configEnabled
+
+    const envTtl = parsePositiveInt(process.env.TD_SYNC_TTL_SECONDS)
+    const configTtl =
+        typeof configSync.ttl_seconds === 'number' && configSync.ttl_seconds > 0
+            ? configSync.ttl_seconds
+            : null
+    const ttlSeconds = envTtl ?? configTtl ?? DEFAULT_SYNC_TTL_SECONDS
+
+    const configuredPath =
+        process.env.TD_SYNC_DB_PATH ?? configSync.db_path ?? DEFAULT_CACHE_DB_PATH
+    const dbPath = resolveHomePath(configuredPath)
+
+    if (!isAbsolute(dbPath)) {
+        throw new Error(
+            'TD_SYNC_DB_PATH and sync.db_path must be absolute paths (or start with ~/).',
+        )
+    }
+
+    return {
+        enabled,
+        ttlSeconds,
+        dbPath,
+    }
 }
 
 export async function clearApiToken(): Promise<void> {
-    let config: Config = {}
-    try {
-        const content = await readFile(CONFIG_PATH, 'utf-8')
-        config = JSON.parse(content)
-    } catch {
-        return // Config doesn't exist, nothing to clear
+    const config = await readConfig()
+    if (Object.keys(config).length === 0) {
+        return
     }
 
     delete config.api_token
@@ -74,6 +127,6 @@ export async function clearApiToken(): Promise<void> {
     if (Object.keys(config).length === 0) {
         await unlink(CONFIG_PATH)
     } else {
-        await writeFile(CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`)
+        await writeConfig(config)
     }
 }

--- a/src/lib/sync/db.ts
+++ b/src/lib/sync/db.ts
@@ -1,0 +1,69 @@
+import { mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { getSyncSettings } from '../auth.js'
+import { runMigrations } from './migrations.js'
+
+type SqlArgs = Array<string | number | boolean | null>
+
+interface SqlStatement {
+    sql: string
+    args?: SqlArgs
+}
+
+interface SqlResult {
+    rows: Array<Record<string, unknown>>
+}
+
+interface SqlClient {
+    execute(statement: string | SqlStatement): Promise<SqlResult>
+}
+
+export class CacheDb {
+    constructor(private readonly client: SqlClient) {}
+
+    async execute(sql: string, args: SqlArgs = []): Promise<SqlResult> {
+        return this.client.execute({ sql, args })
+    }
+
+    async query(sql: string, args: SqlArgs = []): Promise<Array<Record<string, unknown>>> {
+        const result = await this.client.execute({ sql, args })
+        return result.rows.map((row) => ({ ...row }))
+    }
+
+    async first(sql: string, args: SqlArgs = []): Promise<Record<string, unknown> | null> {
+        const rows = await this.query(sql, args)
+        return rows[0] ?? null
+    }
+}
+
+let cachedPath: string | null = null
+let dbPromise: Promise<CacheDb | null> | null = null
+
+async function createDb(dbPath: string): Promise<CacheDb> {
+    await mkdir(dirname(dbPath), { recursive: true })
+    const libsqlModuleName = '@libsql/client'
+    const libsql = (await import(libsqlModuleName)) as {
+        createClient: (options: { url: string }) => SqlClient
+    }
+    const client = libsql.createClient({ url: `file:${dbPath}` })
+    await runMigrations(client)
+    return new CacheDb(client)
+}
+
+export async function getCacheDb(options?: { ignoreEnabled?: boolean }): Promise<CacheDb | null> {
+    const sync = await getSyncSettings()
+    if (!options?.ignoreEnabled && !sync.enabled) return null
+
+    if (dbPromise && cachedPath === sync.dbPath) {
+        return dbPromise
+    }
+
+    cachedPath = sync.dbPath
+    dbPromise = createDb(sync.dbPath)
+    return dbPromise
+}
+
+export function resetCacheDbForTests(): void {
+    cachedPath = null
+    dbPromise = null
+}

--- a/src/lib/sync/engine.ts
+++ b/src/lib/sync/engine.ts
@@ -1,0 +1,530 @@
+import { createHash, randomUUID } from 'node:crypto'
+import type { Label, Task } from '@doist/todoist-api-typescript'
+import type { Project, Section } from '../api/core.js'
+import type { Filter } from '../api/filters.js'
+import type { Workspace, WorkspaceFolder } from '../api/workspaces.js'
+import { getApiToken, getSyncSettings } from '../auth.js'
+import { getCacheDb } from './db.js'
+import { SyncRepository } from './repository.js'
+import {
+    type CachedEntity,
+    type CachedUser,
+    CORE_SYNC_RESOURCES,
+    type CoreSyncResource,
+    type SyncDeltaPayload,
+} from './types.js'
+
+const SYNC_ENDPOINT = 'https://api.todoist.com/api/v1/sync'
+const RUN_ID = randomUUID()
+const ONE_TIME_WARNING_KEY = 'stale_warning_run_id'
+let staleWarningPrinted = false
+
+interface SyncContext {
+    repo: SyncRepository
+    token: string
+    ttlSeconds: number
+}
+
+function toResourceList(resources: CoreSyncResource[]): CoreSyncResource[] {
+    const source = resources.length > 0 ? resources : [...CORE_SYNC_RESOURCES]
+    return [...new Set(source)]
+}
+
+function asString(value: unknown, fallback = ''): string {
+    if (value == null) return fallback
+    return String(value)
+}
+
+function asOptionalString(value: unknown): string | null {
+    if (value == null) return null
+    return String(value)
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function asBool(value: unknown): boolean {
+    return value === true || value === 1 || value === '1'
+}
+
+function asOptionalBool(value: unknown): boolean | null {
+    if (value == null) return null
+    return asBool(value)
+}
+
+function isDeleted(raw: Record<string, unknown>): boolean {
+    return asBool(raw.is_deleted ?? raw.isDeleted)
+}
+
+function mapDue(rawDue: unknown): Task['due'] | null {
+    if (!rawDue || typeof rawDue !== 'object') return null
+    const due = rawDue as Record<string, unknown>
+    const date = asOptionalString(due.date)
+    if (!date) return null
+
+    const mapped = {
+        date,
+        string: asString(due.string, date),
+        isRecurring: asBool(due.is_recurring ?? due.isRecurring),
+    } as NonNullable<Task['due']>
+    const timezone = asOptionalString(due.timezone)
+    if (timezone) mapped.timezone = timezone
+    const lang = asOptionalString(due.lang)
+    if (lang) mapped.lang = lang
+    return mapped
+}
+
+function mapDuration(rawDuration: unknown): Task['duration'] | null {
+    if (!rawDuration || typeof rawDuration !== 'object') return null
+    const duration = rawDuration as Record<string, unknown>
+    const amount = asNumber(duration.amount, 0)
+    const unitRaw = asString(duration.unit, 'minute')
+    const unit = unitRaw === 'day' ? 'day' : 'minute'
+    return {
+        amount,
+        unit,
+    } as Task['duration']
+}
+
+function mapDeadline(rawDeadline: unknown): Task['deadline'] | null {
+    if (!rawDeadline || typeof rawDeadline !== 'object') return null
+    const deadline = rawDeadline as Record<string, unknown>
+    const date = asOptionalString(deadline.date)
+    if (!date) return null
+    return {
+        date,
+        lang: asOptionalString(deadline.lang) ?? undefined,
+    } as Task['deadline']
+}
+
+function mapTask(raw: Record<string, unknown>): Task {
+    const id = asString(raw.id)
+    const task = {
+        id,
+        content: asString(raw.content),
+        description: asString(raw.description),
+        projectId: asString(raw.project_id ?? raw.projectId),
+        sectionId: asOptionalString(raw.section_id ?? raw.sectionId),
+        parentId: asOptionalString(raw.parent_id ?? raw.parentId),
+        labels: Array.isArray(raw.labels) ? raw.labels.map((label) => asString(label)) : [],
+        priority: asNumber(raw.priority, 1),
+        due: mapDue(raw.due),
+        deadline: mapDeadline(raw.deadline),
+        duration: mapDuration(raw.duration),
+        checked: asBool(raw.checked),
+        isDeleted: asBool(raw.is_deleted ?? raw.isDeleted),
+        responsibleUid: asOptionalString(raw.responsible_uid ?? raw.responsibleUid),
+        addedByUid: asOptionalString(raw.added_by_uid ?? raw.addedByUid),
+        assignedByUid: asOptionalString(raw.assigned_by_uid ?? raw.assignedByUid),
+        isUncompletable: asBool(raw.is_uncompletable ?? raw.isUncompletable),
+        userId: asString(raw.user_id ?? raw.userId),
+        createdAt: asString(
+            raw.created_at ?? raw.createdAt ?? raw.added_at,
+            new Date().toISOString(),
+        ),
+        addedAt: asOptionalString(raw.added_at ?? raw.addedAt),
+        updatedAt: asOptionalString(raw.updated_at ?? raw.updatedAt),
+        completedAt: asOptionalString(raw.completed_at ?? raw.completedAt),
+        syncId: asOptionalString(raw.sync_id ?? raw.syncId),
+        order: asNumber(raw.order ?? raw.item_order, 0),
+        childOrder: asNumber(raw.child_order ?? raw.childOrder, 0),
+        dayOrder: asNumber(raw.day_order ?? raw.dayOrder, 0),
+        noteCount: asNumber(raw.note_count ?? raw.noteCount, 0),
+        isCollapsed: asBool(raw.is_collapsed ?? raw.isCollapsed ?? raw.collapsed),
+        url: asString(raw.url, `https://app.todoist.com/app/task/${id}`),
+    } as Task
+    return task
+}
+
+function mapProject(raw: Record<string, unknown>): Project {
+    const id = asString(raw.id)
+    const workspaceId = asOptionalString(raw.workspace_id ?? raw.workspaceId)
+    const projectBase = {
+        id,
+        canAssignTasks: asBool(raw.can_assign_tasks ?? raw.canAssignTasks),
+        childOrder: asNumber(raw.child_order ?? raw.childOrder, 0),
+        name: asString(raw.name),
+        color: asString(raw.color, 'charcoal'),
+        createdAt: asOptionalString(raw.created_at ?? raw.createdAt),
+        updatedAt: asOptionalString(raw.updated_at ?? raw.updatedAt),
+        isFavorite: asBool(raw.is_favorite ?? raw.isFavorite),
+        isDeleted: asBool(raw.is_deleted ?? raw.isDeleted),
+        isFrozen: asBool(raw.is_frozen ?? raw.isFrozen),
+        viewStyle: asString(raw.view_style ?? raw.viewStyle, 'list') as Project['viewStyle'],
+        defaultOrder: asNumber(raw.default_order ?? raw.defaultOrder, 0),
+        description: asString(raw.description),
+        isCollapsed: asBool(raw.is_collapsed ?? raw.isCollapsed),
+        url: asString(raw.url, `https://app.todoist.com/app/project/${id}`),
+        isShared: asBool(raw.is_shared ?? raw.isShared),
+        isArchived: asBool(raw.is_archived ?? raw.isArchived),
+    }
+
+    if (workspaceId) {
+        return {
+            ...projectBase,
+            collaboratorRoleDefault: asString(
+                raw.collaborator_role_default ?? raw.collaboratorRoleDefault,
+            ),
+            workspaceId,
+            folderId: asOptionalString(raw.folder_id ?? raw.folderId),
+            isInviteOnly: asOptionalBool(raw.is_invite_only ?? raw.isInviteOnly),
+            isLinkSharingEnabled: asBool(raw.is_link_sharing_enabled ?? raw.isLinkSharingEnabled),
+            role: asOptionalString(raw.role),
+            status: asString(raw.status, 'IN_PROGRESS'),
+        } as Project
+    }
+
+    return {
+        ...projectBase,
+        parentId: asOptionalString(raw.parent_id ?? raw.parentId),
+        inboxProject: asBool(raw.inbox_project ?? raw.inboxProject),
+    } as Project
+}
+
+function mapSection(raw: Record<string, unknown>): Section {
+    const id = asString(raw.id)
+    return {
+        id,
+        name: asString(raw.name),
+        projectId: asString(raw.project_id ?? raw.projectId),
+        sectionOrder: asNumber(raw.section_order ?? raw.sectionOrder, 0),
+        url: asString(raw.url, `https://app.todoist.com/app/section/${id}`),
+    } as Section
+}
+
+function mapLabel(raw: Record<string, unknown>): Label {
+    return {
+        id: asString(raw.id),
+        name: asString(raw.name),
+        color: asString(raw.color, 'charcoal'),
+        isFavorite: asBool(raw.is_favorite ?? raw.isFavorite),
+    } as Label
+}
+
+function mapUser(raw: Record<string, unknown>): CachedUser {
+    return {
+        id: asString(raw.id),
+        email: asString(raw.email),
+        name: asOptionalString(raw.name) ?? undefined,
+        fullName: asString(raw.full_name ?? raw.fullName),
+        inboxProjectId: asOptionalString(raw.inbox_project_id ?? raw.inboxProjectId) ?? '',
+    }
+}
+
+function mapFilter(raw: Record<string, unknown>): Filter {
+    return {
+        id: asString(raw.id),
+        name: asString(raw.name),
+        query: asString(raw.query),
+        color: asOptionalString(raw.color) ?? undefined,
+        itemOrder:
+            raw.item_order == null && raw.itemOrder == null
+                ? undefined
+                : asNumber(raw.item_order ?? raw.itemOrder, 0),
+        isFavorite: asBool(raw.is_favorite ?? raw.isFavorite),
+        isDeleted: asBool(raw.is_deleted ?? raw.isDeleted),
+    }
+}
+
+function mapWorkspace(raw: Record<string, unknown>): Workspace {
+    const memberCountByType = (raw.member_count_by_type ?? raw.memberCountByType) as
+        | Record<string, unknown>
+        | undefined
+    return {
+        id: asString(raw.id),
+        name: asString(raw.name),
+        role: asString(raw.role, 'MEMBER') as Workspace['role'],
+        plan: asString(raw.plan, 'STARTER'),
+        domainName: asOptionalString(raw.domain_name ?? raw.domainName),
+        currentMemberCount: asNumber(raw.current_member_count ?? raw.currentMemberCount, 0),
+        currentActiveProjects: asNumber(
+            raw.current_active_projects ?? raw.currentActiveProjects,
+            0,
+        ),
+        memberCountByType: {
+            adminCount: asNumber(
+                memberCountByType?.admin_count ?? memberCountByType?.adminCount,
+                0,
+            ),
+            memberCount: asNumber(
+                memberCountByType?.member_count ?? memberCountByType?.memberCount,
+                0,
+            ),
+            guestCount: asNumber(
+                memberCountByType?.guest_count ?? memberCountByType?.guestCount,
+                0,
+            ),
+        },
+    }
+}
+
+function mapFolder(raw: Record<string, unknown>): WorkspaceFolder {
+    return {
+        id: asString(raw.id),
+        name: asString(raw.name),
+        workspaceId: asString(raw.workspace_id ?? raw.workspaceId),
+    }
+}
+
+function splitDelta<T>(
+    rows: Array<Record<string, unknown>> | undefined,
+    mapper: (row: Record<string, unknown>) => T,
+): { upserts: T[]; deletes: string[] } {
+    const upserts: T[] = []
+    const deletes: string[] = []
+    for (const row of rows ?? []) {
+        const id = asOptionalString(row.id)
+        if (!id) continue
+        if (isDeleted(row)) {
+            deletes.push(id)
+            continue
+        }
+        upserts.push(mapper(row))
+    }
+    return { upserts, deletes }
+}
+
+async function getRepository(): Promise<SyncRepository | null> {
+    if (process.env.VITEST && process.env.TD_SYNC_ENABLE_IN_TESTS !== '1') {
+        return null
+    }
+
+    const settings = await getSyncSettings()
+    if (!settings.enabled) return null
+    const db = await getCacheDb()
+    if (!db) return null
+    return new SyncRepository(db)
+}
+
+async function getSyncContext(): Promise<SyncContext | null> {
+    if (process.env.VITEST && process.env.TD_SYNC_ENABLE_IN_TESTS !== '1') {
+        return null
+    }
+
+    const settings = await getSyncSettings()
+    if (!settings.enabled) return null
+
+    let token: string
+    try {
+        token = await getApiToken()
+    } catch {
+        return null
+    }
+
+    const db = await getCacheDb()
+    if (!db) return null
+
+    return {
+        repo: new SyncRepository(db),
+        token,
+        ttlSeconds: settings.ttlSeconds,
+    }
+}
+
+function fingerprintToken(token: string): string {
+    return createHash('sha256').update(token).digest('hex')
+}
+
+async function ensureFingerprint(repo: SyncRepository, token: string): Promise<void> {
+    const nextFingerprint = fingerprintToken(token)
+    const existing = await repo.getTokenFingerprint()
+    if (!existing) {
+        await repo.setTokenFingerprint(nextFingerprint)
+        return
+    }
+    if (existing !== nextFingerprint) {
+        await repo.clearAllData()
+        await repo.setTokenFingerprint(nextFingerprint)
+    }
+}
+
+async function fetchSyncDelta(token: string, syncToken: string): Promise<SyncDeltaPayload> {
+    const response = await fetch(SYNC_ENDPOINT, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+            sync_token: syncToken,
+            resource_types: JSON.stringify(CORE_SYNC_RESOURCES),
+        }),
+    })
+
+    if (!response.ok) {
+        throw new Error(`Sync API error: ${response.status}`)
+    }
+
+    const data = (await response.json()) as SyncDeltaPayload
+    if (data.error) {
+        throw new Error(`Sync API error: ${data.error}`)
+    }
+    return data
+}
+
+async function applyDelta(repo: SyncRepository, payload: SyncDeltaPayload): Promise<void> {
+    const tasks = splitDelta(payload.items, mapTask)
+    if (tasks.upserts.length > 0) await repo.upsertTasks(tasks.upserts)
+    if (tasks.deletes.length > 0) await repo.deleteTasks(tasks.deletes)
+
+    const projects = splitDelta(payload.projects, mapProject)
+    if (projects.upserts.length > 0) await repo.upsertProjects(projects.upserts)
+    if (projects.deletes.length > 0) await repo.deleteProjects(projects.deletes)
+
+    const sections = splitDelta(payload.sections, mapSection)
+    if (sections.upserts.length > 0) await repo.upsertSections(sections.upserts)
+    if (sections.deletes.length > 0) await repo.deleteSections(sections.deletes)
+
+    const labels = splitDelta(payload.labels, mapLabel)
+    if (labels.upserts.length > 0) await repo.upsertLabels(labels.upserts)
+    if (labels.deletes.length > 0) await repo.deleteLabels(labels.deletes)
+
+    const users = splitDelta(payload.users, mapUser)
+    if (users.upserts.length > 0) await repo.upsertUsers(users.upserts)
+    if (users.deletes.length > 0) await repo.deleteUsers(users.deletes)
+
+    const filters = splitDelta(payload.filters, mapFilter)
+    if (filters.upserts.length > 0) await repo.upsertFilters(filters.upserts)
+    if (filters.deletes.length > 0) await repo.deleteFilters(filters.deletes)
+
+    const workspaces = splitDelta(payload.workspaces, mapWorkspace)
+    if (workspaces.upserts.length > 0) await repo.upsertWorkspaces(workspaces.upserts)
+    if (workspaces.deletes.length > 0) await repo.deleteWorkspaces(workspaces.deletes)
+
+    const folders = splitDelta(payload.folders, mapFolder)
+    if (folders.upserts.length > 0) await repo.upsertFolders(folders.upserts)
+    if (folders.deletes.length > 0) await repo.deleteFolders(folders.deletes)
+}
+
+async function syncNow(repo: SyncRepository, token: string): Promise<void> {
+    const currentToken = (await repo.getSyncToken()) ?? '*'
+    const payload = await fetchSyncDelta(token, currentToken)
+    await applyDelta(repo, payload)
+    if (payload.sync_token) {
+        await repo.setSyncToken(payload.sync_token)
+    }
+    const syncedAt = new Date().toISOString()
+    await repo.markResourcesClean([...CORE_SYNC_RESOURCES], syncedAt)
+}
+
+async function warnStaleOnce(repo: SyncRepository, error: unknown): Promise<void> {
+    if (staleWarningPrinted) return
+
+    const alreadyWarnedForRun = await repo.getMeta(ONE_TIME_WARNING_KEY)
+    if (alreadyWarnedForRun === RUN_ID) {
+        staleWarningPrinted = true
+        return
+    }
+
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`Warning: sync failed, using stale cache (${message}).`)
+    staleWarningPrinted = true
+    await repo.setMeta(ONE_TIME_WARNING_KEY, RUN_ID)
+}
+
+export async function ensureFresh(
+    requiredResources: CoreSyncResource[],
+): Promise<SyncRepository | null> {
+    const context = await getSyncContext()
+    if (!context) return null
+
+    const { repo, token, ttlSeconds } = context
+    const resources = toResourceList(requiredResources)
+
+    await ensureFingerprint(repo, token)
+
+    const hasSnapshot = await repo.hasSnapshot(resources)
+    const shouldSync =
+        !hasSnapshot ||
+        (await repo.isAnyResourceDirty(resources)) ||
+        (await repo.isAnyResourceExpired(resources, ttlSeconds))
+
+    if (!shouldSync) {
+        return repo
+    }
+
+    try {
+        await syncNow(repo, token)
+        return repo
+    } catch (error) {
+        if (hasSnapshot) {
+            await warnStaleOnce(repo, error)
+            return repo
+        }
+        throw error
+    }
+}
+
+export async function getRepositoryWithoutSync(): Promise<SyncRepository | null> {
+    return getRepository()
+}
+
+export async function markResourcesDirty(resources: CoreSyncResource[]): Promise<void> {
+    const context = await getSyncContext()
+    if (!context) return
+
+    try {
+        await context.repo.markResourcesDirty(toResourceList(resources))
+    } catch {}
+}
+
+export async function upsertCachedEntity(entity: CachedEntity): Promise<void> {
+    const context = await getSyncContext()
+    if (!context) return
+
+    try {
+        switch (entity.resource) {
+            case 'items':
+                await context.repo.upsertTasks([entity.value])
+                break
+            case 'projects':
+                await context.repo.upsertProjects([entity.value])
+                break
+            case 'sections':
+                await context.repo.upsertSections([entity.value])
+                break
+            case 'labels':
+                await context.repo.upsertLabels([entity.value])
+                break
+            case 'users':
+                await context.repo.upsertUsers([entity.value])
+                break
+            case 'filters':
+                await context.repo.upsertFilters([entity.value])
+                break
+            case 'workspaces':
+                await context.repo.upsertWorkspaces([entity.value])
+                break
+            case 'folders':
+                await context.repo.upsertFolders([entity.value])
+                break
+        }
+    } catch {}
+}
+
+export async function setCachedCurrentUserId(userId: string): Promise<void> {
+    const context = await getSyncContext()
+    if (!context) return
+    try {
+        await context.repo.setCurrentUserId(userId)
+    } catch {}
+}
+
+export async function getCachedCurrentUserId(): Promise<string | null> {
+    const context = await getSyncContext()
+    if (!context) return null
+    try {
+        return await context.repo.getCurrentUserId()
+    } catch {
+        return null
+    }
+}
+
+export async function clearSyncCache(): Promise<void> {
+    const db = await getCacheDb({ ignoreEnabled: true })
+    if (!db) return
+    const repo = new SyncRepository(db)
+    await repo.clearAllData()
+}

--- a/src/lib/sync/migrations.ts
+++ b/src/lib/sync/migrations.ts
@@ -1,0 +1,156 @@
+import { CORE_SYNC_RESOURCES } from './types.js'
+
+interface SqlStatement {
+    sql: string
+    args?: Array<string | number | boolean | null>
+}
+
+interface SqlClient {
+    execute(statement: string | SqlStatement): Promise<unknown>
+}
+
+export const SCHEMA_VERSION = 1
+
+export const CACHE_TABLES = [
+    'tasks',
+    'projects',
+    'sections',
+    'labels',
+    'users',
+    'filters',
+    'workspaces',
+    'folders',
+    'workspace_users',
+    'project_collaborators',
+] as const
+
+async function executeAll(client: SqlClient, statements: string[]): Promise<void> {
+    for (const sql of statements) {
+        await client.execute(sql)
+    }
+}
+
+export async function runMigrations(client: SqlClient): Promise<void> {
+    await executeAll(client, [
+        `CREATE TABLE IF NOT EXISTS meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )`,
+        `CREATE TABLE IF NOT EXISTS sync_state (
+            resource TEXT PRIMARY KEY,
+            dirty INTEGER NOT NULL DEFAULT 1,
+            last_synced_at TEXT
+        )`,
+        `CREATE TABLE IF NOT EXISTS tasks (
+            id TEXT PRIMARY KEY,
+            data TEXT NOT NULL,
+            content TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            section_id TEXT,
+            parent_id TEXT,
+            priority INTEGER NOT NULL,
+            due_date TEXT,
+            responsible_uid TEXT,
+            checked INTEGER NOT NULL DEFAULT 0,
+            updated_at TEXT
+        )`,
+        `CREATE TABLE IF NOT EXISTS projects (
+            id TEXT PRIMARY KEY,
+            data TEXT NOT NULL,
+            name TEXT NOT NULL,
+            workspace_id TEXT,
+            folder_id TEXT,
+            parent_id TEXT,
+            is_shared INTEGER NOT NULL DEFAULT 0,
+            is_archived INTEGER NOT NULL DEFAULT 0
+        )`,
+        `CREATE TABLE IF NOT EXISTS sections (
+            id TEXT PRIMARY KEY,
+            data TEXT NOT NULL,
+            name TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            section_order INTEGER
+        )`,
+        `CREATE TABLE IF NOT EXISTS labels (
+            id TEXT PRIMARY KEY,
+            data TEXT NOT NULL,
+            name TEXT NOT NULL,
+            color TEXT,
+            is_favorite INTEGER NOT NULL DEFAULT 0
+        )`,
+        `CREATE TABLE IF NOT EXISTS users (
+            id TEXT PRIMARY KEY,
+            data TEXT NOT NULL,
+            full_name TEXT,
+            email TEXT,
+            inbox_project_id TEXT
+        )`,
+        `CREATE TABLE IF NOT EXISTS filters (
+            id TEXT PRIMARY KEY,
+            data TEXT NOT NULL,
+            name TEXT NOT NULL,
+            query TEXT NOT NULL,
+            is_favorite INTEGER NOT NULL DEFAULT 0,
+            is_deleted INTEGER NOT NULL DEFAULT 0
+        )`,
+        `CREATE TABLE IF NOT EXISTS workspaces (
+            id TEXT PRIMARY KEY,
+            data TEXT NOT NULL,
+            name TEXT NOT NULL,
+            role TEXT,
+            plan TEXT
+        )`,
+        `CREATE TABLE IF NOT EXISTS folders (
+            id TEXT PRIMARY KEY,
+            data TEXT NOT NULL,
+            name TEXT NOT NULL,
+            workspace_id TEXT NOT NULL
+        )`,
+        `CREATE TABLE IF NOT EXISTS workspace_users (
+            workspace_id TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            data TEXT NOT NULL,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (workspace_id, user_id)
+        )`,
+        `CREATE TABLE IF NOT EXISTS project_collaborators (
+            project_id TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            data TEXT NOT NULL,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (project_id, user_id)
+        )`,
+        `CREATE INDEX IF NOT EXISTS idx_tasks_project_id ON tasks(project_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_tasks_section_id ON tasks(section_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_tasks_parent_id ON tasks(parent_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_tasks_due_date ON tasks(due_date)`,
+        `CREATE INDEX IF NOT EXISTS idx_tasks_responsible_uid ON tasks(responsible_uid)`,
+        `CREATE INDEX IF NOT EXISTS idx_projects_workspace_id ON projects(workspace_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_projects_folder_id ON projects(folder_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_projects_parent_id ON projects(parent_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_sections_project_id ON sections(project_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_filters_name ON filters(name)`,
+        `CREATE INDEX IF NOT EXISTS idx_workspaces_name ON workspaces(name)`,
+        `CREATE INDEX IF NOT EXISTS idx_folders_workspace_id ON folders(workspace_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_workspace_users_workspace_id ON workspace_users(workspace_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_project_collaborators_project_id ON project_collaborators(project_id)`,
+    ])
+
+    await client.execute({
+        sql: `INSERT INTO meta(key, value) VALUES ('schema_version', ?)
+              ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+        args: [String(SCHEMA_VERSION)],
+    })
+
+    for (const resource of CORE_SYNC_RESOURCES) {
+        await client.execute({
+            sql: `INSERT OR IGNORE INTO sync_state(resource, dirty, last_synced_at)
+                  VALUES (?, 1, NULL)`,
+            args: [resource],
+        })
+    }
+}

--- a/src/lib/sync/repository.ts
+++ b/src/lib/sync/repository.ts
@@ -1,0 +1,644 @@
+import type { Label, Task } from '@doist/todoist-api-typescript'
+import type { Project, Section } from '../api/core.js'
+import type { Filter } from '../api/filters.js'
+import type { Workspace, WorkspaceFolder } from '../api/workspaces.js'
+import type { CacheDb } from './db.js'
+import { CACHE_TABLES } from './migrations.js'
+import type {
+    CachedUser,
+    CoreSyncResource,
+    LocalPaginatedResult,
+    LocalTaskQuery,
+    ProjectCollaboratorRecord,
+    WorkspaceUserRecord,
+} from './types.js'
+
+const LOCAL_CURSOR_PREFIX = 'local:'
+
+function dateOnly(value: string | undefined | null): string | null {
+    if (!value) return null
+    return value.split('T')[0]
+}
+
+function parseLocalCursor(cursor: string | undefined): number {
+    if (!cursor) return 0
+    if (cursor.startsWith(LOCAL_CURSOR_PREFIX)) {
+        const parsed = Number.parseInt(cursor.slice(LOCAL_CURSOR_PREFIX.length), 10)
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+    }
+    const parsed = Number.parseInt(cursor, 10)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+}
+
+function formatLocalCursor(offset: number): string {
+    return `${LOCAL_CURSOR_PREFIX}${offset}`
+}
+
+function parseData<T>(row: Record<string, unknown>): T {
+    const raw = row.data
+    if (typeof raw !== 'string') {
+        throw new Error('Invalid cached row payload')
+    }
+    return JSON.parse(raw) as T
+}
+
+function toSqlBool(value: boolean | undefined): number {
+    return value ? 1 : 0
+}
+
+export class SyncRepository {
+    constructor(private readonly db: CacheDb) {}
+
+    async getMeta(key: string): Promise<string | null> {
+        const row = await this.db.first('SELECT value FROM meta WHERE key = ?', [key])
+        if (!row) return null
+        return typeof row.value === 'string' ? row.value : String(row.value ?? '')
+    }
+
+    async setMeta(key: string, value: string): Promise<void> {
+        await this.db.execute(
+            `INSERT INTO meta(key, value) VALUES (?, ?)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+            [key, value],
+        )
+    }
+
+    async deleteMeta(key: string): Promise<void> {
+        await this.db.execute('DELETE FROM meta WHERE key = ?', [key])
+    }
+
+    async getSyncToken(): Promise<string | null> {
+        return this.getMeta('sync_token')
+    }
+
+    async setSyncToken(token: string): Promise<void> {
+        await this.setMeta('sync_token', token)
+    }
+
+    async getTokenFingerprint(): Promise<string | null> {
+        return this.getMeta('token_fingerprint')
+    }
+
+    async setTokenFingerprint(fingerprint: string): Promise<void> {
+        await this.setMeta('token_fingerprint', fingerprint)
+    }
+
+    async getCurrentUserId(): Promise<string | null> {
+        return this.getMeta('current_user_id')
+    }
+
+    async setCurrentUserId(userId: string): Promise<void> {
+        await this.setMeta('current_user_id', userId)
+    }
+
+    async markResourcesDirty(resources: CoreSyncResource[]): Promise<void> {
+        for (const resource of resources) {
+            await this.db.execute(
+                `INSERT INTO sync_state(resource, dirty, last_synced_at)
+                 VALUES (?, 1, NULL)
+                 ON CONFLICT(resource) DO UPDATE SET dirty = 1`,
+                [resource],
+            )
+        }
+    }
+
+    async markResourcesClean(resources: CoreSyncResource[], syncedAt: string): Promise<void> {
+        for (const resource of resources) {
+            await this.db.execute(
+                `INSERT INTO sync_state(resource, dirty, last_synced_at)
+                 VALUES (?, 0, ?)
+                 ON CONFLICT(resource) DO UPDATE SET dirty = 0, last_synced_at = excluded.last_synced_at`,
+                [resource, syncedAt],
+            )
+        }
+    }
+
+    async isAnyResourceDirty(resources: CoreSyncResource[]): Promise<boolean> {
+        for (const resource of resources) {
+            const row = await this.db.first(
+                'SELECT dirty FROM sync_state WHERE resource = ? LIMIT 1',
+                [resource],
+            )
+            const dirty = Number(row?.dirty ?? 1)
+            if (dirty > 0) return true
+        }
+        return false
+    }
+
+    async isAnyResourceExpired(
+        resources: CoreSyncResource[],
+        ttlSeconds: number,
+    ): Promise<boolean> {
+        const nowMs = Date.now()
+        for (const resource of resources) {
+            const row = await this.db.first(
+                'SELECT last_synced_at FROM sync_state WHERE resource = ? LIMIT 1',
+                [resource],
+            )
+            const lastSyncedAt = typeof row?.last_synced_at === 'string' ? row.last_synced_at : null
+            if (!lastSyncedAt) return true
+            const syncedMs = Date.parse(lastSyncedAt)
+            if (!Number.isFinite(syncedMs)) return true
+            if (nowMs - syncedMs > ttlSeconds * 1000) return true
+        }
+        return false
+    }
+
+    async hasSnapshot(resources: CoreSyncResource[]): Promise<boolean> {
+        for (const resource of resources) {
+            const row = await this.db.first(
+                'SELECT last_synced_at FROM sync_state WHERE resource = ? LIMIT 1',
+                [resource],
+            )
+            const lastSyncedAt = typeof row?.last_synced_at === 'string' ? row.last_synced_at : null
+            if (!lastSyncedAt) return false
+        }
+        return true
+    }
+
+    async clearAllData(): Promise<void> {
+        for (const table of CACHE_TABLES) {
+            await this.db.execute(`DELETE FROM ${table}`)
+        }
+        await this.db.execute('UPDATE sync_state SET dirty = 1, last_synced_at = NULL')
+        await this.deleteMeta('sync_token')
+        await this.deleteMeta('current_user_id')
+        await this.deleteMeta('stale_warning_run_id')
+    }
+
+    async upsertTasks(tasks: Task[]): Promise<void> {
+        for (const task of tasks) {
+            await this.db.execute(
+                `INSERT INTO tasks(
+                    id, data, content, project_id, section_id, parent_id,
+                    priority, due_date, responsible_uid, checked, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    data = excluded.data,
+                    content = excluded.content,
+                    project_id = excluded.project_id,
+                    section_id = excluded.section_id,
+                    parent_id = excluded.parent_id,
+                    priority = excluded.priority,
+                    due_date = excluded.due_date,
+                    responsible_uid = excluded.responsible_uid,
+                    checked = excluded.checked,
+                    updated_at = excluded.updated_at`,
+                [
+                    task.id,
+                    JSON.stringify(task),
+                    task.content,
+                    task.projectId,
+                    task.sectionId,
+                    task.parentId,
+                    task.priority,
+                    dateOnly(task.due?.date),
+                    task.responsibleUid ?? null,
+                    toSqlBool(task.checked),
+                    task.updatedAt ?? null,
+                ],
+            )
+        }
+    }
+
+    async deleteTasks(taskIds: string[]): Promise<void> {
+        for (const id of taskIds) {
+            await this.db.execute('DELETE FROM tasks WHERE id = ?', [id])
+        }
+    }
+
+    async upsertProjects(projects: Project[]): Promise<void> {
+        for (const project of projects) {
+            const workspaceId =
+                'workspaceId' in project && typeof project.workspaceId === 'string'
+                    ? project.workspaceId
+                    : null
+            const folderId =
+                'folderId' in project && project.folderId != null ? String(project.folderId) : null
+            const parentId =
+                'parentId' in project && typeof project.parentId === 'string'
+                    ? project.parentId
+                    : null
+            await this.db.execute(
+                `INSERT INTO projects(
+                    id, data, name, workspace_id, folder_id, parent_id, is_shared, is_archived
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    data = excluded.data,
+                    name = excluded.name,
+                    workspace_id = excluded.workspace_id,
+                    folder_id = excluded.folder_id,
+                    parent_id = excluded.parent_id,
+                    is_shared = excluded.is_shared,
+                    is_archived = excluded.is_archived`,
+                [
+                    project.id,
+                    JSON.stringify(project),
+                    project.name,
+                    workspaceId,
+                    folderId,
+                    parentId,
+                    toSqlBool(project.isShared),
+                    toSqlBool(project.isArchived),
+                ],
+            )
+        }
+    }
+
+    async deleteProjects(projectIds: string[]): Promise<void> {
+        for (const id of projectIds) {
+            await this.db.execute('DELETE FROM projects WHERE id = ?', [id])
+        }
+    }
+
+    async upsertSections(sections: Section[]): Promise<void> {
+        for (const section of sections) {
+            await this.db.execute(
+                `INSERT INTO sections(id, data, name, project_id, section_order)
+                 VALUES (?, ?, ?, ?, ?)
+                 ON CONFLICT(id) DO UPDATE SET
+                    data = excluded.data,
+                    name = excluded.name,
+                    project_id = excluded.project_id,
+                    section_order = excluded.section_order`,
+                [
+                    section.id,
+                    JSON.stringify(section),
+                    section.name,
+                    section.projectId,
+                    section.sectionOrder ?? null,
+                ],
+            )
+        }
+    }
+
+    async deleteSections(sectionIds: string[]): Promise<void> {
+        for (const id of sectionIds) {
+            await this.db.execute('DELETE FROM sections WHERE id = ?', [id])
+        }
+    }
+
+    async upsertLabels(labels: Label[]): Promise<void> {
+        for (const label of labels) {
+            await this.db.execute(
+                `INSERT INTO labels(id, data, name, color, is_favorite)
+                 VALUES (?, ?, ?, ?, ?)
+                 ON CONFLICT(id) DO UPDATE SET
+                    data = excluded.data,
+                    name = excluded.name,
+                    color = excluded.color,
+                    is_favorite = excluded.is_favorite`,
+                [
+                    label.id,
+                    JSON.stringify(label),
+                    label.name,
+                    label.color ?? null,
+                    toSqlBool(label.isFavorite),
+                ],
+            )
+        }
+    }
+
+    async deleteLabels(labelIds: string[]): Promise<void> {
+        for (const id of labelIds) {
+            await this.db.execute('DELETE FROM labels WHERE id = ?', [id])
+        }
+    }
+
+    async upsertUsers(users: CachedUser[]): Promise<void> {
+        for (const user of users) {
+            const fullName = user.fullName ?? user.name ?? null
+            await this.db.execute(
+                `INSERT INTO users(id, data, full_name, email, inbox_project_id)
+                 VALUES (?, ?, ?, ?, ?)
+                 ON CONFLICT(id) DO UPDATE SET
+                    data = excluded.data,
+                    full_name = excluded.full_name,
+                    email = excluded.email,
+                    inbox_project_id = excluded.inbox_project_id`,
+                [
+                    user.id,
+                    JSON.stringify(user),
+                    fullName,
+                    user.email ?? null,
+                    user.inboxProjectId ?? null,
+                ],
+            )
+        }
+    }
+
+    async deleteUsers(userIds: string[]): Promise<void> {
+        for (const id of userIds) {
+            await this.db.execute('DELETE FROM users WHERE id = ?', [id])
+        }
+    }
+
+    async upsertFilters(filters: Filter[]): Promise<void> {
+        for (const filter of filters) {
+            await this.db.execute(
+                `INSERT INTO filters(id, data, name, query, is_favorite, is_deleted)
+                 VALUES (?, ?, ?, ?, ?, ?)
+                 ON CONFLICT(id) DO UPDATE SET
+                    data = excluded.data,
+                    name = excluded.name,
+                    query = excluded.query,
+                    is_favorite = excluded.is_favorite,
+                    is_deleted = excluded.is_deleted`,
+                [
+                    filter.id,
+                    JSON.stringify(filter),
+                    filter.name,
+                    filter.query,
+                    toSqlBool(filter.isFavorite),
+                    toSqlBool(filter.isDeleted),
+                ],
+            )
+        }
+    }
+
+    async deleteFilters(filterIds: string[]): Promise<void> {
+        for (const id of filterIds) {
+            await this.db.execute('DELETE FROM filters WHERE id = ?', [id])
+        }
+    }
+
+    async upsertWorkspaces(workspaces: Workspace[]): Promise<void> {
+        for (const workspace of workspaces) {
+            await this.db.execute(
+                `INSERT INTO workspaces(id, data, name, role, plan)
+                 VALUES (?, ?, ?, ?, ?)
+                 ON CONFLICT(id) DO UPDATE SET
+                    data = excluded.data,
+                    name = excluded.name,
+                    role = excluded.role,
+                    plan = excluded.plan`,
+                [
+                    workspace.id,
+                    JSON.stringify(workspace),
+                    workspace.name,
+                    workspace.role,
+                    workspace.plan,
+                ],
+            )
+        }
+    }
+
+    async deleteWorkspaces(workspaceIds: string[]): Promise<void> {
+        for (const id of workspaceIds) {
+            await this.db.execute('DELETE FROM workspaces WHERE id = ?', [id])
+        }
+    }
+
+    async upsertFolders(folders: WorkspaceFolder[]): Promise<void> {
+        for (const folder of folders) {
+            await this.db.execute(
+                `INSERT INTO folders(id, data, name, workspace_id)
+                 VALUES (?, ?, ?, ?)
+                 ON CONFLICT(id) DO UPDATE SET
+                    data = excluded.data,
+                    name = excluded.name,
+                    workspace_id = excluded.workspace_id`,
+                [folder.id, JSON.stringify(folder), folder.name, folder.workspaceId],
+            )
+        }
+    }
+
+    async deleteFolders(folderIds: string[]): Promise<void> {
+        for (const id of folderIds) {
+            await this.db.execute('DELETE FROM folders WHERE id = ?', [id])
+        }
+    }
+
+    async listProjects(): Promise<Project[]> {
+        const rows = await this.db.query('SELECT data FROM projects ORDER BY rowid ASC')
+        return rows.map((row) => parseData<Project>(row))
+    }
+
+    async getProject(projectId: string): Promise<Project | null> {
+        const row = await this.db.first('SELECT data FROM projects WHERE id = ? LIMIT 1', [
+            projectId,
+        ])
+        return row ? parseData<Project>(row) : null
+    }
+
+    async listSections(projectId?: string): Promise<Section[]> {
+        const rows = projectId
+            ? await this.db.query(
+                  'SELECT data FROM sections WHERE project_id = ? ORDER BY section_order ASC, rowid ASC',
+                  [projectId],
+              )
+            : await this.db.query('SELECT data FROM sections ORDER BY section_order ASC, rowid ASC')
+        return rows.map((row) => parseData<Section>(row))
+    }
+
+    async listLabels(): Promise<Label[]> {
+        const rows = await this.db.query('SELECT data FROM labels ORDER BY name COLLATE NOCASE ASC')
+        return rows.map((row) => parseData<Label>(row))
+    }
+
+    async getLabel(labelId: string): Promise<Label | null> {
+        const row = await this.db.first('SELECT data FROM labels WHERE id = ? LIMIT 1', [labelId])
+        return row ? parseData<Label>(row) : null
+    }
+
+    async listUsers(): Promise<CachedUser[]> {
+        const rows = await this.db.query('SELECT data FROM users ORDER BY rowid ASC')
+        return rows.map((row) => parseData<CachedUser>(row))
+    }
+
+    async getUser(userId: string): Promise<CachedUser | null> {
+        const row = await this.db.first('SELECT data FROM users WHERE id = ? LIMIT 1', [userId])
+        return row ? parseData<CachedUser>(row) : null
+    }
+
+    async listFilters(): Promise<Filter[]> {
+        const rows = await this.db.query(
+            'SELECT data FROM filters WHERE is_deleted = 0 ORDER BY name COLLATE NOCASE ASC',
+        )
+        return rows.map((row) => parseData<Filter>(row))
+    }
+
+    async getFilter(filterId: string): Promise<Filter | null> {
+        const row = await this.db.first('SELECT data FROM filters WHERE id = ? LIMIT 1', [filterId])
+        return row ? parseData<Filter>(row) : null
+    }
+
+    async listWorkspaces(): Promise<Workspace[]> {
+        const rows = await this.db.query(
+            'SELECT data FROM workspaces ORDER BY name COLLATE NOCASE ASC',
+        )
+        return rows.map((row) => parseData<Workspace>(row))
+    }
+
+    async listFolders(workspaceId?: string): Promise<WorkspaceFolder[]> {
+        const rows = workspaceId
+            ? await this.db.query(
+                  'SELECT data FROM folders WHERE workspace_id = ? ORDER BY name COLLATE NOCASE ASC',
+                  [workspaceId],
+              )
+            : await this.db.query('SELECT data FROM folders ORDER BY name COLLATE NOCASE ASC')
+        return rows.map((row) => parseData<WorkspaceFolder>(row))
+    }
+
+    async getTask(taskId: string): Promise<Task | null> {
+        const row = await this.db.first('SELECT data FROM tasks WHERE id = ? LIMIT 1', [taskId])
+        return row ? parseData<Task>(row) : null
+    }
+
+    async listTasks(includeCompleted = false): Promise<Task[]> {
+        const rows = includeCompleted
+            ? await this.db.query('SELECT data FROM tasks ORDER BY rowid ASC')
+            : await this.db.query('SELECT data FROM tasks WHERE checked = 0 ORDER BY rowid ASC')
+        return rows.map((row) => parseData<Task>(row))
+    }
+
+    async queryTasks(options: LocalTaskQuery): Promise<LocalPaginatedResult<Task>> {
+        let tasks = await this.listTasks(options.includeCompleted ?? false)
+
+        if (options.projectId) {
+            tasks = tasks.filter((task) => task.projectId === options.projectId)
+        }
+
+        if (options.parentId !== undefined) {
+            tasks = tasks.filter((task) => (task.parentId ?? null) === (options.parentId ?? null))
+        }
+
+        if (options.priority !== undefined) {
+            tasks = tasks.filter((task) => task.priority === options.priority)
+        }
+
+        if (options.due) {
+            const today = new Date().toISOString().split('T')[0]
+            if (options.due === 'today') {
+                tasks = tasks.filter((task) => dateOnly(task.due?.date) === today)
+            } else if (options.due === 'overdue') {
+                tasks = tasks.filter((task) => {
+                    const taskDate = dateOnly(task.due?.date)
+                    return Boolean(taskDate && taskDate < today)
+                })
+            } else {
+                tasks = tasks.filter((task) => dateOnly(task.due?.date) === options.due)
+            }
+        }
+
+        if (options.labels && options.labels.length > 0) {
+            const needles = new Set(options.labels.map((label) => label.toLowerCase()))
+            tasks = tasks.filter((task) =>
+                task.labels.some((label) => needles.has(label.toLowerCase())),
+            )
+        }
+
+        if (options.assigneeId) {
+            tasks = tasks.filter((task) => task.responsibleUid === options.assigneeId)
+        }
+
+        if (options.unassigned) {
+            tasks = tasks.filter((task) => !task.responsibleUid)
+        }
+
+        if (options.workspaceId || options.personal) {
+            const rows = await this.db.query('SELECT id, workspace_id FROM projects')
+            const projectWorkspace = new Map<string, string | null>()
+            for (const row of rows) {
+                const id = String(row.id)
+                const workspaceId = row.workspace_id == null ? null : String(row.workspace_id)
+                projectWorkspace.set(id, workspaceId)
+            }
+            if (options.workspaceId) {
+                tasks = tasks.filter(
+                    (task) => projectWorkspace.get(task.projectId) === options.workspaceId,
+                )
+            } else if (options.personal) {
+                tasks = tasks.filter((task) => !projectWorkspace.get(task.projectId))
+            }
+        }
+
+        const start = parseLocalCursor(options.cursor)
+        const end = start + options.limit
+        const paged = tasks.slice(start, end)
+        const nextCursor = end < tasks.length ? formatLocalCursor(end) : null
+        return { results: paged, nextCursor }
+    }
+
+    async replaceWorkspaceUsers(workspaceId: string, users: WorkspaceUserRecord[]): Promise<void> {
+        await this.db.execute('DELETE FROM workspace_users WHERE workspace_id = ?', [workspaceId])
+        const timestamp = new Date().toISOString()
+        for (const user of users) {
+            await this.db.execute(
+                `INSERT INTO workspace_users(workspace_id, user_id, data, name, email, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?)`,
+                [workspaceId, user.id, JSON.stringify(user), user.name, user.email, timestamp],
+            )
+        }
+    }
+
+    async getWorkspaceUsers(
+        workspaceId: string,
+        maxAgeSeconds: number,
+    ): Promise<WorkspaceUserRecord[] | null> {
+        const rows = await this.db.query(
+            'SELECT user_id, name, email, updated_at FROM workspace_users WHERE workspace_id = ? ORDER BY rowid ASC',
+            [workspaceId],
+        )
+        if (rows.length === 0) return null
+
+        const updatedAt = typeof rows[0].updated_at === 'string' ? rows[0].updated_at : null
+        if (!updatedAt) return null
+        const ageMs = Date.now() - Date.parse(updatedAt)
+        if (!Number.isFinite(ageMs) || ageMs > maxAgeSeconds * 1000) {
+            return null
+        }
+
+        return rows.map((row) => ({
+            id: String(row.user_id),
+            name: String(row.name),
+            email: String(row.email),
+        }))
+    }
+
+    async replaceProjectCollaborators(
+        projectId: string,
+        collaborators: ProjectCollaboratorRecord[],
+    ): Promise<void> {
+        await this.db.execute('DELETE FROM project_collaborators WHERE project_id = ?', [projectId])
+        const timestamp = new Date().toISOString()
+        for (const collaborator of collaborators) {
+            await this.db.execute(
+                `INSERT INTO project_collaborators(project_id, user_id, data, name, email, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?)`,
+                [
+                    projectId,
+                    collaborator.id,
+                    JSON.stringify(collaborator),
+                    collaborator.name,
+                    collaborator.email,
+                    timestamp,
+                ],
+            )
+        }
+    }
+
+    async getProjectCollaborators(
+        projectId: string,
+        maxAgeSeconds: number,
+    ): Promise<ProjectCollaboratorRecord[] | null> {
+        const rows = await this.db.query(
+            'SELECT user_id, name, email, updated_at FROM project_collaborators WHERE project_id = ? ORDER BY rowid ASC',
+            [projectId],
+        )
+        if (rows.length === 0) return null
+
+        const updatedAt = typeof rows[0].updated_at === 'string' ? rows[0].updated_at : null
+        if (!updatedAt) return null
+        const ageMs = Date.now() - Date.parse(updatedAt)
+        if (!Number.isFinite(ageMs) || ageMs > maxAgeSeconds * 1000) {
+            return null
+        }
+
+        return rows.map((row) => ({
+            id: String(row.user_id),
+            name: String(row.name),
+            email: String(row.email),
+        }))
+    }
+}

--- a/src/lib/sync/types.ts
+++ b/src/lib/sync/types.ts
@@ -1,0 +1,82 @@
+import type { Label, Task } from '@doist/todoist-api-typescript'
+import type { Project, Section } from '../api/core.js'
+import type { Filter } from '../api/filters.js'
+import type { Workspace, WorkspaceFolder } from '../api/workspaces.js'
+
+export const CORE_SYNC_RESOURCES = [
+    'items',
+    'projects',
+    'sections',
+    'labels',
+    'users',
+    'filters',
+    'workspaces',
+    'folders',
+] as const
+
+export type CoreSyncResource = (typeof CORE_SYNC_RESOURCES)[number]
+export type SyncResource = CoreSyncResource | 'workspace_users' | 'project_collaborators'
+
+export interface LocalPaginatedResult<T> {
+    results: T[]
+    nextCursor: string | null
+}
+
+export interface LocalTaskQuery {
+    projectId?: string | null
+    parentId?: string | null
+    priority?: number
+    due?: string
+    labels?: string[]
+    assigneeId?: string
+    unassigned?: boolean
+    workspaceId?: string
+    personal?: boolean
+    includeCompleted?: boolean
+    limit: number
+    cursor?: string
+}
+
+export interface WorkspaceUserRecord {
+    id: string
+    name: string
+    email: string
+}
+
+export interface ProjectCollaboratorRecord {
+    id: string
+    name: string
+    email: string
+}
+
+export interface SyncDeltaPayload {
+    sync_token?: string
+    full_sync?: boolean
+    items?: Array<Record<string, unknown>>
+    projects?: Array<Record<string, unknown>>
+    sections?: Array<Record<string, unknown>>
+    labels?: Array<Record<string, unknown>>
+    users?: Array<Record<string, unknown>>
+    filters?: Array<Record<string, unknown>>
+    workspaces?: Array<Record<string, unknown>>
+    folders?: Array<Record<string, unknown>>
+    error?: string
+}
+
+export interface CachedUser {
+    id: string
+    email: string
+    name?: string
+    fullName?: string
+    inboxProjectId?: string
+}
+
+export type CachedEntity =
+    | { resource: 'items'; value: Task }
+    | { resource: 'projects'; value: Project }
+    | { resource: 'sections'; value: Section }
+    | { resource: 'labels'; value: Label }
+    | { resource: 'users'; value: CachedUser }
+    | { resource: 'filters'; value: Filter }
+    | { resource: 'workspaces'; value: Workspace }
+    | { resource: 'folders'; value: WorkspaceFolder }


### PR DESCRIPTION
Following up from https://github.com/Doist/todoist-cli/issues/80, I wanted to raise a concrete performance topic.

I really like the CLI, but command latency in normal usage feels high for repeated read-heavy flows (today, upcoming, inbox, task list/view, etc.).

I know the project is relatively new, and this might already be on the roadmap (or maybe intentionally out of scope for now). I’m not sure, so I wanted to open this as a focused discussion.
Problem

Current read paths are mostly network-first, so repeated commands repeatedly pay API latency even when data has only minimally changed.

From a UX perspective, this feels especially noticeable for agent workflows and frequent shell usage.
Simple Proposal (for discussion)

Introduce a local SQLite sync cache as a practical phase-1 approach:

    local cache file (e.g. ~/.config/todoist-cli/cache.db)
    Todoist Sync API delta token flow (sync_token)
    TTL-based auto refresh (e.g. default 60s)
    local-first reads for structured list/view/ref paths
    mark resources dirty after writes, refresh on next read
    stale-cache fallback if network fails and snapshot exists
    no offline write queue in phase 1

There are definitely more advanced architectures, but this is intentionally the simplest thing that could improve responsiveness and be easy to reason about.
Benchmark Script + Results

I added a warm-cache benchmark script in a working branch to make this concrete:

    scripts/benchmark-sync-cache-warm.mjs

It uses a persistent pre-warmed DB and compares:

    sync_off: TD_SYNC_DISABLE=1
    sync_on_warm: sync enabled with persistent DB

Recent run (5x avg per command):

    today --json: 44.9% faster (1637.4ms -> 901.8ms)
    upcoming --json: 30.3% faster (1441.4ms -> 1004.6ms)
    inbox --json --limit 50: 44.3% faster (1135.4ms -> 632.8ms)
    task list --json --limit 50: 71.1% faster (891.2ms -> 257.6ms)
    task view id:<task> --json: 60.4% faster (654.4ms -> 259.4ms)
    task list --project id:<project> --json --limit 50: 75.9% faster (1082.6ms -> 260.6ms)
    project view id:<project> --json: 61.4% faster (687.8ms -> 265.8ms)
    filter list --json: 62.4% faster (685.2ms -> 257.8ms)

Known Gaps / Risks

    Some local list paths still have ordering/cursor differences vs network responses
    cold-start sync remains slower than warm steady-state
    this phase does not address offline mutation conflict resolution

Questions for Maintainers

    Is a local sync cache direction acceptable for this CLI?
    If yes, what constraints should guide it (scope, consistency guarantees, config surface)?
    If no, is there another preferred path for improving command responsiveness?

Happy to adapt to maintainers’ preferred direction.