### PR TITLE
ci: announce releases in Twist

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,15 @@ name: Release @doist/todoist-cli package
 
 on:
     workflow_dispatch:
+        inputs:
+            release_tag:
+                description: Release tag created by release-please
+                required: true
+                type: string
+            release_sha:
+                description: Release commit SHA created by release-please
+                required: true
+                type: string
 
 permissions:
     contents: read
@@ -14,6 +23,9 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v5
+              with:
+                  fetch-depth: 0
+                  ref: ${{ inputs.release_sha }}
 
             - name: Setup Node.js
               uses: actions/setup-node@v6
@@ -44,3 +56,58 @@ jobs:
 
             - name: Publish to npm
               run: npm publish --provenance --access public
+
+            - name: Derive release metadata
+              id: release
+              run: |
+                  release_tag="${{ inputs.release_tag }}"
+                  release_sha="${{ inputs.release_sha }}"
+                  package_name="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).name")"
+                  package_version="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")"
+                  release_version="${release_tag#v}"
+
+                  if [ "${package_version}" != "${release_version}" ]; then
+                      echo "Package version ${package_version} does not match release tag ${release_tag}" >&2
+                      exit 1
+                  fi
+
+                  package_url="https://www.npmjs.com/package/${package_name}/v/${package_version}"
+                  release_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${release_tag}"
+                  published_at="$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+                  previous_tag="$(git describe --tags --abbrev=0 "${release_sha}^" 2>/dev/null || true)"
+
+                  if [ -n "${previous_tag}" ]; then
+                      changelog="$(git log --no-merges --pretty='format:- %s (%H-%h)' "${previous_tag}..${release_sha}" | grep -v '^- chore(main): release ' || true)"
+                  else
+                      changelog="$(git log --no-merges --pretty='format:- %s (%H-%h)' "${release_sha}" | grep -v '^- chore(main): release ' || true)"
+                  fi
+
+                  if [ -z "${changelog}" ]; then
+                      changelog='- No additional commits listed.'
+                  else
+                      changelog="$(printf '%s\n' "${changelog}" | sed -E -e 's,\(([a-f0-9]+)-([a-f0-9]+)\),([`\2`]('"${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"'/commit/\1)),g' | sed -E -e 's,\(#([0-9]+)\),([#\1]('"${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"'/pull/\1)),g')"
+                  fi
+
+                  {
+                      echo "release_tag=${release_tag}"
+                      echo "package_name=${package_name}"
+                      echo "package_version=${package_version}"
+                      echo "package_url=${package_url}"
+                      echo "release_url=${release_url}"
+                      echo "message<<EOF"
+                      echo "🎉 **${package_name} ${release_tag} Published** (${published_at})"
+                      echo
+                      echo "📝 Changes"
+                      echo
+                      printf '%s\n' "${changelog}"
+                      echo
+                      echo "[GitHub release](${release_url}) | [npm package](${package_url})"
+                      echo "EOF"
+                  } >> "${GITHUB_OUTPUT}"
+
+            - name: Announce release in Twist
+              uses: Doist/twist-post-action@74a0255b75ad93c06b9eb1009960106efe13f5ca
+              with:
+                  message: ${{ steps.release.outputs.message }}
+                  install_id: ${{ secrets.TWIST_RELEASE_INSTALL_ID }}
+                  install_token: ${{ secrets.TWIST_RELEASE_INSTALL_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,15 @@ jobs:
 
             - name: Trigger publish workflow
               if: ${{ steps.release.outputs.release_created }}
-              run: gh workflow run publish.yml --repo ${{ github.repository }}
+              run: |
+                  gh workflow run publish.yml \
+                      --repo "${GITHUB_REPOSITORY}" \
+                      --ref "${GITHUB_REF_NAME}" \
+                      -f release_tag="${RELEASE_TAG}" \
+                      -f release_sha="${RELEASE_SHA}"
               env:
                   GH_TOKEN: ${{ github.token }}
+                  GITHUB_REPOSITORY: ${{ github.repository }}
+                  GITHUB_REF_NAME: ${{ github.ref_name }}
+                  RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
+                  RELEASE_SHA: ${{ steps.release.outputs.sha }}


### PR DESCRIPTION
We're announcing new releases in Twist (https://twist.com/a/1585/ch/2263/t/7674024/) now. We cannot use our internal action that parses semantic commits, but this will be good enough.

Exemplary output:

---


🎉 **@doist/todoist-cli v1.27.0 Published** (2026-03-20 09:35:22 UTC)

📝 Changes

- feat(attachment): add `td attachment view` command ([#168](https://github.com/Doist/todoist-cli/pull/168)) ([`15ef686`](https://github.com/Doist/todoist-cli/commit/15ef686ca7ed4e348e1025cb11607747031a3090))

[npm package](https://www.npmjs.com/package/@doist/todoist-cli/v/1.27.0) | [GitHub release](https://github.com/Doist/todoist-cli/releases/tag/v1.27.0)