### PR TITLE
fix: upgrade Todoist SDK for proxy env var support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@doist/todoist-api-typescript": "7.2.0",
+        "@doist/todoist-api-typescript": "7.5.0",
         "@napi-rs/keyring": "1.2.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
@@ -34,7 +34,7 @@
         "vitest": "4.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@colors/colors": {
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/@doist/todoist-api-typescript": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-7.2.0.tgz",
-      "integrity": "sha512-JdTzh/p3bh3utAwRdNi9RpYv5ECaz656ieGLfmUVa6OD9hu1VUuRTe2xkRMVxzdMUHCELyfF0IjQ0DF5Cr9UHA==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-7.5.0.tgz",
+      "integrity": "sha512-F+b/U3jS7gyAjjeyZWTJE1thxmzEpevqHilOHDtbN/HHvdbfPrVUmVlgiqk+HLcCjmYb9VkleGUupMAsCO5Ycg==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "6.3.0",
@@ -62,7 +62,7 @@
         "zod": "4.3.6"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.18.1"
       },
       "peerDependencies": {
         "type-fest": "^4.12.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=20.18.1"
   },
   "files": [
     "dist",
@@ -51,7 +51,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@doist/todoist-api-typescript": "7.2.0",
+    "@doist/todoist-api-typescript": "7.5.0",
     "@napi-rs/keyring": "1.2.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",


### PR DESCRIPTION
## Summary
- bump `@doist/todoist-api-typescript` from `7.2.0` to `7.5.0`
- refresh `package-lock.json`

## Validation
- `npm run format:check`
- `npm run lint:check`
- `TZ=UTC npm test`
- `npm run type-check`