### PR TITLE
docs: add uninstallation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ A command-line interface for Todoist.
 > npm install -g @doist/todoist-cli
 > ```
 
+### Uninstallation
+
+```bash
+npm uninstall -g @doist/todoist-cli
+```
+
+To also remove installed agent skills:
+
+```bash
+td skill uninstall claude-code   # repeat for each installed agent
+```
+
 ### Local Setup (for now)
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds an **Uninstallation** subsection to the Installation section of the README
- Includes the `npm uninstall -g @doist/todoist-cli` command for removing the CLI
- Includes `td skill uninstall` guidance for removing installed agent skills

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)