### PR TITLE
fix: changelog parsing skips latest version entry

### DIFF
--- a/src/__tests__/changelog.test.ts
+++ b/src/__tests__/changelog.test.ts
@@ -81,6 +81,27 @@ describe('changelog command', () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('View full changelog'))
     })
 
+    it('includes latest version when changelog has no preamble', async () => {
+        const noPreambleChangelog = `## [2.0.0](https://example.com) (2026-03-20)
+
+### Features
+* new major version
+
+## [1.5.0](https://example.com) (2026-03-15)
+
+### Features
+* feature five
+`
+        mockReadFile.mockResolvedValue(noPreambleChangelog)
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'td', 'changelog'])
+
+        const output = consoleSpy.mock.calls[0][0] as string
+        expect(output).toContain('2.0.0')
+        expect(output).toContain('1.5.0')
+    })
+
     it('respects --count option', async () => {
         mockReadFile.mockResolvedValue(SAMPLE_CHANGELOG)
 

--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -58,7 +58,7 @@ function cleanChangelog(text: string): string {
 
 function parseChangelog(content: string, count: number): { text: string; hasMore: boolean } {
     const sections = content.split(/\n(?=## \[)/)
-    const versionSections = sections.slice(1)
+    const versionSections = sections.filter((s) => s.startsWith('## ['))
     const selected = versionSections.slice(0, count)
 
     if (selected.length === 0) {


### PR DESCRIPTION
## Summary
- Fixes #196 — `td changelog` was missing the most recent version entry
- `parseChangelog` used `sections.slice(1)` assuming the first section was a preamble, but `@semantic-release/changelog` prepends versions to the top of CHANGELOG.md, so the first section is the latest version
- Changed to `sections.filter(s => s.startsWith('## ['))` to identify version sections by content rather than position

## Test plan
- [x] Added test for changelog without preamble (semantic-release format)
- [x] All 1100 existing tests pass
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)