### PR TITLE
fix: address PR #112 review feedback

### DIFF
--- a/src/__tests__/completed.test.ts
+++ b/src/__tests__/completed.test.ts
@@ -312,7 +312,7 @@ describe('completed command', () => {
         expect(mockApi.getWorkspaceUsers).not.toHaveBeenCalled()
     })
 
-    it('includes assigneeName in JSON output', async () => {
+    it('includes responsibleName in JSON output', async () => {
         const program = createProgram()
 
         mockApi.getCompletedTasksByCompletionDate.mockResolvedValue({
@@ -340,6 +340,6 @@ describe('completed command', () => {
 
         const output = consoleSpy.mock.calls[0][0]
         const parsed = JSON.parse(output)
-        expect(parsed.results[0].assigneeName).toBe('Alice S.')
+        expect(parsed.results[0].responsibleName).toBe('Alice S.')
     })
 })

--- a/src/commands/completed.ts
+++ b/src/commands/completed.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import { Command } from 'commander'
-import { getApi, type Project } from '../lib/api/core.js'
+import { getApi, type Project, type Task } from '../lib/api/core.js'
 import { CollaboratorCache, formatAssignee } from '../lib/collaborators.js'
 import {
     formatNextCursorFooter,
@@ -108,7 +108,7 @@ export function registerCompletedCommand(program: Command): void {
             await collaboratorCache.preload(api, tasks, projects)
 
             // Helper to get assignee name for a task
-            const getAssigneeName = (task: (typeof tasks)[0]): string | null => {
+            const getAssigneeName = (task: Task): string | null => {
                 return formatAssignee({
                     userId: task.responsibleUid,
                     projectId: task.projectId,
@@ -120,7 +120,7 @@ export function registerCompletedCommand(program: Command): void {
             if (options.json) {
                 const tasksWithAssignee = tasks.map((task) => ({
                     ...task,
-                    assigneeName: getAssigneeName(task),
+                    responsibleName: getAssigneeName(task),
                 }))
                 console.log(
                     formatPaginatedJson(
@@ -136,7 +136,7 @@ export function registerCompletedCommand(program: Command): void {
             if (options.ndjson) {
                 const tasksWithAssignee = tasks.map((task) => ({
                     ...task,
-                    assigneeName: getAssigneeName(task),
+                    responsibleName: getAssigneeName(task),
                 }))
                 console.log(
                     formatPaginatedNdjson(

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -182,7 +182,7 @@ const TASK_ESSENTIAL_FIELDS = [
     'labels',
     'url',
     'responsibleUid',
-    'assigneeName',
+    'responsibleName',
     'isUncompletable',
 ] as const
 const PROJECT_ESSENTIAL_FIELDS = [


### PR DESCRIPTION
## Summary
- Use `Task` type instead of `(typeof tasks)[0]` for cleaner typing (feedback from @pawelgrimm)
- Rename `assigneeName` to `responsibleName` for consistency with existing `responsibleUid` field (feedback from @pawelgrimm)

Addresses unresolved review comments from #112.

## Test plan
- [x] All 931 tests pass
- [x] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)