### PR TITLE
chore(deps): Updates `@doist/todoist-api-typescript` to v7.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@doist/todoist-api-typescript": "7.5.0",
+        "@doist/todoist-api-typescript": "7.7.0",
         "@napi-rs/keyring": "1.2.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/@doist/todoist-api-typescript": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-7.5.0.tgz",
-      "integrity": "sha512-F+b/U3jS7gyAjjeyZWTJE1thxmzEpevqHilOHDtbN/HHvdbfPrVUmVlgiqk+HLcCjmYb9VkleGUupMAsCO5Ycg==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-7.7.0.tgz",
+      "integrity": "sha512-66JQG195EBPPXJo5hZRyqpyxn27Od7SAjHjfiWS6pdC2RfMtCmit2yZqf/Io7ECDtY9CaOoEep+Nd1DGuIzWKQ==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@doist/todoist-api-typescript": "7.5.0",
+    "@doist/todoist-api-typescript": "7.7.0",
     "@napi-rs/keyring": "1.2.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",

--- a/src/__tests__/attachment.test.ts
+++ b/src/__tests__/attachment.test.ts
@@ -1,4 +1,4 @@
-import type { ViewAttachmentResponse } from '@doist/todoist-api-typescript'
+import type { FileResponse } from '@doist/todoist-api-typescript'
 import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -33,7 +33,7 @@ function createMockResponse({
     contentType?: string
     contentLength?: string
     body?: ArrayBuffer | string
-}): ViewAttachmentResponse {
+}): FileResponse {
     const headers: Record<string, string> = { 'content-type': contentType }
     if (contentLength) {
         headers['content-length'] = contentLength


### PR DESCRIPTION
Also corrects a change that should have meant a breaking change in the SDK (oops 🤦🏻‍♂️)