### PR TITLE
fix(deps): update dependency @doist/todoist-api-typescript to v7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@doist/todoist-api-typescript": "6.10.0",
+        "@doist/todoist-api-typescript": "7.0.0",
         "@napi-rs/keyring": "1.2.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/@doist/todoist-api-typescript": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-6.10.0.tgz",
-      "integrity": "sha512-obSwvJLSA4/8Sw6xbse8OL+Oq7l//+JtwtVissTEZ/9NTjRrdS/jqykgaiviW1wHUWZWf1LY7RVDKfRjCzaghA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-7.0.0.tgz",
+      "integrity": "sha512-TUO0nG1AK1miiTNvOS8HyvCC3neHZBoK84Nq4uRCV9KsN/PJv21DkIqop9GhaYBSSZ4jHHuAMj8nzCwcONeeMw==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "dist"
   ],
   "dependencies": {
-    "@doist/todoist-api-typescript": "6.10.0",
+    "@doist/todoist-api-typescript": "7.0.0",
     "@napi-rs/keyring": "1.2.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",

--- a/src/__tests__/activity.test.ts
+++ b/src/__tests__/activity.test.ts
@@ -90,7 +90,7 @@ describe('activity command', () => {
 
         expect(mockApi.getActivityLogs).toHaveBeenCalledWith(
             expect.objectContaining({
-                objectType: 'task',
+                objectEventTypes: 'task:',
             }),
         )
     })
@@ -102,7 +102,7 @@ describe('activity command', () => {
 
         expect(mockApi.getActivityLogs).toHaveBeenCalledWith(
             expect.objectContaining({
-                eventType: 'completed',
+                objectEventTypes: ':completed',
             }),
         )
     })
@@ -122,8 +122,8 @@ describe('activity command', () => {
 
         expect(mockApi.getActivityLogs).toHaveBeenCalledWith(
             expect.objectContaining({
-                since: new Date('2025-01-01'),
-                until: new Date('2025-01-10'),
+                dateFrom: new Date('2025-01-01'),
+                dateTo: new Date('2025-01-10'),
             }),
         )
     })

--- a/src/commands/activity.ts
+++ b/src/commands/activity.ts
@@ -1,8 +1,4 @@
-import type {
-    ActivityEvent,
-    ActivityEventType,
-    ActivityObjectType,
-} from '@doist/todoist-api-typescript'
+import type { ActivityEvent, ActivityObjectEventType } from '@doist/todoist-api-typescript'
 import chalk from 'chalk'
 import { Command, Option } from 'commander'
 import { getApi, getCurrentUserId, isWorkspaceProject, type Project } from '../lib/api/core.js'
@@ -260,11 +256,14 @@ export function registerActivityCommand(program: Command): void {
 
             const { results: events, nextCursor } = await paginate(
                 async (cursor, limit) => {
+                    const objectEventTypes: ActivityObjectEventType | undefined =
+                        options.type || options.event
+                            ? (`${options.type ?? ''}:${options.event ?? ''}` as ActivityObjectEventType)
+                            : undefined
                     const resp = await api.getActivityLogs({
-                        since: options.since ? new Date(options.since) : undefined,
-                        until: options.until ? new Date(options.until) : undefined,
-                        objectType: options.type as ActivityObjectType | undefined,
-                        eventType: options.event as ActivityEventType | undefined,
+                        dateFrom: options.since ? new Date(options.since) : undefined,
+                        dateTo: options.until ? new Date(options.until) : undefined,
+                        objectEventTypes,
                         parentProjectId: projectId,
                         initiatorId,
                         cursor: cursor ?? undefined,


### PR DESCRIPTION
## Summary

- Bumps `@doist/todoist-api-typescript` from `6.10.0` to `7.0.0`
- Adapts `getActivityLogs` call to v7 breaking changes:
  - `since` / `until` renamed to `dateFrom` / `dateTo`
  - Separate `objectType` + `eventType` params merged into `objectEventTypes` (format: `"type:event"`)
- Updates corresponding test assertions in `activity.test.ts`

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint:check` passes
- [x] `npm run format:check` passes
- [x] `npm test` — all 952 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)