### PR TITLE
refactor: Use `Boolean()` instead of double bang

### DIFF
--- a/src/commands/today.ts
+++ b/src/commands/today.ts
@@ -38,10 +38,8 @@ export async function showToday(options: TodayOptions): Promise<void> {
     const baseQuery = 'today | overdue'
     const query = options.anyAssignee ? baseQuery : `(${baseQuery}) & (assigned to: me | !assigned)`
 
-    const needsProjects = !!(
-        options.workspace ||
-        options.personal ||
-        (!options.json && !options.ndjson)
+    const needsProjects = Boolean(
+        options.workspace || options.personal || (!options.json && !options.ndjson),
     )
     const [{ results: tasks, nextCursor }, projects] = await Promise.all([
         paginate(


### PR DESCRIPTION
I wanted to change this originally in the code for #118, but for some reason couldn't, so merged #118 with a view to correcting this in a follow up PR. 