### PR TITLE
chore: Fix renovate config to not point at internal config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,4 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "github>doist/renovate-config:frontend-base",
-        "github>doist/renovate-config-internal:npm-registry-token"
-    ]
+    "extends": ["github>doist/renovate-config:frontend-base"]
 }


### PR DESCRIPTION
Fixes https://github.com/Doist/todoist-cli/issues/109