### PR TITLE
chore: scope bot token permissions and fail closed on ID lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,9 @@ jobs:
               with:
                   app-id: ${{ secrets.DOIST_RELEASE_BOT_ID }}
                   private-key: ${{ secrets.DOIST_RELEASE_BOT_PRIVATE_KEY }}
-                  permissions: contents:write, issues:write, pull-requests:write
+                  permission-contents: write
+                  permission-issues: write
+                  permission-pull-requests: write
 
             - name: Get bot user ID
               id: bot_user


### PR DESCRIPTION
## Summary
- Add explicit `permissions` to `create-github-app-token` so the token is least-privileged (`contents:write`, `issues:write`, `pull-requests:write`)
- Fix bot user ID lookup to fail the workflow if `gh api` errors or returns empty, instead of silently continuing with a malformed email

Part of https://github.com/Doist/todoist-web/issues/16941

🤖 Generated with [Claude Code](https://claude.com/claude-code)