### PR TITLE
feat: add --json output to auth status command

### DIFF
--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -266,6 +266,34 @@ describe('auth command', () => {
             expect(consoleSpy).toHaveBeenCalledWith('  Name:  Test User')
         })
 
+        it('outputs JSON when --json flag is used', async () => {
+            const program = createProgram()
+            const mockUser = { id: '123', email: 'test@example.com', fullName: 'Test User' }
+            const mockApi = createMockApi({ getUser: vi.fn().mockResolvedValue(mockUser) })
+            mockGetApi.mockResolvedValue(mockApi)
+
+            await program.parseAsync(['node', 'td', 'auth', 'status', '--json'])
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                JSON.stringify(
+                    { id: '123', email: 'test@example.com', fullName: 'Test User' },
+                    null,
+                    2,
+                ),
+            )
+        })
+
+        it('outputs JSON error when --json flag is used and not authenticated', async () => {
+            const program = createProgram()
+            mockGetApi.mockRejectedValue(new Error('No API token found'))
+
+            await program.parseAsync(['node', 'td', 'auth', 'status', '--json'])
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                JSON.stringify({ error: 'Not authenticated' }, null, 2),
+            )
+        })
+
         it('shows not authenticated when no token', async () => {
             const program = createProgram()
             mockGetApi.mockRejectedValue(new Error('No API token found'))

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -72,16 +72,31 @@ async function loginWithOAuth(): Promise<void> {
     }
 }
 
-async function showStatus(): Promise<void> {
+async function showStatus(options: { json?: boolean }): Promise<void> {
     try {
         const api = await getApi()
         const user = await api.getUser()
-        console.log(chalk.green('✓'), 'Authenticated')
-        console.log(`  Email: ${user.email}`)
-        console.log(`  Name:  ${user.fullName}`)
+        if (options.json) {
+            console.log(
+                JSON.stringify(
+                    { id: user.id, email: user.email, fullName: user.fullName },
+                    null,
+                    2,
+                ),
+            )
+        } else {
+            console.log(chalk.green('✓'), 'Authenticated')
+            console.log(`  Email: ${user.email}`)
+            console.log(`  Name:  ${user.fullName}`)
+        }
     } catch {
-        console.log(chalk.yellow('Not authenticated'))
-        console.log(chalk.dim('Run `td auth login` or `td auth token <token>` to authenticate'))
+        if (options.json) {
+            console.log(JSON.stringify({ error: 'Not authenticated' }, null, 2))
+            process.exitCode = 1
+        } else {
+            console.log(chalk.yellow('Not authenticated'))
+            console.log(chalk.dim('Run `td auth login` or `td auth token <token>` to authenticate'))
+        }
     }
 }
 
@@ -100,7 +115,10 @@ export function registerAuthCommand(program: Command): void {
         .description('Save API token to config file (manual authentication)')
         .action(loginWithToken)
 
-    auth.command('status').description('Show current authentication status').action(showStatus)
+    auth.command('status')
+        .description('Show current authentication status')
+        .option('--json', 'Output as JSON')
+        .action(showStatus)
 
     auth.command('logout').description('Remove saved authentication token').action(logout)
 }

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -22,6 +22,7 @@ Use this skill when the user wants to interact with their Todoist tasks.
 - \`td activity\` - Activity logs
 - \`td notification list\` - Notifications
 - \`td reminder add\` - Task reminders
+- \`td auth status\` - Authentication status
 - \`td stats\` - Productivity stats
 - \`td settings view\` - User settings
 - \`td completion install\` - Install shell completions
@@ -246,6 +247,15 @@ td reminder add "task name" --before 30m      # or --task "task name" --before 3
 td reminder add "task name" --at "2024-01-15 10:00"
 td reminder update id:123 --before 1h
 td reminder delete id:123 --yes
+\`\`\`
+
+### Auth
+\`\`\`bash
+td auth status                                # Check authentication
+td auth status --json                         # JSON: { id, email, fullName }
+td auth login                                 # OAuth login
+td auth token <token>                         # Save API token
+td auth logout                                # Remove saved token
 \`\`\`
 
 ### Stats


### PR DESCRIPTION
## Summary
- Add `--json` flag to `td auth status` that outputs `{ id, email, fullName }` as structured JSON
- When not authenticated with `--json`, outputs `{ error: "Not authenticated" }` with exit code 1
- Update agent skill content to document auth commands

This will be useful for Doist OS to ensure that when an agent is told to do something with "me/my" tasks context, it can get the right user id. 

## Test plan
- [x] `td auth status` — existing human-readable output unchanged
- [x] `td auth status --json` — outputs JSON with id, email, fullName
- [x] `td auth status --json` when not authenticated — outputs JSON error
- [x] All 933 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)