### PR TITLE
feat: store auth tokens in OS credential storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ This makes the `td` command available globally.
 td auth login
 ```
 
-This opens your browser to authenticate with Todoist. Once approved, the token is saved automatically.
+This opens your browser to authenticate with Todoist. Once approved, the token is stored in your OS credential manager:
+
+- macOS: Keychain
+- Windows: Credential Manager
+- Linux: Secret Service/libsecret
+
+If secure storage is unavailable, the CLI warns and falls back to `~/.config/todoist-cli/config.json`. Existing plaintext tokens are migrated automatically the next time the CLI reads them successfully from the config file.
 
 ### Alternative methods
 
@@ -45,6 +51,8 @@ td auth token "your-token"
 ```bash
 export TODOIST_API_TOKEN="your-token"
 ```
+
+`TODOIST_API_TOKEN` always takes priority over the stored token.
 
 ### Auth commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@doist/todoist-api-typescript": "6.7.0",
+        "@napi-rs/keyring": "1.2.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
         "commander": "14.0.2",
@@ -515,6 +516,225 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.2.0.tgz",
+      "integrity": "sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.2.0",
+        "@napi-rs/keyring-darwin-x64": "1.2.0",
+        "@napi-rs/keyring-freebsd-x64": "1.2.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.2.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.2.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.2.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.2.0.tgz",
+      "integrity": "sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.2.0.tgz",
+      "integrity": "sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.2.0.tgz",
+      "integrity": "sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.2.0.tgz",
+      "integrity": "sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.2.0.tgz",
+      "integrity": "sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.2.0.tgz",
+      "integrity": "sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.2.0.tgz",
+      "integrity": "sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.2.0.tgz",
+      "integrity": "sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.2.0.tgz",
+      "integrity": "sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.2.0.tgz",
+      "integrity": "sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
       "version": "0.36.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   ],
   "dependencies": {
     "@doist/todoist-api-typescript": "6.7.0",
+    "@napi-rs/keyring": "1.2.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",
     "commander": "14.0.2",
@@ -61,8 +62,8 @@
     "@types/marked-terminal": "6.1.1",
     "@types/node": "25.0.3",
     "lefthook": "1.10.10",
-    "oxlint": "1.51.0",
     "oxfmt": "0.36.0",
+    "oxlint": "1.51.0",
     "typescript": "5.9.3",
     "vitest": "4.0.16"
   }

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -77,14 +77,17 @@ function createProgram() {
 
 describe('auth command', () => {
     let consoleSpy: ReturnType<typeof vi.spyOn>
+    let errorSpy: ReturnType<typeof vi.spyOn>
 
     beforeEach(() => {
         vi.clearAllMocks()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     })
 
     afterEach(() => {
         consoleSpy.mockRestore()
+        errorSpy.mockRestore()
     })
 
     describe('token subcommand', () => {
@@ -92,14 +95,14 @@ describe('auth command', () => {
             const program = createProgram()
             const token = 'some_token_123456789'
 
-            mockSaveApiToken.mockResolvedValue(undefined)
+            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
 
             await program.parseAsync(['node', 'td', 'auth', 'token', token])
 
             expect(mockSaveApiToken).toHaveBeenCalledWith(token)
             expect(consoleSpy).toHaveBeenCalledWith('✓', 'API token saved successfully!')
             expect(consoleSpy).toHaveBeenCalledWith(
-                'Token saved to ~/.config/todoist-cli/config.json',
+                'Token stored securely in the system credential manager',
             )
         })
 
@@ -121,7 +124,7 @@ describe('auth command', () => {
             const tokenWithWhitespace = '  some_token_123456789  '
             const expectedToken = 'some_token_123456789'
 
-            mockSaveApiToken.mockResolvedValue(undefined)
+            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
 
             await program.parseAsync(['node', 'td', 'auth', 'token', tokenWithWhitespace])
 
@@ -138,7 +141,7 @@ describe('auth command', () => {
                 _writeToOutput: vi.fn(),
             }
             mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
-            mockSaveApiToken.mockResolvedValue(undefined)
+            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
             const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
 
             await program.parseAsync(['node', 'td', 'auth', 'token'])
@@ -160,14 +163,51 @@ describe('auth command', () => {
             }
             mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
             const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
-            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
             await program.parseAsync(['node', 'td', 'auth', 'token'])
 
             expect(mockSaveApiToken).not.toHaveBeenCalled()
             expect(errorSpy).toHaveBeenCalledWith('Error:', 'No token provided')
             writeSpy.mockRestore()
-            errorSpy.mockRestore()
+        })
+
+        it('shows a warning when token storage falls back to config', async () => {
+            const program = createProgram()
+            const token = 'some_token_123456789'
+
+            mockSaveApiToken.mockResolvedValue({
+                storage: 'config-file',
+                warning:
+                    'system credential manager unavailable; token saved as plaintext in /tmp/test-config.json',
+            })
+
+            await program.parseAsync(['node', 'td', 'auth', 'token', token])
+
+            expect(errorSpy).toHaveBeenCalledWith(
+                'Warning:',
+                'system credential manager unavailable; token saved as plaintext in /tmp/test-config.json',
+            )
+        })
+
+        it('shows a warning when secure storage succeeds but plaintext cleanup fails', async () => {
+            const program = createProgram()
+            const token = 'some_token_123456789'
+
+            mockSaveApiToken.mockResolvedValue({
+                storage: 'secure-store',
+                warning:
+                    'Token was stored securely, but could not remove legacy plaintext token from /tmp/test-config.json (EACCES)',
+            })
+
+            await program.parseAsync(['node', 'td', 'auth', 'token', token])
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Token stored securely in the system credential manager',
+            )
+            expect(errorSpy).toHaveBeenCalledWith(
+                'Warning:',
+                'Token was stored securely, but could not remove legacy plaintext token from /tmp/test-config.json (EACCES)',
+            )
         })
     })
 
@@ -182,7 +222,7 @@ describe('auth command', () => {
                 cleanup: vi.fn(),
             })
             mockExchangeCodeForToken.mockResolvedValue(accessToken)
-            mockSaveApiToken.mockResolvedValue(undefined)
+            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
             mockOpen.mockResolvedValue({} as Awaited<ReturnType<typeof open>>)
 
             await program.parseAsync(['node', 'td', 'auth', 'login'])
@@ -192,6 +232,9 @@ describe('auth command', () => {
             expect(mockExchangeCodeForToken).toHaveBeenCalledWith(authCode, 'test_code_verifier')
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken)
             expect(consoleSpy).toHaveBeenCalledWith('✓', 'Successfully logged in!')
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Token stored securely in the system credential manager',
+            )
         })
 
         it('handles OAuth callback server error', async () => {
@@ -279,14 +322,14 @@ describe('auth command', () => {
     describe('logout subcommand', () => {
         it('clears the API token', async () => {
             const program = createProgram()
-            mockClearApiToken.mockResolvedValue(undefined)
+            mockClearApiToken.mockResolvedValue({ storage: 'secure-store' })
 
             await program.parseAsync(['node', 'td', 'auth', 'logout'])
 
             expect(mockClearApiToken).toHaveBeenCalled()
             expect(consoleSpy).toHaveBeenCalledWith('✓', 'Logged out')
             expect(consoleSpy).toHaveBeenCalledWith(
-                'Token removed from ~/.config/todoist-cli/config.json',
+                'Stored token removed from the system credential manager',
             )
         })
     })

--- a/src/__tests__/lib-auth.test.ts
+++ b/src/__tests__/lib-auth.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const TEST_HOME = '/tmp/todoist-cli-tests'
+const TEST_CONFIG_PATH = `${TEST_HOME}/.config/todoist-cli/config.json`
+
+interface KeyringState {
+    token: string | null
+    getError?: Error
+    setError?: Error
+    deleteError?: Error
+    getCalls: number
+    service?: string
+    account?: string
+    setCalls: string[]
+    deleteCalls: number
+}
+
+describe('lib/auth', () => {
+    let configContent: string | null
+    let configUnlinkError: Error | null
+    let configWriteError: Error | null
+    let mkdirMock: ReturnType<typeof vi.fn>
+    let readFileMock: ReturnType<typeof vi.fn>
+    let unlinkMock: ReturnType<typeof vi.fn>
+    let writeFileMock: ReturnType<typeof vi.fn>
+    let keyringState: KeyringState
+    let errorSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.resetModules()
+        vi.clearAllMocks()
+        vi.unstubAllEnvs()
+
+        configContent = null
+        configUnlinkError = null
+        configWriteError = null
+        keyringState = {
+            token: null,
+            getCalls: 0,
+            setCalls: [],
+            deleteCalls: 0,
+        }
+
+        mkdirMock = vi.fn().mockResolvedValue(undefined)
+        readFileMock = vi.fn().mockImplementation(async () => {
+            if (configContent === null) {
+                throw createErrnoError('ENOENT')
+            }
+            return configContent
+        })
+        unlinkMock = vi.fn().mockImplementation(async () => {
+            if (configUnlinkError) {
+                throw configUnlinkError
+            }
+            if (configContent === null) {
+                throw createErrnoError('ENOENT')
+            }
+            configContent = null
+        })
+        writeFileMock = vi.fn().mockImplementation(async (_path: string, content: string) => {
+            if (configWriteError) {
+                throw configWriteError
+            }
+            configContent = content
+        })
+
+        vi.doMock('node:os', () => ({
+            homedir: () => TEST_HOME,
+        }))
+
+        vi.doMock('node:fs/promises', () => ({
+            mkdir: mkdirMock,
+            readFile: readFileMock,
+            unlink: unlinkMock,
+            writeFile: writeFileMock,
+        }))
+
+        vi.doMock('@napi-rs/keyring', () => ({
+            AsyncEntry: class {
+                constructor(service: string, account: string) {
+                    keyringState.service = service
+                    keyringState.account = account
+                }
+
+                async getPassword(): Promise<string | null> {
+                    keyringState.getCalls += 1
+                    if (keyringState.getError) {
+                        throw keyringState.getError
+                    }
+                    return keyringState.token
+                }
+
+                async setPassword(password: string): Promise<void> {
+                    if (keyringState.setError) {
+                        throw keyringState.setError
+                    }
+                    keyringState.token = password
+                    keyringState.setCalls.push(password)
+                }
+
+                async deleteCredential(): Promise<boolean> {
+                    if (keyringState.deleteError) {
+                        throw keyringState.deleteError
+                    }
+                    const hadCredential = keyringState.token !== null
+                    keyringState.token = null
+                    keyringState.deleteCalls += 1
+                    return hadCredential
+                }
+            },
+        }))
+
+        errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        errorSpy.mockRestore()
+        vi.unstubAllEnvs()
+    })
+
+    it('prefers TODOIST_API_TOKEN over secure storage and config', async () => {
+        vi.stubEnv('TODOIST_API_TOKEN', 'env-token-123456')
+        keyringState.token = 'secure-token-abcdef'
+        setConfig({ api_token: 'config-token-xyz', currentWorkspace: 'personal' })
+
+        const { getApiToken } = await import('../lib/auth.js')
+
+        await expect(getApiToken()).resolves.toBe('env-token-123456')
+        expect(readFileMock).not.toHaveBeenCalled()
+        expect(keyringState.service).toBeUndefined()
+    })
+
+    it('reads and writes tokens through secure storage when available', async () => {
+        const { clearApiToken, getApiToken, saveApiToken } = await import('../lib/auth.js')
+
+        await expect(saveApiToken('secure-token-123456')).resolves.toEqual({
+            storage: 'secure-store',
+        })
+        expect(keyringState.token).toBe('secure-token-123456')
+        expect(keyringState.service).toBe('todoist-cli')
+        expect(keyringState.account).toBe('api-token')
+
+        await expect(getApiToken()).resolves.toBe('secure-token-123456')
+
+        setConfig({ currentWorkspace: 'work', api_token: 'legacy-token' })
+        await expect(clearApiToken()).resolves.toEqual({ storage: 'secure-store' })
+        expect(keyringState.token).toBeNull()
+        expect(readConfig()).toEqual({ currentWorkspace: 'work' })
+    })
+
+    it('migrates a plaintext config token into secure storage and preserves other config', async () => {
+        setConfig({
+            api_token: 'legacy-token-123456',
+            currentWorkspace: 'team-1',
+            theme: 'compact',
+        })
+
+        const { getApiToken } = await import('../lib/auth.js')
+
+        await expect(getApiToken()).resolves.toBe('legacy-token-123456')
+        expect(keyringState.setCalls).toEqual(['legacy-token-123456'])
+        expect(keyringState.token).toBe('legacy-token-123456')
+        expect(readConfig()).toEqual({
+            currentWorkspace: 'team-1',
+            theme: 'compact',
+        })
+    })
+
+    it('prefers a fallback config token over a stale secure-store token', async () => {
+        keyringState.token = 'stale-secure-token-123456'
+        setConfig({
+            api_token: 'fallback-token-123456',
+            currentWorkspace: 'team-1',
+        })
+
+        const { getApiToken } = await import('../lib/auth.js')
+
+        await expect(getApiToken()).resolves.toBe('fallback-token-123456')
+        expect(keyringState.getCalls).toBe(0)
+        expect(keyringState.setCalls).toEqual(['fallback-token-123456'])
+        expect(keyringState.token).toBe('fallback-token-123456')
+        expect(readConfig()).toEqual({ currentWorkspace: 'team-1' })
+    })
+
+    it('returns the migrated token even when config cleanup fails after secure-store write', async () => {
+        configUnlinkError = new Error('EACCES')
+        setConfig({ api_token: 'legacy-token-123456' })
+
+        const { getApiToken } = await import('../lib/auth.js')
+
+        await expect(getApiToken()).resolves.toBe('legacy-token-123456')
+        expect(keyringState.setCalls).toEqual(['legacy-token-123456'])
+        expect(errorSpy).toHaveBeenCalledWith(
+            `Warning: Token was migrated to secure storage, but could not remove legacy plaintext token from ${TEST_CONFIG_PATH} (EACCES)`,
+        )
+        expect(readConfig()).toEqual({ api_token: 'legacy-token-123456' })
+    })
+
+    it('falls back to plaintext config with a warning when secure storage is unavailable', async () => {
+        keyringState.getError = new Error('Keychain unavailable')
+        keyringState.setError = new Error('Keychain unavailable')
+        keyringState.deleteError = new Error('Keychain unavailable')
+
+        const { clearApiToken, getApiToken, saveApiToken } = await import('../lib/auth.js')
+
+        await expect(saveApiToken('fallback-token-123456')).resolves.toEqual({
+            storage: 'config-file',
+            warning: `system credential manager unavailable; token saved as plaintext in ${TEST_CONFIG_PATH}`,
+        })
+        expect(readConfig()).toEqual({ api_token: 'fallback-token-123456' })
+
+        await expect(getApiToken()).resolves.toBe('fallback-token-123456')
+        expect(errorSpy).toHaveBeenCalledWith(
+            `Warning: system credential manager unavailable; using plaintext token from ${TEST_CONFIG_PATH}`,
+        )
+
+        setConfig({
+            api_token: 'fallback-token-123456',
+            currentWorkspace: 'team-2',
+        })
+        await expect(clearApiToken()).resolves.toEqual({
+            storage: 'config-file',
+            warning: `system credential manager unavailable; local auth state cleared in ${TEST_CONFIG_PATH}`,
+        })
+        expect(readConfig()).toEqual({
+            currentWorkspace: 'team-2',
+            pendingSecureStoreClear: true,
+        })
+    })
+
+    it('removes plaintext tokens after secure-store save while preserving non-secret config', async () => {
+        setConfig({
+            api_token: 'old-token-123456',
+            currentWorkspace: 'workspace-1',
+        })
+
+        const { saveApiToken } = await import('../lib/auth.js')
+
+        await expect(saveApiToken('new-token-123456')).resolves.toEqual({
+            storage: 'secure-store',
+        })
+        expect(keyringState.token).toBe('new-token-123456')
+        expect(readConfig()).toEqual({ currentWorkspace: 'workspace-1' })
+    })
+
+    it('keeps secure-store success when plaintext cleanup fails after save', async () => {
+        configWriteError = new Error('EACCES')
+        setConfig({
+            api_token: 'old-token-123456',
+            currentWorkspace: 'workspace-1',
+        })
+
+        const { saveApiToken } = await import('../lib/auth.js')
+
+        await expect(saveApiToken('new-token-123456')).resolves.toEqual({
+            storage: 'secure-store',
+            warning: `Token was stored securely, but could not remove legacy plaintext token from ${TEST_CONFIG_PATH} (EACCES)`,
+        })
+        expect(keyringState.token).toBe('new-token-123456')
+        expect(readConfig()).toEqual({
+            api_token: 'old-token-123456',
+            currentWorkspace: 'workspace-1',
+        })
+    })
+
+    it('keeps secure-store success when plaintext cleanup fails after logout', async () => {
+        configWriteError = new Error('EACCES')
+        keyringState.token = 'secure-token-123456'
+        setConfig({
+            api_token: 'old-token-123456',
+            currentWorkspace: 'workspace-1',
+        })
+
+        const { clearApiToken } = await import('../lib/auth.js')
+
+        await expect(clearApiToken()).resolves.toEqual({
+            storage: 'secure-store',
+            warning: `Secure-store token was removed, but could not remove legacy plaintext token from ${TEST_CONFIG_PATH} (EACCES)`,
+        })
+        expect(keyringState.token).toBeNull()
+        expect(readConfig()).toEqual({
+            api_token: 'old-token-123456',
+            currentWorkspace: 'workspace-1',
+        })
+    })
+
+    it('clears pending secure-store deletion when fallback save writes a new token', async () => {
+        keyringState.setError = new Error('Keychain unavailable')
+        setConfig({
+            currentWorkspace: 'workspace-1',
+            pendingSecureStoreClear: true,
+        })
+
+        const { saveApiToken } = await import('../lib/auth.js')
+
+        await expect(saveApiToken('fallback-token-123456')).resolves.toEqual({
+            storage: 'config-file',
+            warning: `system credential manager unavailable; token saved as plaintext in ${TEST_CONFIG_PATH}`,
+        })
+        expect(readConfig()).toEqual({
+            api_token: 'fallback-token-123456',
+            currentWorkspace: 'workspace-1',
+        })
+    })
+
+    it('treats pending secure-store deletion as logged out and clears stale secure tokens', async () => {
+        keyringState.token = 'stale-secure-token-123456'
+        setConfig({
+            currentWorkspace: 'workspace-1',
+            pendingSecureStoreClear: true,
+        })
+
+        const { getApiToken } = await import('../lib/auth.js')
+
+        await expect(getApiToken()).rejects.toThrow('No API token found')
+        expect(keyringState.deleteCalls).toBe(1)
+        expect(keyringState.getCalls).toBe(0)
+        expect(keyringState.token).toBeNull()
+        expect(readConfig()).toEqual({ currentWorkspace: 'workspace-1' })
+    })
+
+    function setConfig(config: Record<string, unknown>): void {
+        configContent = `${JSON.stringify(config, null, 2)}\n`
+    }
+
+    function readConfig(): Record<string, unknown> | null {
+        return configContent ? (JSON.parse(configContent) as Record<string, unknown>) : null
+    }
+
+    function createErrnoError(code: string): Error & { code: string } {
+        const error = new Error(code) as Error & { code: string }
+        error.code = code
+        return error
+    }
+})

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 import { Command } from 'commander'
 import open from 'open'
 import { getApi } from '../lib/api/core.js'
-import { clearApiToken, saveApiToken } from '../lib/auth.js'
+import { clearApiToken, saveApiToken, type TokenStorageResult } from '../lib/auth.js'
 import { startCallbackServer } from '../lib/oauth-server.js'
 import { buildAuthorizationUrl, exchangeCodeForToken } from '../lib/oauth.js'
 import { generateCodeChallenge, generateCodeVerifier, generateState } from '../lib/pkce.js'
@@ -39,9 +39,9 @@ async function loginWithToken(token?: string): Promise<void> {
             return
         }
     }
-    await saveApiToken(token.trim())
+    const result = await saveApiToken(token.trim())
     console.log(chalk.green('✓'), 'API token saved successfully!')
-    console.log(chalk.dim('Token saved to ~/.config/todoist-cli/config.json'))
+    logTokenStorageResult(result, 'Token stored securely in the system credential manager')
 }
 
 async function loginWithOAuth(): Promise<void> {
@@ -62,10 +62,10 @@ async function loginWithOAuth(): Promise<void> {
         console.log(chalk.dim('Exchanging code for token...'))
 
         const accessToken = await exchangeCodeForToken(code, codeVerifier)
-        await saveApiToken(accessToken)
+        const result = await saveApiToken(accessToken)
 
         console.log(chalk.green('✓'), 'Successfully logged in!')
-        console.log(chalk.dim('Token saved to ~/.config/todoist-cli/config.json'))
+        logTokenStorageResult(result, 'Token stored securely in the system credential manager')
     } catch (error) {
         cleanup()
         throw error
@@ -86,9 +86,19 @@ async function showStatus(): Promise<void> {
 }
 
 async function logout(): Promise<void> {
-    await clearApiToken()
+    const result = await clearApiToken()
     console.log(chalk.green('✓'), 'Logged out')
-    console.log(chalk.dim('Token removed from ~/.config/todoist-cli/config.json'))
+    logTokenStorageResult(result, 'Stored token removed from the system credential manager')
+}
+
+function logTokenStorageResult(result: TokenStorageResult, secureStoreMessage: string): void {
+    if (result.storage === 'secure-store') {
+        console.log(chalk.dim(secureStoreMessage))
+    }
+
+    if (result.warning) {
+        console.error(chalk.yellow('Warning:'), result.warning)
+    }
 }
 
 export function registerAuthCommand(program: Command): void {
@@ -97,7 +107,7 @@ export function registerAuthCommand(program: Command): void {
     auth.command('login').description('Authenticate with Todoist via OAuth').action(loginWithOAuth)
 
     auth.command('token [token]')
-        .description('Save API token to config file (manual authentication)')
+        .description('Save API token for CLI authentication')
         .action(loginWithToken)
 
     auth.command('status').description('Show current authentication status').action(showStatus)

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,79 +1,223 @@
 import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
+import {
+    createSecureStore,
+    SecureStoreUnavailableError,
+    SECURE_STORE_DESCRIPTION,
+} from './secure-store.js'
 
-const CONFIG_PATH = join(homedir(), '.config', 'todoist-cli', 'config.json')
+export const CONFIG_PATH = join(homedir(), '.config', 'todoist-cli', 'config.json')
+export const TOKEN_ENV_VAR = 'TODOIST_API_TOKEN'
 
-interface Config {
+export type TokenStorageLocation = 'secure-store' | 'config-file'
+
+export interface TokenStorageResult {
+    storage: TokenStorageLocation
+    warning?: string
+}
+
+interface Config extends Record<string, unknown> {
     api_token?: string
+    pendingSecureStoreClear?: boolean
 }
 
 export async function getApiToken(): Promise<string> {
     // Priority 1: Environment variable
-    const envToken = process.env.TODOIST_API_TOKEN
+    const envToken = process.env[TOKEN_ENV_VAR]
     if (envToken) {
         return envToken
     }
 
-    // Priority 2: Config file
-    try {
-        const content = await readFile(CONFIG_PATH, 'utf-8')
-        const config: Config = JSON.parse(content)
-        if (config.api_token) {
-            return config.api_token
+    const config = await readConfig()
+    const configToken = getConfigToken(config)
+    const secureStore = createSecureStore()
+
+    if (configToken) {
+        try {
+            await secureStore.setSecret(configToken)
+            const cleanupWarning = await cleanupAuthFallbackState(
+                config,
+                'Token was migrated to secure storage,',
+            )
+            if (cleanupWarning) {
+                warn(cleanupWarning)
+            }
+        } catch (error) {
+            if (error instanceof SecureStoreUnavailableError) {
+                warnSecureStoreFallback('using plaintext token from')
+            } else {
+                throw error
+            }
         }
-    } catch {
-        // Config file doesn't exist or is invalid
+
+        return configToken
+    }
+
+    if (config.pendingSecureStoreClear) {
+        try {
+            await secureStore.deleteSecret()
+            const cleanupWarning = await cleanupAuthFallbackState(
+                config,
+                'Secure-store token was removed,',
+            )
+            if (cleanupWarning) {
+                warn(cleanupWarning)
+            }
+        } catch (error) {
+            if (!(error instanceof SecureStoreUnavailableError)) {
+                throw error
+            }
+        }
+
+        throw new Error(
+            `No API token found. Set ${TOKEN_ENV_VAR} or run \`td auth login\` or \`td auth token <token>\`.`,
+        )
+    }
+
+    try {
+        const storedToken = await secureStore.getSecret()
+        if (storedToken?.trim()) {
+            return storedToken
+        }
+    } catch (error) {
+        if (error instanceof SecureStoreUnavailableError) {
+            warnSecureStoreFallback('using plaintext token from')
+        } else {
+            throw error
+        }
     }
 
     throw new Error(
-        'No API token found. Set TODOIST_API_TOKEN environment variable or create ~/.config/todoist-cli/config.json with {"api_token": "your-token"}',
+        `No API token found. Set ${TOKEN_ENV_VAR} or run \`td auth login\` or \`td auth token <token>\`.`,
     )
 }
 
-export async function saveApiToken(token: string): Promise<void> {
+export async function saveApiToken(token: string): Promise<TokenStorageResult> {
     // Validate token (non-empty, reasonable length)
     if (!token || token.trim().length < 10) {
         throw new Error('Invalid token: Token must be at least 10 characters')
     }
 
-    // Ensure config directory exists
-    const configDir = dirname(CONFIG_PATH)
-    await mkdir(configDir, { recursive: true })
+    const trimmedToken = token.trim()
+    const secureStore = createSecureStore()
 
-    // Read existing config to preserve other settings
-    let existingConfig: Config = {}
     try {
-        const content = await readFile(CONFIG_PATH, 'utf-8')
-        existingConfig = JSON.parse(content)
-    } catch {
-        // Config doesn't exist - start fresh
+        await secureStore.setSecret(trimmedToken)
+        const existingConfig = await readConfig()
+        const warning = await cleanupAuthFallbackState(existingConfig, 'Token was stored securely,')
+        return warning ? { storage: 'secure-store', warning } : { storage: 'secure-store' }
+    } catch (error) {
+        if (!(error instanceof SecureStoreUnavailableError)) {
+            throw error
+        }
     }
 
-    // Update config with new token
-    const newConfig: Config = {
-        ...existingConfig,
-        api_token: token.trim(),
+    const config = await readConfig()
+    config.api_token = trimmedToken
+    delete config.pendingSecureStoreClear
+    await writeConfig(config)
+    return {
+        storage: 'config-file',
+        warning: buildFallbackWarning('token saved as plaintext in'),
     }
-
-    // Write config file with proper formatting
-    await writeFile(CONFIG_PATH, `${JSON.stringify(newConfig, null, 2)}\n`)
 }
 
-export async function clearApiToken(): Promise<void> {
-    let config: Config = {}
+export async function clearApiToken(): Promise<TokenStorageResult> {
+    const config = await readConfig()
+    const secureStore = createSecureStore()
+
+    try {
+        await secureStore.deleteSecret()
+        const warning = await cleanupAuthFallbackState(config, 'Secure-store token was removed,')
+        return warning ? { storage: 'secure-store', warning } : { storage: 'secure-store' }
+    } catch (error) {
+        if (!(error instanceof SecureStoreUnavailableError)) {
+            throw error
+        }
+    }
+
+    await writeConfig(withPendingSecureStoreClear(config))
+    return {
+        storage: 'config-file',
+        warning: buildFallbackWarning('local auth state cleared in'),
+    }
+}
+
+async function readConfig(): Promise<Config> {
     try {
         const content = await readFile(CONFIG_PATH, 'utf-8')
-        config = JSON.parse(content)
+        const parsed = JSON.parse(content)
+        return isObject(parsed) ? (parsed as Config) : {}
     } catch {
-        return // Config doesn't exist, nothing to clear
+        return {}
     }
+}
 
-    delete config.api_token
-
+async function writeConfig(config: Config): Promise<void> {
     if (Object.keys(config).length === 0) {
-        await unlink(CONFIG_PATH)
-    } else {
-        await writeFile(CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`)
+        try {
+            await unlink(CONFIG_PATH)
+        } catch (error) {
+            if (!isMissingFileError(error)) {
+                throw error
+            }
+        }
+        return
     }
+
+    await mkdir(dirname(CONFIG_PATH), { recursive: true })
+    await writeFile(CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`)
+}
+
+async function cleanupAuthFallbackState(
+    config: Config,
+    warningPrefix: string,
+): Promise<string | undefined> {
+    try {
+        await writeConfig(withoutAuthFallbackState(config))
+        return undefined
+    } catch (error) {
+        return buildConfigCleanupWarning(warningPrefix, error)
+    }
+}
+
+function getConfigToken(config: Config): string | null {
+    return typeof config.api_token === 'string' && config.api_token.trim()
+        ? config.api_token.trim()
+        : null
+}
+
+function withoutAuthFallbackState(config: Config): Config {
+    const { api_token: _token, pendingSecureStoreClear: _pending, ...rest } = config
+    return rest
+}
+
+function withPendingSecureStoreClear(config: Config): Config {
+    return { ...withoutAuthFallbackState(config), pendingSecureStoreClear: true }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isMissingFileError(error: unknown): boolean {
+    return error instanceof Error && 'code' in error && error.code === 'ENOENT'
+}
+
+function buildFallbackWarning(action: string): string {
+    return `${SECURE_STORE_DESCRIPTION} unavailable; ${action} ${CONFIG_PATH}`
+}
+
+function buildConfigCleanupWarning(prefix: string, error: unknown): string {
+    const detail = error instanceof Error && error.message ? ` (${error.message})` : ''
+    return `${prefix} but could not remove legacy plaintext token from ${CONFIG_PATH}${detail}`
+}
+
+function warn(message: string): void {
+    console.error(`Warning: ${message}`)
+}
+
+function warnSecureStoreFallback(action: string): void {
+    warn(buildFallbackWarning(action))
 }

--- a/src/lib/secure-store.ts
+++ b/src/lib/secure-store.ts
@@ -1,0 +1,67 @@
+const SERVICE_NAME = 'todoist-cli'
+const ACCOUNT_NAME = 'api-token'
+
+export const SECURE_STORE_DESCRIPTION = 'system credential manager'
+
+export class SecureStoreUnavailableError extends Error {
+    constructor(message = 'System credential storage is unavailable') {
+        super(message)
+        this.name = 'SecureStoreUnavailableError'
+    }
+}
+
+export interface SecureStore {
+    getSecret(): Promise<string | null>
+    setSecret(secret: string): Promise<void>
+    deleteSecret(): Promise<boolean>
+}
+
+export function createSecureStore(): SecureStore {
+    return {
+        async getSecret(): Promise<string | null> {
+            const entry = await getEntry()
+            try {
+                return (await entry.getPassword()) ?? null
+            } catch (error) {
+                throw toUnavailableError(error)
+            }
+        },
+
+        async setSecret(secret: string): Promise<void> {
+            const entry = await getEntry()
+            try {
+                await entry.setPassword(secret)
+            } catch (error) {
+                throw toUnavailableError(error)
+            }
+        },
+
+        async deleteSecret(): Promise<boolean> {
+            const entry = await getEntry()
+            try {
+                return await entry.deleteCredential()
+            } catch (error) {
+                throw toUnavailableError(error)
+            }
+        },
+    }
+}
+
+async function getEntry(): Promise<import('@napi-rs/keyring').AsyncEntry> {
+    try {
+        const { AsyncEntry } = await import('@napi-rs/keyring')
+        return new AsyncEntry(SERVICE_NAME, ACCOUNT_NAME)
+    } catch (error) {
+        throw toUnavailableError(error)
+    }
+}
+
+function toUnavailableError(error: unknown): SecureStoreUnavailableError {
+    if (error instanceof SecureStoreUnavailableError) {
+        return error
+    }
+
+    const message =
+        error instanceof Error ? error.message : 'System credential storage is unavailable'
+    return new SecureStoreUnavailableError(message)
+}

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -12,6 +12,7 @@ Use this skill when the user wants to interact with their Todoist tasks.
 - \`td inbox\` - Inbox tasks
 - \`td upcoming\` - Tasks due in next N days
 - \`td completed\` - Recently completed tasks
+- \`td auth login\` - Authenticate and store the token securely
 - \`td task add "content"\` - Add a task
 - \`td task list\` - List tasks with filters
 - \`td task complete <ref>\` - Complete a task
@@ -50,6 +51,18 @@ Most list commands also support:
 - \`--progress-jsonl\` - Machine-readable progress events (JSONL to stderr)
 - \`-v, --verbose\` - Verbose output to stderr (repeat: -v info, -vv detail, -vvv debug, -vvvv trace)
 - \`--accessible\` - Add text labels to color-coded output (due:/deadline:/~ prefixes, ★ for favorites). Also: \`TD_ACCESSIBLE=1\`
+
+## Authentication
+
+\`\`\`bash
+td auth login                          # OAuth login; stores token in OS credential manager
+td auth token "your-token"            # Save a manual API token
+td auth status                         # Check whether auth works
+td auth logout                         # Remove the saved token
+export TODOIST_API_TOKEN="your-token"  # Highest priority; overrides stored token
+\`\`\`
+
+If OS credential storage is unavailable, \`td\` warns and falls back to \`~/.config/todoist-cli/config.json\`. Legacy plaintext config tokens are migrated automatically when secure storage becomes available.
 
 ## References
 


### PR DESCRIPTION
## Summary
- Store auth tokens in OS-native secure storage via `@napi-rs/keyring`.
- Keep `TODOIST_API_TOKEN` as the highest-priority auth source.
- Automatically migrate legacy plaintext `api_token` values from config into secure storage while preserving other config fields.
- Fall back to plaintext config storage with an explicit warning when the system credential store is unavailable.

## User-facing updates
- Update `auth login`, `auth token`, and `auth logout` messaging to stop claiming tokens are always stored in the config file.
- Document secure storage, migration, fallback behavior, and env-var precedence in the README and installed skill content.

## Test plan

First build the CLI in this branch:

```bash
npm run build
```

Then try the auth commands:

```bash
node dist/index.js auth status

# if you're signed in, the above command should've already migrated to secure store
# the config file should either not exist, or have other config but not the token anymore
cat ~/.config/todoist-cli/config.json
```

Optional: try signing out and signing back in:

```bash
node dist/index.js auth logout
node dist/index.js auth login

# and run auth status again
node dist/index.js auth status
```
