### PR TITLE
Add notify-uids support for comment creation

### DIFF
--- a/src/commands/comment.ts
+++ b/src/commands/comment.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk'
 import { Command } from 'commander'
+import { createCommentV1 } from '../lib/api/comments.js'
 import { getApi } from '../lib/api/core.js'
 import { uploadFile } from '../lib/api/uploads.js'
 import { openInBrowser } from '../lib/browser.js'
@@ -108,6 +109,7 @@ interface AddOptions {
     content: string
     file?: string
     project?: boolean
+    notifyUids?: string
 }
 
 async function addComment(ref: string, options: AddOptions): Promise<void> {
@@ -124,6 +126,13 @@ async function addComment(ref: string, options: AddOptions): Promise<void> {
         targetArgs = { taskId: task.id }
         targetName = task.content
     }
+
+    const notifyUids = options.notifyUids
+        ? options.notifyUids
+              .split(',')
+              .map((s) => s.trim())
+              .filter(Boolean)
+        : []
 
     let attachment:
         | {
@@ -144,11 +153,19 @@ async function addComment(ref: string, options: AddOptions): Promise<void> {
         }
     }
 
-    const comment = await api.addComment({
-        ...targetArgs,
-        content: options.content,
-        ...(attachment && { attachment }),
-    })
+    const comment =
+        notifyUids.length > 0
+            ? await createCommentV1({
+                  ...targetArgs,
+                  content: options.content,
+                  ...(attachment && { attachment }),
+                  uidsToNotify: notifyUids,
+              })
+            : await api.addComment({
+                  ...targetArgs,
+                  content: options.content,
+                  ...(attachment && { attachment }),
+              })
 
     console.log(`Added comment to "${targetName}"`)
     if (attachment) {
@@ -264,6 +281,10 @@ export function registerCommentCommand(program: Command): void {
         .option('-P, --project', 'Target a project instead of a task')
         .option('--content <text>', 'Comment content (required)')
         .option('--file <path>', 'Attach a file to the comment')
+        .option(
+            '--notify-uids <uids>',
+            'Comma-separated Todoist user IDs to notify (API v1: uids_to_notify)',
+        )
         .action((ref, options) => {
             if (!ref || !options.content) {
                 addCmd.help()

--- a/src/lib/api/comments.ts
+++ b/src/lib/api/comments.ts
@@ -1,0 +1,57 @@
+import { getApiToken } from '../auth.js'
+
+export interface CreateCommentV1Args {
+    taskId?: string
+    projectId?: string
+    content: string
+    attachment?: unknown
+    uidsToNotify?: string[]
+}
+
+export interface CommentV1Response {
+    id: string
+    posted_uid: string
+    content: string
+    file_attachment: unknown
+    uids_to_notify: string[] | null
+    is_deleted: boolean
+    posted_at: string
+    reactions: unknown
+    item_id?: string
+    project_id?: string
+}
+
+/**
+ * Create comment via Todoist API v1.
+ * We use this to pass uids_to_notify (not supported by the official REST v2 docs).
+ */
+export async function createCommentV1(args: CreateCommentV1Args): Promise<CommentV1Response> {
+    if (!args.taskId && !args.projectId) {
+        throw new Error('createCommentV1 requires taskId or projectId')
+    }
+
+    const token = await getApiToken()
+    const res = await fetch('https://api.todoist.com/api/v1/comments', {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            ...(args.taskId ? { task_id: args.taskId } : {}),
+            ...(args.projectId ? { project_id: args.projectId } : {}),
+            content: args.content,
+            ...(args.attachment ? { attachment: args.attachment } : {}),
+            ...(args.uidsToNotify && args.uidsToNotify.length > 0
+                ? { uids_to_notify: args.uidsToNotify }
+                : {}),
+        }),
+    })
+
+    const text = await res.text()
+    if (!res.ok) {
+        throw new Error(`API v1 create comment failed: ${res.status} ${text}`)
+    }
+
+    return JSON.parse(text) as CommentV1Response
+}


### PR DESCRIPTION
Add support for notifying specific Todoist users when creating a task/project comment from the CLI.

- adds a `--notify-uids` option to `td comment add`
- routes notified-comment creation through Todoist API v1 so `uids_to_notify` is actually sent
- keeps the existing comment creation path unchanged when no notifications are requested

特に確認してもらいたいところ/懸念点:
- Todoist API v1 の `uids_to_notify` を使う実装にしている。public REST v2 client では直接扱えないため、通知付きコメント時のみ v1 を直接叩く形にした
- 返却 payload は最小限の型付けにしているので、必要なら後で型をもう少し厳密にしてもいい

Auto-generated by OpenClaw
@kanato-masayoshi レビューよろしく