### PR TITLE
feat: replace OAuth page logo with td-cli icon

### DIFF
--- a/src/lib/oauth-server.ts
+++ b/src/lib/oauth-server.ts
@@ -77,7 +77,7 @@ const SUCCESS_HTML = `
         .logo-wrap svg {
             width: 100%;
             height: 100%;
-            filter: drop-shadow(0 4px 12px rgba(228, 67, 50, 0.2));
+            filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.15));
         }
         .badge {
             position: absolute;
@@ -234,11 +234,151 @@ const SUCCESS_HTML = `
     <div class="container">
         <header class="header">
             <div class="logo-wrap">
-                <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path fill-rule="evenodd" clip-rule="evenodd" d="M4 0H28C30.2 0 32 1.8 32 4V28C32 30.2 30.2 32 28 32H4C1.8 32 0 30.2 0 28V22.626L.057 22.659C1.422 23.454 4.649 25.333 5.439 25.779C5.917 26.049 6.375 26.043 6.836 25.777C7.112 25.618 10.138 23.876 13.196 22.116L13.271 22.073C16.453 20.242 19.645 18.405 19.786 18.324C20.063 18.164 20.077 17.673 19.767 17.496L19.549 17.372C19.232 17.191 18.822 16.958 18.648 16.855C18.425 16.725 18.023 16.653 17.65 16.867C17.496 16.956 7.149 22.906 6.803 23.102C6.389 23.338 5.877 23.341 5.465 23.102C5.139 22.913 0 19.927 0 19.927V17.234L.057 17.267C1.422 18.062 4.649 19.941 5.439 20.387C5.917 20.657 6.375 20.651 6.836 20.385C7.113 20.226 10.143 18.482 13.203 16.721L13.257 16.69C16.443 14.856 19.645 13.013 19.786 12.932C20.063 12.772 20.077 12.281 19.767 12.104L19.55 11.98C19.233 11.8 18.823 11.566 18.648 11.463C18.425 11.333 18.023 11.261 17.65 11.475C17.496 11.565 7.149 17.514 6.803 17.71C6.389 17.946 5.877 17.949 5.465 17.71C5.139 17.521 0 14.536 0 14.536V11.843L.056 11.875C1.421 12.67 4.648 14.549 5.439 14.996C5.917 15.266 6.375 15.259 6.836 14.993C7.113 14.834 10.148 13.087 13.21 11.325L13.218 11.32C16.418 9.479 19.644 7.622 19.786 7.54C20.063 7.38 20.077 6.889 19.767 6.712L19.549 6.588C19.232 6.408 18.823 6.174 18.648 6.072C18.425 5.942 18.023 5.869 17.65 6.084C17.496 6.173 7.149 12.122 6.803 12.319C6.389 12.554 5.877 12.557 5.465 12.318C5.139 12.13 0 9.144 0 9.144V4C0 1.8 1.8 0 4 0Z" fill="#E44232"/>
-                    <path d="M6.836 14.993C7.113 14.834 10.147 13.087 13.21 11.325L13.218 11.32C16.417 9.479 19.644 7.622 19.786 7.54C20.063 7.38 20.077 6.889 19.767 6.712L19.549 6.588C19.233 6.408 18.822 6.174 18.648 6.072C18.424 5.942 18.023 5.869 17.65 6.084C17.496 6.173 7.149 12.122 6.803 12.319C6.389 12.554 5.877 12.557 5.464 12.318C5.139 12.13 0 9.144 0 9.144V11.843L.056 11.875C1.42 12.67 4.648 14.549 5.439 14.996C5.917 15.266 6.375 15.259 6.836 14.993Z" fill="white"/>
-                    <path d="M6.836 20.385C7.112 20.226 10.143 18.482 13.203 16.721L13.227 16.707C16.423 14.867 19.644 13.014 19.786 12.932C20.063 12.772 20.077 12.281 19.767 12.104L19.549 11.98C19.233 11.8 18.822 11.566 18.648 11.463C18.424 11.333 18.023 11.261 17.65 11.475C17.496 11.565 7.149 17.514 6.803 17.71C6.389 17.946 5.877 17.949 5.464 17.71C5.139 17.521 0 14.536 0 14.536V17.234L.057 17.267C1.422 18.062 4.648 19.941 5.439 20.387C5.917 20.657 6.375 20.651 6.836 20.385Z" fill="white"/>
-                    <path d="M13.211 22.108C10.148 23.871 7.113 25.617 6.836 25.777C6.375 26.043 5.917 26.049 5.439 25.779C4.648 25.333 1.421 23.454.057 22.659L0 22.626V19.927C0 19.927 5.139 22.913 5.464 23.102C5.877 23.341 6.389 23.338 6.803 23.102C7.149 22.906 17.496 16.956 17.65 16.867C18.023 16.653 18.424 16.725 18.648 16.855C18.822 16.958 19.233 17.191 19.549 17.372C19.63 17.417 19.704 17.46 19.767 17.496C20.077 17.673 20.063 18.164 19.786 18.324C19.644 18.406 16.412 20.265 13.211 22.108Z" fill="white"/>
+                <svg width="72" height="72" viewBox="0 0 72 72" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <g id="Size=72, Style=Color">
+                    <g id="TD CLI">
+                    <rect x="3" y="3" width="66" height="66" rx="12" fill="#858585"/>
+                    <g id="Terminal" filter="url(#filter0_iiiiiiii_12865_530)">
+                    <rect x="4.83334" y="4.83325" width="62.3333" height="62.3333" rx="11" fill="#60514E"/>
+                    <rect x="4.83334" y="4.83325" width="62.3333" height="62.3333" rx="11" fill="url(#paint0_radial_12865_530)" fill-opacity="0.8"/>
+                    <g id="Todoist">
+                    <g id="Todoist_2" filter="url(#filter1_ddii_12865_530)">
+                    <path d="M29.1253 11.7083C31.6564 11.7084 33.7082 13.7602 33.7083 16.2913V29.1252C33.7082 31.6563 31.6564 33.7081 29.1253 33.7083H16.2914C13.7603 33.7081 11.7085 31.6563 11.7083 29.1252V27.4036C12.622 27.9356 14.866 29.2315 15.4154 29.5442C15.8157 29.772 16.0904 29.751 16.4681 29.5315C16.8554 29.3064 25.0944 24.5485 25.2894 24.4377C25.4588 24.3416 25.5776 23.9887 25.2845 23.8137C25.0737 23.6878 24.6383 23.4429 24.4876 23.3547C24.3343 23.2653 24.0481 23.1825 23.7406 23.3596C23.6294 23.4236 16.6216 27.4727 16.3841 27.6077C16.0999 27.7692 15.7446 27.7608 15.4613 27.5969C15.2376 27.4674 11.7083 25.4299 11.7083 25.4299V23.595C12.6219 24.1269 14.866 25.4228 15.4154 25.7356C15.8158 25.9636 16.0903 25.9433 16.4681 25.7239C16.8555 25.4987 25.0978 20.7379 25.2894 20.6292C25.4587 20.5328 25.5775 20.181 25.2845 20.0061C25.0737 19.8802 24.6383 19.6343 24.4876 19.5461C24.3342 19.4568 24.0479 19.375 23.7406 19.552C23.6251 19.6185 16.624 23.6627 16.3841 23.7991C16.0998 23.9607 15.7446 23.9523 15.4613 23.7883C15.2353 23.6575 11.7083 21.6223 11.7083 21.6223V19.7874C12.6219 20.3193 14.866 21.6152 15.4154 21.928C15.8157 22.1559 16.0904 22.1357 16.4681 21.9163C16.8555 21.6911 25.0978 16.9303 25.2894 16.8215C25.4588 16.7253 25.5775 16.3725 25.2845 16.1975C25.0736 16.0716 24.6382 15.8266 24.4876 15.7385C24.3342 15.6491 24.048 15.5674 23.7406 15.7444C23.6209 15.8133 16.6219 19.8563 16.3841 19.9915C16.0998 20.1531 15.7446 20.1447 15.4613 19.9807C15.2367 19.8507 11.7217 17.8224 11.7083 17.8147V16.2913C11.7085 13.7602 13.7603 11.7084 16.2914 11.7083H29.1253Z" fill="#ED8278"/>
+                    <path d="M29.1253 11.7083C31.6564 11.7084 33.7082 13.7602 33.7083 16.2913V29.1252C33.7082 31.6563 31.6564 33.7081 29.1253 33.7083H16.2914C13.7603 33.7081 11.7085 31.6563 11.7083 29.1252V27.4036C12.622 27.9356 14.866 29.2315 15.4154 29.5442C15.8157 29.772 16.0904 29.751 16.4681 29.5315C16.8554 29.3064 25.0944 24.5485 25.2894 24.4377C25.4588 24.3416 25.5776 23.9887 25.2845 23.8137C25.0737 23.6878 24.6383 23.4429 24.4876 23.3547C24.3343 23.2653 24.0481 23.1825 23.7406 23.3596C23.6294 23.4236 16.6216 27.4727 16.3841 27.6077C16.0999 27.7692 15.7446 27.7608 15.4613 27.5969C15.2376 27.4674 11.7083 25.4299 11.7083 25.4299V23.595C12.6219 24.1269 14.866 25.4228 15.4154 25.7356C15.8158 25.9636 16.0903 25.9433 16.4681 25.7239C16.8555 25.4987 25.0978 20.7379 25.2894 20.6292C25.4587 20.5328 25.5775 20.181 25.2845 20.0061C25.0737 19.8802 24.6383 19.6343 24.4876 19.5461C24.3342 19.4568 24.0479 19.375 23.7406 19.552C23.6251 19.6185 16.624 23.6627 16.3841 23.7991C16.0998 23.9607 15.7446 23.9523 15.4613 23.7883C15.2353 23.6575 11.7083 21.6223 11.7083 21.6223V19.7874C12.6219 20.3193 14.866 21.6152 15.4154 21.928C15.8157 22.1559 16.0904 22.1357 16.4681 21.9163C16.8555 21.6911 25.0978 16.9303 25.2894 16.8215C25.4588 16.7253 25.5775 16.3725 25.2845 16.1975C25.0736 16.0716 24.6382 15.8266 24.4876 15.7385C24.3342 15.6491 24.048 15.5674 23.7406 15.7444C23.6209 15.8133 16.6219 19.8563 16.3841 19.9915C16.0998 20.1531 15.7446 20.1447 15.4613 19.9807C15.2367 19.8507 11.7217 17.8224 11.7083 17.8147V16.2913C11.7085 13.7602 13.7603 11.7084 16.2914 11.7083H29.1253Z" fill="url(#paint1_linear_12865_530)" fill-opacity="0.3" style="mix-blend-mode:color-burn"/>
+                    </g>
+                    <path id="Cutout" fill-rule="evenodd" clip-rule="evenodd" d="M23.7406 23.3603C24.048 23.1833 24.3342 23.265 24.4876 23.3545C24.6382 23.4426 25.0736 23.6875 25.2845 23.8134C25.5776 23.9884 25.4588 24.3413 25.2894 24.4375C25.0978 24.5462 16.8555 29.3071 16.4681 29.5322C16.0905 29.7515 15.8157 29.7718 15.4154 29.5439C14.866 29.2312 12.6219 27.9353 11.7083 27.4033V25.4306C11.7281 25.442 15.2374 27.467 15.4613 27.5966C15.7446 27.7606 16.0998 27.769 16.3841 27.6074C16.6214 27.4725 23.619 23.4303 23.7406 23.3603ZM23.7406 19.5517C24.0481 19.3746 24.3343 19.4574 24.4876 19.5468C24.6383 19.635 25.0736 19.8799 25.2845 20.0058C25.5776 20.1808 25.4588 20.5337 25.2894 20.6298C25.0957 20.7398 16.8555 25.4985 16.4681 25.7236C16.0903 25.9431 15.8157 25.9641 15.4154 25.7363C14.866 25.4236 12.622 24.1277 11.7083 23.5957V21.623C11.7382 21.6402 15.2385 23.6601 15.4613 23.789C15.7446 23.9529 16.0998 23.9613 16.3841 23.7998C16.6216 23.6648 23.6315 19.6146 23.7406 19.5517ZM23.7406 15.7441C24.0482 15.567 24.3343 15.6498 24.4876 15.7392C24.6383 15.8274 25.0737 16.0723 25.2845 16.1982C25.5776 16.3732 25.4588 16.7261 25.2894 16.8222C25.0928 16.9339 16.8554 21.6909 16.4681 21.916C16.0903 22.1355 15.8158 22.1557 15.4154 21.9277C14.8659 21.6149 12.622 20.3201 11.7083 19.788V17.8144C11.7083 17.8144 15.2376 19.8519 15.4613 19.9814C15.7445 20.1452 16.0999 20.1536 16.3841 19.9922C16.6215 19.8572 23.627 15.8095 23.7406 15.7441Z" fill="#57332F"/>
+                    </g>
+                    <g id="Underscore" filter="url(#filter2_ddii_12865_530)">
+                    <rect x="38.0052" y="30.0417" width="17.4167" height="3.66667" rx="1.83333" fill="#ED8278"/>
+                    <rect x="38.0052" y="30.0417" width="17.4167" height="3.66667" rx="1.83333" fill="url(#paint2_linear_12865_530)" fill-opacity="0.3" style="mix-blend-mode:color-burn"/>
+                    </g>
+                    </g>
+                    </g>
+                    </g>
+                    <defs>
+                    <filter id="filter0_iiiiiiii_12865_530" x="4.83334" y="4.83325" width="62.3333" height="62.3333" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+                    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+                    <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset/>
+                    <feGaussianBlur stdDeviation="6.63667"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.94902 0 0 0 0 0.94902 0 0 0 0 0.94902 0 0 0 1 0"/>
+                    <feBlend mode="plus-darker" in2="shape" result="effect1_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset/>
+                    <feGaussianBlur stdDeviation="1.30167"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+                    <feBlend mode="overlay" in2="effect1_innerShadow_12865_530" result="effect2_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feMorphology radius="0.88" operator="dilate" in="SourceAlpha" result="effect3_innerShadow_12865_530"/>
+                    <feOffset dx="-0.88" dy="-0.88"/>
+                    <feGaussianBlur stdDeviation="0.22"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
+                    <feBlend mode="overlay" in2="effect2_innerShadow_12865_530" result="effect3_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feMorphology radius="0.88" operator="dilate" in="SourceAlpha" result="effect4_innerShadow_12865_530"/>
+                    <feOffset dx="-1.68667" dy="-1.68667"/>
+                    <feGaussianBlur stdDeviation="0.22"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.14902 0 0 0 0 0.14902 0 0 0 0 0.14902 0 0 0 1 0"/>
+                    <feBlend mode="plus-lighter" in2="effect3_innerShadow_12865_530" result="effect4_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset dx="-0.22" dy="-0.22"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.45 0"/>
+                    <feBlend mode="normal" in2="effect4_innerShadow_12865_530" result="effect5_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feMorphology radius="0.88" operator="dilate" in="SourceAlpha" result="effect6_innerShadow_12865_530"/>
+                    <feOffset dx="0.88" dy="0.88"/>
+                    <feGaussianBlur stdDeviation="0.22"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
+                    <feBlend mode="overlay" in2="effect5_innerShadow_12865_530" result="effect6_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feMorphology radius="0.88" operator="dilate" in="SourceAlpha" result="effect7_innerShadow_12865_530"/>
+                    <feOffset dx="1.68667" dy="1.68667"/>
+                    <feGaussianBlur stdDeviation="0.22"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.2 0 0 0 0 0.2 0 0 0 0 0.2 0 0 0 1 0"/>
+                    <feBlend mode="plus-lighter" in2="effect6_innerShadow_12865_530" result="effect7_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset dx="0.22" dy="0.22"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.35 0"/>
+                    <feBlend mode="normal" in2="effect7_innerShadow_12865_530" result="effect8_innerShadow_12865_530"/>
+                    </filter>
+                    <filter id="filter1_ddii_12865_530" x="7.12501" y="7.12492" width="31.1667" height="31.1667" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+                    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset/>
+                    <feGaussianBlur stdDeviation="2.29167"/>
+                    <feComposite in2="hardAlpha" operator="out"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.634402 0 0 0 0 0.0791257 0 0 0 0 0.028646 0 0 0 0.7 0"/>
+                    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset/>
+                    <feGaussianBlur stdDeviation="0.916667"/>
+                    <feComposite in2="hardAlpha" operator="out"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.635294 0 0 0 0 0.0781046 0 0 0 0 0.027451 0 0 0 0.8 0"/>
+                    <feBlend mode="normal" in2="effect1_dropShadow_12865_530" result="effect2_dropShadow_12865_530"/>
+                    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_12865_530" result="shape"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset dy="0.458333"/>
+                    <feGaussianBlur stdDeviation="0.229167"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.870968 0 0 0 0 0.649194 0 0 0 0 0.629032 0 0 0 1 0"/>
+                    <feBlend mode="normal" in2="shape" result="effect3_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset dy="-0.458333"/>
+                    <feGaussianBlur stdDeviation="0.229167"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.7728 0 0 0 0 0.199333 0 0 0 0 0.1472 0 0 0 1 0"/>
+                    <feBlend mode="normal" in2="effect3_innerShadow_12865_530" result="effect4_innerShadow_12865_530"/>
+                    </filter>
+                    <filter id="filter2_ddii_12865_530" x="33.4219" y="25.4584" width="26.5833" height="12.8334" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+                    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset/>
+                    <feGaussianBlur stdDeviation="2.29167"/>
+                    <feComposite in2="hardAlpha" operator="out"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.634402 0 0 0 0 0.0791257 0 0 0 0 0.028646 0 0 0 0.7 0"/>
+                    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset/>
+                    <feGaussianBlur stdDeviation="0.916667"/>
+                    <feComposite in2="hardAlpha" operator="out"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.635294 0 0 0 0 0.0781046 0 0 0 0 0.027451 0 0 0 0.8 0"/>
+                    <feBlend mode="normal" in2="effect1_dropShadow_12865_530" result="effect2_dropShadow_12865_530"/>
+                    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_12865_530" result="shape"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset dy="0.458333"/>
+                    <feGaussianBlur stdDeviation="0.229167"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.870968 0 0 0 0 0.649194 0 0 0 0 0.629032 0 0 0 1 0"/>
+                    <feBlend mode="normal" in2="shape" result="effect3_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset dy="-0.458333"/>
+                    <feGaussianBlur stdDeviation="0.229167"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.7728 0 0 0 0 0.199333 0 0 0 0 0.1472 0 0 0 1 0"/>
+                    <feBlend mode="normal" in2="effect3_innerShadow_12865_530" result="effect4_innerShadow_12865_530"/>
+                    </filter>
+                    <radialGradient id="paint0_radial_12865_530" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(36 24.9084) rotate(90) scale(44.8021 44.9389)">
+                    <stop stop-opacity="0"/>
+                    <stop offset="1"/>
+                    </radialGradient>
+                    <linearGradient id="paint1_linear_12865_530" x1="29.3542" y1="14.5728" x2="12.5406" y2="33.7347" gradientUnits="userSpaceOnUse">
+                    <stop stop-color="white"/>
+                    <stop offset="1" stop-color="#330000"/>
+                    </linearGradient>
+                    <linearGradient id="paint2_linear_12865_530" x1="51.0699" y1="30.6131" x2="50.4646" y2="35.1722" gradientUnits="userSpaceOnUse">
+                    <stop stop-color="white"/>
+                    <stop offset="1" stop-color="#330000"/>
+                    </linearGradient>
+                    </defs>
                 </svg>
                 <div class="badge">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
@@ -363,7 +503,7 @@ const ERROR_HTML = (message: string) => `
         .logo svg {
             width: 100%;
             height: 100%;
-            filter: drop-shadow(0 4px 12px rgba(228, 67, 50, 0.2));
+            filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.15));
         }
         .badge {
             position: absolute;
@@ -408,12 +548,152 @@ const ERROR_HTML = (message: string) => `
 <body>
     <div class="container">
         <div class="logo">
-            <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path fill-rule="evenodd" clip-rule="evenodd" d="M4 0H28C30.2 0 32 1.8 32 4V28C32 30.2 30.2 32 28 32H4C1.8 32 0 30.2 0 28V22.626L.057 22.659C1.422 23.454 4.649 25.333 5.439 25.779C5.917 26.049 6.375 26.043 6.836 25.777C7.112 25.618 10.138 23.876 13.196 22.116L13.271 22.073C16.453 20.242 19.645 18.405 19.786 18.324C20.063 18.164 20.077 17.673 19.767 17.496L19.549 17.372C19.232 17.191 18.822 16.958 18.648 16.855C18.425 16.725 18.023 16.653 17.65 16.867C17.496 16.956 7.149 22.906 6.803 23.102C6.389 23.338 5.877 23.341 5.465 23.102C5.139 22.913 0 19.927 0 19.927V17.234L.057 17.267C1.422 18.062 4.649 19.941 5.439 20.387C5.917 20.657 6.375 20.651 6.836 20.385C7.113 20.226 10.143 18.482 13.203 16.721L13.257 16.69C16.443 14.856 19.645 13.013 19.786 12.932C20.063 12.772 20.077 12.281 19.767 12.104L19.55 11.98C19.233 11.8 18.823 11.566 18.648 11.463C18.425 11.333 18.023 11.261 17.65 11.475C17.496 11.565 7.149 17.514 6.803 17.71C6.389 17.946 5.877 17.949 5.465 17.71C5.139 17.521 0 14.536 0 14.536V11.843L.056 11.875C1.421 12.67 4.648 14.549 5.439 14.996C5.917 15.266 6.375 15.259 6.836 14.993C7.113 14.834 10.148 13.087 13.21 11.325L13.218 11.32C16.418 9.479 19.644 7.622 19.786 7.54C20.063 7.38 20.077 6.889 19.767 6.712L19.549 6.588C19.232 6.408 18.823 6.174 18.648 6.072C18.425 5.942 18.023 5.869 17.65 6.084C17.496 6.173 7.149 12.122 6.803 12.319C6.389 12.554 5.877 12.557 5.465 12.318C5.139 12.13 0 9.144 0 9.144V4C0 1.8 1.8 0 4 0Z" fill="#E44232"/>
-                <path d="M6.836 14.993C7.113 14.834 10.147 13.087 13.21 11.325L13.218 11.32C16.417 9.479 19.644 7.622 19.786 7.54C20.063 7.38 20.077 6.889 19.767 6.712L19.549 6.588C19.233 6.408 18.822 6.174 18.648 6.072C18.424 5.942 18.023 5.869 17.65 6.084C17.496 6.173 7.149 12.122 6.803 12.319C6.389 12.554 5.877 12.557 5.464 12.318C5.139 12.13 0 9.144 0 9.144V11.843L.056 11.875C1.42 12.67 4.648 14.549 5.439 14.996C5.917 15.266 6.375 15.259 6.836 14.993Z" fill="white"/>
-                <path d="M6.836 20.385C7.112 20.226 10.143 18.482 13.203 16.721L13.227 16.707C16.423 14.867 19.644 13.014 19.786 12.932C20.063 12.772 20.077 12.281 19.767 12.104L19.549 11.98C19.233 11.8 18.822 11.566 18.648 11.463C18.424 11.333 18.023 11.261 17.65 11.475C17.496 11.565 7.149 17.514 6.803 17.71C6.389 17.946 5.877 17.949 5.464 17.71C5.139 17.521 0 14.536 0 14.536V17.234L.057 17.267C1.422 18.062 4.648 19.941 5.439 20.387C5.917 20.657 6.375 20.651 6.836 20.385Z" fill="white"/>
-                <path d="M13.211 22.108C10.148 23.871 7.113 25.617 6.836 25.777C6.375 26.043 5.917 26.049 5.439 25.779C4.648 25.333 1.421 23.454.057 22.659L0 22.626V19.927C0 19.927 5.139 22.913 5.464 23.102C5.877 23.341 6.389 23.338 6.803 23.102C7.149 22.906 17.496 16.956 17.65 16.867C18.023 16.653 18.424 16.725 18.648 16.855C18.822 16.958 19.233 17.191 19.549 17.372C19.63 17.417 19.704 17.46 19.767 17.496C20.077 17.673 20.063 18.164 19.786 18.324C19.644 18.406 16.412 20.265 13.211 22.108Z" fill="white"/>
-            </svg>
+            <svg width="72" height="72" viewBox="0 0 72 72" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <g id="Size=72, Style=Color">
+                    <g id="TD CLI">
+                    <rect x="3" y="3" width="66" height="66" rx="12" fill="#858585"/>
+                    <g id="Terminal" filter="url(#filter0_iiiiiiii_12865_530)">
+                    <rect x="4.83334" y="4.83325" width="62.3333" height="62.3333" rx="11" fill="#60514E"/>
+                    <rect x="4.83334" y="4.83325" width="62.3333" height="62.3333" rx="11" fill="url(#paint0_radial_12865_530)" fill-opacity="0.8"/>
+                    <g id="Todoist">
+                    <g id="Todoist_2" filter="url(#filter1_ddii_12865_530)">
+                    <path d="M29.1253 11.7083C31.6564 11.7084 33.7082 13.7602 33.7083 16.2913V29.1252C33.7082 31.6563 31.6564 33.7081 29.1253 33.7083H16.2914C13.7603 33.7081 11.7085 31.6563 11.7083 29.1252V27.4036C12.622 27.9356 14.866 29.2315 15.4154 29.5442C15.8157 29.772 16.0904 29.751 16.4681 29.5315C16.8554 29.3064 25.0944 24.5485 25.2894 24.4377C25.4588 24.3416 25.5776 23.9887 25.2845 23.8137C25.0737 23.6878 24.6383 23.4429 24.4876 23.3547C24.3343 23.2653 24.0481 23.1825 23.7406 23.3596C23.6294 23.4236 16.6216 27.4727 16.3841 27.6077C16.0999 27.7692 15.7446 27.7608 15.4613 27.5969C15.2376 27.4674 11.7083 25.4299 11.7083 25.4299V23.595C12.6219 24.1269 14.866 25.4228 15.4154 25.7356C15.8158 25.9636 16.0903 25.9433 16.4681 25.7239C16.8555 25.4987 25.0978 20.7379 25.2894 20.6292C25.4587 20.5328 25.5775 20.181 25.2845 20.0061C25.0737 19.8802 24.6383 19.6343 24.4876 19.5461C24.3342 19.4568 24.0479 19.375 23.7406 19.552C23.6251 19.6185 16.624 23.6627 16.3841 23.7991C16.0998 23.9607 15.7446 23.9523 15.4613 23.7883C15.2353 23.6575 11.7083 21.6223 11.7083 21.6223V19.7874C12.6219 20.3193 14.866 21.6152 15.4154 21.928C15.8157 22.1559 16.0904 22.1357 16.4681 21.9163C16.8555 21.6911 25.0978 16.9303 25.2894 16.8215C25.4588 16.7253 25.5775 16.3725 25.2845 16.1975C25.0736 16.0716 24.6382 15.8266 24.4876 15.7385C24.3342 15.6491 24.048 15.5674 23.7406 15.7444C23.6209 15.8133 16.6219 19.8563 16.3841 19.9915C16.0998 20.1531 15.7446 20.1447 15.4613 19.9807C15.2367 19.8507 11.7217 17.8224 11.7083 17.8147V16.2913C11.7085 13.7602 13.7603 11.7084 16.2914 11.7083H29.1253Z" fill="#ED8278"/>
+                    <path d="M29.1253 11.7083C31.6564 11.7084 33.7082 13.7602 33.7083 16.2913V29.1252C33.7082 31.6563 31.6564 33.7081 29.1253 33.7083H16.2914C13.7603 33.7081 11.7085 31.6563 11.7083 29.1252V27.4036C12.622 27.9356 14.866 29.2315 15.4154 29.5442C15.8157 29.772 16.0904 29.751 16.4681 29.5315C16.8554 29.3064 25.0944 24.5485 25.2894 24.4377C25.4588 24.3416 25.5776 23.9887 25.2845 23.8137C25.0737 23.6878 24.6383 23.4429 24.4876 23.3547C24.3343 23.2653 24.0481 23.1825 23.7406 23.3596C23.6294 23.4236 16.6216 27.4727 16.3841 27.6077C16.0999 27.7692 15.7446 27.7608 15.4613 27.5969C15.2376 27.4674 11.7083 25.4299 11.7083 25.4299V23.595C12.6219 24.1269 14.866 25.4228 15.4154 25.7356C15.8158 25.9636 16.0903 25.9433 16.4681 25.7239C16.8555 25.4987 25.0978 20.7379 25.2894 20.6292C25.4587 20.5328 25.5775 20.181 25.2845 20.0061C25.0737 19.8802 24.6383 19.6343 24.4876 19.5461C24.3342 19.4568 24.0479 19.375 23.7406 19.552C23.6251 19.6185 16.624 23.6627 16.3841 23.7991C16.0998 23.9607 15.7446 23.9523 15.4613 23.7883C15.2353 23.6575 11.7083 21.6223 11.7083 21.6223V19.7874C12.6219 20.3193 14.866 21.6152 15.4154 21.928C15.8157 22.1559 16.0904 22.1357 16.4681 21.9163C16.8555 21.6911 25.0978 16.9303 25.2894 16.8215C25.4588 16.7253 25.5775 16.3725 25.2845 16.1975C25.0736 16.0716 24.6382 15.8266 24.4876 15.7385C24.3342 15.6491 24.048 15.5674 23.7406 15.7444C23.6209 15.8133 16.6219 19.8563 16.3841 19.9915C16.0998 20.1531 15.7446 20.1447 15.4613 19.9807C15.2367 19.8507 11.7217 17.8224 11.7083 17.8147V16.2913C11.7085 13.7602 13.7603 11.7084 16.2914 11.7083H29.1253Z" fill="url(#paint1_linear_12865_530)" fill-opacity="0.3" style="mix-blend-mode:color-burn"/>
+                    </g>
+                    <path id="Cutout" fill-rule="evenodd" clip-rule="evenodd" d="M23.7406 23.3603C24.048 23.1833 24.3342 23.265 24.4876 23.3545C24.6382 23.4426 25.0736 23.6875 25.2845 23.8134C25.5776 23.9884 25.4588 24.3413 25.2894 24.4375C25.0978 24.5462 16.8555 29.3071 16.4681 29.5322C16.0905 29.7515 15.8157 29.7718 15.4154 29.5439C14.866 29.2312 12.6219 27.9353 11.7083 27.4033V25.4306C11.7281 25.442 15.2374 27.467 15.4613 27.5966C15.7446 27.7606 16.0998 27.769 16.3841 27.6074C16.6214 27.4725 23.619 23.4303 23.7406 23.3603ZM23.7406 19.5517C24.0481 19.3746 24.3343 19.4574 24.4876 19.5468C24.6383 19.635 25.0736 19.8799 25.2845 20.0058C25.5776 20.1808 25.4588 20.5337 25.2894 20.6298C25.0957 20.7398 16.8555 25.4985 16.4681 25.7236C16.0903 25.9431 15.8157 25.9641 15.4154 25.7363C14.866 25.4236 12.622 24.1277 11.7083 23.5957V21.623C11.7382 21.6402 15.2385 23.6601 15.4613 23.789C15.7446 23.9529 16.0998 23.9613 16.3841 23.7998C16.6216 23.6648 23.6315 19.6146 23.7406 19.5517ZM23.7406 15.7441C24.0482 15.567 24.3343 15.6498 24.4876 15.7392C24.6383 15.8274 25.0737 16.0723 25.2845 16.1982C25.5776 16.3732 25.4588 16.7261 25.2894 16.8222C25.0928 16.9339 16.8554 21.6909 16.4681 21.916C16.0903 22.1355 15.8158 22.1557 15.4154 21.9277C14.8659 21.6149 12.622 20.3201 11.7083 19.788V17.8144C11.7083 17.8144 15.2376 19.8519 15.4613 19.9814C15.7445 20.1452 16.0999 20.1536 16.3841 19.9922C16.6215 19.8572 23.627 15.8095 23.7406 15.7441Z" fill="#57332F"/>
+                    </g>
+                    <g id="Underscore" filter="url(#filter2_ddii_12865_530)">
+                    <rect x="38.0052" y="30.0417" width="17.4167" height="3.66667" rx="1.83333" fill="#ED8278"/>
+                    <rect x="38.0052" y="30.0417" width="17.4167" height="3.66667" rx="1.83333" fill="url(#paint2_linear_12865_530)" fill-opacity="0.3" style="mix-blend-mode:color-burn"/>
+                    </g>
+                    </g>
+                    </g>
+                    </g>
+                    <defs>
+                    <filter id="filter0_iiiiiiii_12865_530" x="4.83334" y="4.83325" width="62.3333" height="62.3333" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+                    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+                    <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset/>
+                    <feGaussianBlur stdDeviation="6.63667"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.94902 0 0 0 0 0.94902 0 0 0 0 0.94902 0 0 0 1 0"/>
+                    <feBlend mode="plus-darker" in2="shape" result="effect1_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset/>
+                    <feGaussianBlur stdDeviation="1.30167"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+                    <feBlend mode="overlay" in2="effect1_innerShadow_12865_530" result="effect2_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feMorphology radius="0.88" operator="dilate" in="SourceAlpha" result="effect3_innerShadow_12865_530"/>
+                    <feOffset dx="-0.88" dy="-0.88"/>
+                    <feGaussianBlur stdDeviation="0.22"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
+                    <feBlend mode="overlay" in2="effect2_innerShadow_12865_530" result="effect3_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feMorphology radius="0.88" operator="dilate" in="SourceAlpha" result="effect4_innerShadow_12865_530"/>
+                    <feOffset dx="-1.68667" dy="-1.68667"/>
+                    <feGaussianBlur stdDeviation="0.22"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.14902 0 0 0 0 0.14902 0 0 0 0 0.14902 0 0 0 1 0"/>
+                    <feBlend mode="plus-lighter" in2="effect3_innerShadow_12865_530" result="effect4_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset dx="-0.22" dy="-0.22"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.45 0"/>
+                    <feBlend mode="normal" in2="effect4_innerShadow_12865_530" result="effect5_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feMorphology radius="0.88" operator="dilate" in="SourceAlpha" result="effect6_innerShadow_12865_530"/>
+                    <feOffset dx="0.88" dy="0.88"/>
+                    <feGaussianBlur stdDeviation="0.22"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
+                    <feBlend mode="overlay" in2="effect5_innerShadow_12865_530" result="effect6_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feMorphology radius="0.88" operator="dilate" in="SourceAlpha" result="effect7_innerShadow_12865_530"/>
+                    <feOffset dx="1.68667" dy="1.68667"/>
+                    <feGaussianBlur stdDeviation="0.22"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.2 0 0 0 0 0.2 0 0 0 0 0.2 0 0 0 1 0"/>
+                    <feBlend mode="plus-lighter" in2="effect6_innerShadow_12865_530" result="effect7_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset dx="0.22" dy="0.22"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.35 0"/>
+                    <feBlend mode="normal" in2="effect7_innerShadow_12865_530" result="effect8_innerShadow_12865_530"/>
+                    </filter>
+                    <filter id="filter1_ddii_12865_530" x="7.12501" y="7.12492" width="31.1667" height="31.1667" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+                    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset/>
+                    <feGaussianBlur stdDeviation="2.29167"/>
+                    <feComposite in2="hardAlpha" operator="out"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.634402 0 0 0 0 0.0791257 0 0 0 0 0.028646 0 0 0 0.7 0"/>
+                    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset/>
+                    <feGaussianBlur stdDeviation="0.916667"/>
+                    <feComposite in2="hardAlpha" operator="out"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.635294 0 0 0 0 0.0781046 0 0 0 0 0.027451 0 0 0 0.8 0"/>
+                    <feBlend mode="normal" in2="effect1_dropShadow_12865_530" result="effect2_dropShadow_12865_530"/>
+                    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_12865_530" result="shape"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset dy="0.458333"/>
+                    <feGaussianBlur stdDeviation="0.229167"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.870968 0 0 0 0 0.649194 0 0 0 0 0.629032 0 0 0 1 0"/>
+                    <feBlend mode="normal" in2="shape" result="effect3_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset dy="-0.458333"/>
+                    <feGaussianBlur stdDeviation="0.229167"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.7728 0 0 0 0 0.199333 0 0 0 0 0.1472 0 0 0 1 0"/>
+                    <feBlend mode="normal" in2="effect3_innerShadow_12865_530" result="effect4_innerShadow_12865_530"/>
+                    </filter>
+                    <filter id="filter2_ddii_12865_530" x="33.4219" y="25.4584" width="26.5833" height="12.8334" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+                    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset/>
+                    <feGaussianBlur stdDeviation="2.29167"/>
+                    <feComposite in2="hardAlpha" operator="out"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.634402 0 0 0 0 0.0791257 0 0 0 0 0.028646 0 0 0 0.7 0"/>
+                    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset/>
+                    <feGaussianBlur stdDeviation="0.916667"/>
+                    <feComposite in2="hardAlpha" operator="out"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.635294 0 0 0 0 0.0781046 0 0 0 0 0.027451 0 0 0 0.8 0"/>
+                    <feBlend mode="normal" in2="effect1_dropShadow_12865_530" result="effect2_dropShadow_12865_530"/>
+                    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_12865_530" result="shape"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset dy="0.458333"/>
+                    <feGaussianBlur stdDeviation="0.229167"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.870968 0 0 0 0 0.649194 0 0 0 0 0.629032 0 0 0 1 0"/>
+                    <feBlend mode="normal" in2="shape" result="effect3_innerShadow_12865_530"/>
+                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+                    <feOffset dy="-0.458333"/>
+                    <feGaussianBlur stdDeviation="0.229167"/>
+                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+                    <feColorMatrix type="matrix" values="0 0 0 0 0.7728 0 0 0 0 0.199333 0 0 0 0 0.1472 0 0 0 1 0"/>
+                    <feBlend mode="normal" in2="effect3_innerShadow_12865_530" result="effect4_innerShadow_12865_530"/>
+                    </filter>
+                    <radialGradient id="paint0_radial_12865_530" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(36 24.9084) rotate(90) scale(44.8021 44.9389)">
+                    <stop stop-opacity="0"/>
+                    <stop offset="1"/>
+                    </radialGradient>
+                    <linearGradient id="paint1_linear_12865_530" x1="29.3542" y1="14.5728" x2="12.5406" y2="33.7347" gradientUnits="userSpaceOnUse">
+                    <stop stop-color="white"/>
+                    <stop offset="1" stop-color="#330000"/>
+                    </linearGradient>
+                    <linearGradient id="paint2_linear_12865_530" x1="51.0699" y1="30.6131" x2="50.4646" y2="35.1722" gradientUnits="userSpaceOnUse">
+                    <stop stop-color="white"/>
+                    <stop offset="1" stop-color="#330000"/>
+                    </linearGradient>
+                    </defs>
+                </svg>
             <div class="badge">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round">
                     <line x1="18" y1="6" x2="6" y2="18"/>


### PR DESCRIPTION
## Summary
- Replace the standard Todoist app icon on OAuth callback pages (success and error) with the new `td-cli.svg` branding icon
- Update CSS drop-shadow color from red-tinted to neutral to match the dark brown icon background

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (926 tests)
- [ ] Visually verify by running `td auth login` in a test environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)