### PR TITLE
feat(task): add --uncompletable/--completable flags to task add and update

### DIFF
--- a/src/__tests__/task.test.ts
+++ b/src/__tests__/task.test.ts
@@ -1697,6 +1697,24 @@ describe('task add/update --uncompletable', () => {
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', { isUncompletable: false })
         consoleSpy.mockRestore()
     })
+
+    it('throws when both --uncompletable and --completable are passed together', async () => {
+        const program = createProgram()
+
+        mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'task',
+                'update',
+                'id:task-1',
+                '--uncompletable',
+                '--completable',
+            ]),
+        ).rejects.toThrow('Cannot use --uncompletable and --completable together')
+    })
 })
 
 describe('task list --filter', () => {

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -303,7 +303,9 @@ async function updateTask(ref: string, options: UpdateOptions): Promise<void> {
         applyDuration(args as DurationArgs, options.duration)
     }
 
-    if (options.uncompletable) {
+    if (options.uncompletable && options.completable) {
+        throw new Error('Cannot use --uncompletable and --completable together')
+    } else if (options.uncompletable) {
         args.isUncompletable = true
     } else if (options.completable) {
         args.isUncompletable = false

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -140,6 +140,7 @@ td task add "Task" --deadline "2024-03-01" --project "Work"
 td task add "Task" --duration 1h --section "Planning" --project "Work"
 td task add "Task" --labels "urgent,review" --parent "Parent task"
 td task add "Task" --description "Details here" --assignee me
+td task add "Reference header" --uncompletable  # Non-actionable reference/header task
 
 # Update
 td task update "task name" --due "next week"
@@ -148,6 +149,8 @@ td task update "task name" --no-deadline
 td task update "task name" --duration 2h
 td task update "task name" --assignee "john@example.com"
 td task update "task name" --unassign
+td task update "task name" --uncompletable   # Mark as non-completable reference item
+td task update "task name" --completable     # Revert to completable (undo --uncompletable)
 
 # Move
 td task move "task name" --project "Personal"


### PR DESCRIPTION
## Summary

- Exposes the Todoist API's `isUncompletable` field via new CLI flags
- `task add --uncompletable` creates a task with `isUncompletable: true` (reference/header item)
- `task update --uncompletable` sets `isUncompletable: true`; `task update --completable` reverts it to `false`

Closes #140

## Test plan

- [ ] `task add --uncompletable` → `addTask` called with `{ isUncompletable: true }`
- [ ] `task update --uncompletable` → `updateTask` called with `{ isUncompletable: true }`
- [ ] `task update --completable` → `updateTask` called with `{ isUncompletable: false }`
- [ ] `task add` (no flag) → `addTask` not called with `isUncompletable`
- [ ] `npm test` passes (956 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)