### PR TITLE
fix: align skill name with install directory

### DIFF
--- a/src/__tests__/skill.test.ts
+++ b/src/__tests__/skill.test.ts
@@ -204,7 +204,7 @@ describe('installer paths', () => {
     it('generates skill file with YAML frontmatter', () => {
         const content = skillInstallers['claude-code'].generateContent()
         expect(content).toContain('---')
-        expect(content).toContain('name: todoist')
+        expect(content).toContain('name: todoist-cli')
         expect(content).toContain('description: Manage Todoist tasks')
         expect(content).toContain('# Todoist CLI (td)')
         expect(content).toContain('td today')
@@ -234,7 +234,7 @@ describe('installer file operations', () => {
         await writeFile(targetFile, content, 'utf-8')
 
         const written = await readFile(targetFile, 'utf-8')
-        expect(written).toContain('name: todoist')
+        expect(written).toContain('name: todoist-cli')
     })
 
     it('detects existing file', async () => {
@@ -297,7 +297,7 @@ describe('update file operations', () => {
         await writeFile(targetFile, latestContent, 'utf-8')
 
         const written = await readFile(targetFile, 'utf-8')
-        expect(written).toContain('name: todoist')
+        expect(written).toContain('name: todoist-cli')
         expect(written).not.toBe('old content')
     })
 })

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -1,4 +1,4 @@
-export const SKILL_NAME = 'todoist'
+export const SKILL_NAME = 'todoist-cli'
 export const SKILL_DESCRIPTION =
     'Manage Todoist tasks, projects, labels, comments, and more via the td CLI'
 

--- a/src/lib/skills/create-installer.ts
+++ b/src/lib/skills/create-installer.ts
@@ -23,7 +23,7 @@ description: ${SKILL_DESCRIPTION}
 export function createInstaller(config: InstallerConfig): SkillInstaller {
     function getInstallPath(local: boolean): string {
         const base = local ? process.cwd() : homedir()
-        return join(base, config.dirName, 'skills', 'todoist-cli', 'SKILL.md')
+        return join(base, config.dirName, 'skills', SKILL_NAME, 'SKILL.md')
     }
 
     return {


### PR DESCRIPTION
Fixes #155

## Summary
- change the generated skill frontmatter name to `todoist-cli`
- derive the install directory from the same skill name constant so the manifest and folder stay aligned
- update skill installer tests to cover the expected frontmatter value

## Testing
- npm test