### PR TITLE
feat: suppress package manager output during update

### DIFF
--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -52,6 +52,9 @@ function mockFetchNetworkError(message: string) {
 
 function mockSpawnSuccess() {
     mockSpawn.mockReturnValue({
+        stderr: {
+            on: vi.fn(),
+        },
         on: vi.fn((event: string, cb: (arg?: unknown) => void) => {
             if (event === 'close') cb(0)
         }),
@@ -60,6 +63,9 @@ function mockSpawnSuccess() {
 
 function mockSpawnFailure(exitCode: number) {
     mockSpawn.mockReturnValue({
+        stderr: {
+            on: vi.fn(),
+        },
         on: vi.fn((event: string, cb: (arg?: unknown) => void) => {
             if (event === 'close') cb(exitCode)
         }),
@@ -68,6 +74,9 @@ function mockSpawnFailure(exitCode: number) {
 
 function mockSpawnPermissionError() {
     mockSpawn.mockReturnValue({
+        stderr: {
+            on: vi.fn(),
+        },
         on: vi.fn((event: string, cb: (arg?: unknown) => void) => {
             if (event === 'error') {
                 const err = Object.assign(new Error('EACCES'), { code: 'EACCES' })
@@ -150,7 +159,7 @@ describe('update command', () => {
             expect(mockSpawn).toHaveBeenCalledWith(
                 'npm',
                 ['install', '-g', '@doist/todoist-cli@latest'],
-                { stdio: 'inherit' },
+                { stdio: 'pipe' },
             )
             expect(consoleSpy).toHaveBeenCalledWith(
                 expect.anything(),
@@ -169,7 +178,7 @@ describe('update command', () => {
             expect(mockSpawn).toHaveBeenCalledWith(
                 'pnpm',
                 ['add', '-g', '@doist/todoist-cli@latest'],
-                { stdio: 'inherit' },
+                { stdio: 'pipe' },
             )
         })
     })


### PR DESCRIPTION
## Summary
- Suppress npm/pnpm stdout/stderr during `td update` by switching from `stdio: 'inherit'` to `stdio: 'pipe'`
- Wrap the install step in a spinner ("Updating to vX.Y.Z...") for a clean terminal experience
- Surface captured stderr only on failure, so users still get useful error context

## Test plan
- [x] All existing tests updated and passing (926/926)
- [x] TypeScript type check passes
- [ ] Manual: `td update` when already up-to-date shows clean "Already up to date" message
- [ ] Manual: `td update` when update available shows spinner, no npm output, then "Updated to vX.Y.Z"

🤖 Generated with [Claude Code](https://claude.com/claude-code)