### PR TITLE
feat: add folder command group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@doist/todoist-sdk": "9.3.0",
+        "@doist/todoist-sdk": "9.8.0",
         "@napi-rs/keyring": "1.2.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@doist/todoist-sdk": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-9.3.0.tgz",
-      "integrity": "sha512-5OcyZlTlMU1h4mwGcgIjADnZc1OYmx3eW9Lm1A9vhZw8WEpDS5VgZ33cGnYYZBn9T/eVD0yJdjuwG78hrGbsIQ==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-9.8.0.tgz",
+      "integrity": "sha512-qCXWlV3BTZfF9xhgs4slHttf9kna4F0HN16+S4osbc8WxNNcZlzbre8PzewWuVyd4RskcGyMsEogZLZC8U/0Gg==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@doist/todoist-sdk": "9.3.0",
+    "@doist/todoist-sdk": "9.8.0",
     "@napi-rs/keyring": "1.2.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -59,7 +59,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Task lifecycle: `td task list/view/add/quickadd/update/reschedule/move/complete/uncomplete/delete/browse` (alias: `td task qa` for `quickadd`)
 - Projects: `td project list/view/create/update/archive/unarchive/archived/delete/move/join/browse/collaborators/permissions`
 - Project analytics: `td project progress/health/health-context/activity-stats/analyze-health`
-- Organization: `td label ...`, `td filter ...`, `td section ...`, `td workspace ...`
+- Organization: `td label ...`, `td filter ...`, `td section ...`, `td folder ...`, `td workspace ...`
 - Collaboration: `td comment ...`, `td notification ...`, `td reminder ...`
 - Templates and files: `td template ...`, `td attachment view <file-url>`, `td backup ...`
 - Help Center: `td hc locales/search/view`
@@ -149,6 +149,11 @@ td workspace update "Acme" --description "Acme Inc." --dry-run   # admin-only
 td workspace delete "Old WS" --yes                                # admin-only
 td workspace user-tasks "Acme" --user alice@example.com
 td workspace activity "Acme" --json
+td folder list "Acme"
+td folder view "Engineering"
+td folder create "Acme" --name "Engineering"
+td folder update "Engineering" --name "Platform" --workspace "Acme"
+td folder delete "Engineering" --workspace "Acme" --yes
 ```
 
 ### Labels, Filters, And Sections

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -127,6 +127,8 @@ td project view "Roadmap" --detailed
 td project collaborators "Roadmap"
 td project create --name "New Project" --color blue
 td project update "Roadmap" --favorite
+td project update "Roadmap" --folder "Engineering"
+td project update "Roadmap" --no-folder
 td project archive "Roadmap"
 td project unarchive "Roadmap"
 td project move "Roadmap" --to-workspace "Acme" --folder "Engineering" --visibility team --yes

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -56,7 +56,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Task lifecycle: `td task list/view/add/quickadd/update/reschedule/move/complete/uncomplete/delete/browse` (alias: `td task qa` for `quickadd`)
 - Projects: `td project list/view/create/update/archive/unarchive/archived/delete/move/join/browse/collaborators/permissions`
 - Project analytics: `td project progress/health/health-context/activity-stats/analyze-health`
-- Organization: `td label ...`, `td filter ...`, `td section ...`, `td workspace ...`
+- Organization: `td label ...`, `td filter ...`, `td section ...`, `td folder ...`, `td workspace ...`
 - Collaboration: `td comment ...`, `td notification ...`, `td reminder ...`
 - Templates and files: `td template ...`, `td attachment view <file-url>`, `td backup ...`
 - Account and tooling: `td stats`, `td settings ...`, `td completion ...`, `td view <todoist-url>`, `td doctor`, `td update`, `td changelog`
@@ -145,6 +145,11 @@ td workspace update "Acme" --description "Acme Inc." --dry-run   # admin-only
 td workspace delete "Old WS" --yes                                # admin-only
 td workspace user-tasks "Acme" --user alice@example.com
 td workspace activity "Acme" --json
+td folder list "Acme"
+td folder view "Engineering"
+td folder create "Acme" --name "Engineering"
+td folder update "Engineering" --name "Platform" --workspace "Acme"
+td folder delete "Engineering" --workspace "Acme" --yes
 ```
 
 ### Labels, Filters, And Sections

--- a/src/__tests__/folder.test.ts
+++ b/src/__tests__/folder.test.ts
@@ -1,0 +1,468 @@
+import { Command } from 'commander'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/api/core.js', () => ({
+    getApi: vi.fn(),
+}))
+
+vi.mock('../lib/api/workspaces.js', () => ({
+    fetchWorkspaces: vi.fn(),
+    fetchWorkspaceFolders: vi.fn(),
+}))
+
+import { registerFolderCommand } from '../commands/folder/index.js'
+import { getApi } from '../lib/api/core.js'
+import { fetchWorkspaceFolders, fetchWorkspaces } from '../lib/api/workspaces.js'
+import { createMockApi, type MockApi } from './helpers/mock-api.js'
+
+const mockGetApi = vi.mocked(getApi)
+const mockFetchWorkspaces = vi.mocked(fetchWorkspaces)
+const mockFetchWorkspaceFolders = vi.mocked(fetchWorkspaceFolders)
+
+function createProgram() {
+    const program = new Command()
+    program.exitOverride()
+    registerFolderCommand(program)
+    return program
+}
+
+const mockWorkspace = {
+    id: '12345',
+    name: 'Acme',
+    role: 'ADMIN' as const,
+    plan: 'BUSINESS',
+    domainName: 'acme.com',
+    currentMemberCount: 10,
+    currentActiveProjects: 5,
+    memberCountByType: { adminCount: 1, memberCount: 8, guestCount: 1 },
+}
+
+const mockFolder = {
+    id: 'folder-1',
+    name: 'Engineering',
+    workspaceId: '12345',
+    isDeleted: false,
+    defaultOrder: 0,
+    childOrder: 1,
+}
+
+describe('folder list', () => {
+    let mockApi: MockApi
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+        mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    it('lists folders for a workspace', async () => {
+        const program = createProgram()
+        mockApi.getFolders.mockResolvedValue({
+            results: [mockFolder, { ...mockFolder, id: 'folder-2', name: 'Design' }],
+            nextCursor: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'folder', 'list', 'Acme'])
+
+        expect(mockApi.getFolders).toHaveBeenCalledWith(
+            expect.objectContaining({ workspaceId: 12345 }),
+        )
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Engineering'))
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Design'))
+        consoleSpy.mockRestore()
+    })
+
+    it('shows "No folders found." when empty', async () => {
+        const program = createProgram()
+        mockApi.getFolders.mockResolvedValue({ results: [], nextCursor: null })
+
+        await program.parseAsync(['node', 'td', 'folder', 'list', 'Acme'])
+
+        expect(consoleSpy).toHaveBeenCalledWith('No folders found.')
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs JSON with --json flag', async () => {
+        const program = createProgram()
+        mockApi.getFolders.mockResolvedValue({
+            results: [mockFolder],
+            nextCursor: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'folder', 'list', 'Acme', '--json'])
+
+        const output = consoleSpy.mock.calls[0][0]
+        const parsed = JSON.parse(output)
+        expect(parsed.results).toBeDefined()
+        expect(parsed.results[0].name).toBe('Engineering')
+        consoleSpy.mockRestore()
+    })
+
+    it('accepts --workspace flag instead of positional arg', async () => {
+        const program = createProgram()
+        mockApi.getFolders.mockResolvedValue({ results: [], nextCursor: null })
+
+        await program.parseAsync(['node', 'td', 'folder', 'list', '--workspace', 'Acme'])
+
+        expect(mockApi.getFolders).toHaveBeenCalled()
+        consoleSpy.mockRestore()
+    })
+
+    it('errors when both positional and --workspace are provided', async () => {
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'td', 'folder', 'list', 'Acme', '--workspace', 'Other']),
+        ).rejects.toThrow('Cannot specify workspace both as argument and --workspace flag')
+    })
+})
+
+describe('folder create', () => {
+    let mockApi: MockApi
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+        mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    it('creates folder in workspace', async () => {
+        const program = createProgram()
+        mockApi.addFolder.mockResolvedValue(mockFolder)
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'folder',
+            'create',
+            'Acme',
+            '--name',
+            'Engineering',
+        ])
+
+        expect(mockApi.addFolder).toHaveBeenCalledWith({
+            name: 'Engineering',
+            workspaceId: 12345,
+            defaultOrder: undefined,
+            childOrder: undefined,
+        })
+        expect(consoleSpy).toHaveBeenCalledWith('Created: Engineering')
+        consoleSpy.mockRestore()
+    })
+
+    it('shows folder ID after creation', async () => {
+        const program = createProgram()
+        mockApi.addFolder.mockResolvedValue(mockFolder)
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'folder',
+            'create',
+            'Acme',
+            '--name',
+            'Engineering',
+        ])
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('folder-1'))
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs created folder as JSON with --json', async () => {
+        const program = createProgram()
+        mockApi.addFolder.mockResolvedValue(mockFolder)
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'folder',
+            'create',
+            'Acme',
+            '--name',
+            'Engineering',
+            '--json',
+        ])
+
+        const output = consoleSpy.mock.calls[0][0]
+        const parsed = JSON.parse(output)
+        expect(parsed.id).toBe('folder-1')
+        expect(parsed.name).toBe('Engineering')
+        consoleSpy.mockRestore()
+    })
+
+    it('shows dry-run preview with --dry-run', async () => {
+        const program = createProgram()
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'folder',
+            'create',
+            'Acme',
+            '--name',
+            'Engineering',
+            '--dry-run',
+        ])
+
+        expect(mockApi.addFolder).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would create folder'))
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('folder update', () => {
+    let mockApi: MockApi
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+        mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
+        mockFetchWorkspaceFolders.mockResolvedValue([
+            { id: 'folder-1', name: 'Engineering', workspaceId: '12345' },
+        ])
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    it('updates folder name by id:xxx', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+        mockApi.updateFolder.mockResolvedValue({ ...mockFolder, name: 'Platform' })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'folder',
+            'update',
+            'id:folder-1',
+            '--name',
+            'Platform',
+        ])
+
+        expect(mockApi.updateFolder).toHaveBeenCalledWith('folder-1', { name: 'Platform' })
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Engineering → Platform'))
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs updated folder as JSON with --json', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+        mockApi.updateFolder.mockResolvedValue({ ...mockFolder, name: 'Platform' })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'folder',
+            'update',
+            'id:folder-1',
+            '--name',
+            'Platform',
+            '--json',
+        ])
+
+        const output = consoleSpy.mock.calls[0][0]
+        const parsed = JSON.parse(output)
+        expect(parsed.name).toBe('Platform')
+        consoleSpy.mockRestore()
+    })
+
+    it('errors with NO_CHANGES when no update flags provided', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+
+        await expect(
+            program.parseAsync(['node', 'td', 'folder', 'update', 'id:folder-1']),
+        ).rejects.toHaveProperty('code', 'NO_CHANGES')
+    })
+
+    it('shows dry-run preview with --dry-run', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'folder',
+            'update',
+            'id:folder-1',
+            '--name',
+            'Platform',
+            '--dry-run',
+        ])
+
+        expect(mockApi.updateFolder).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would update folder'))
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('folder delete', () => {
+    let mockApi: MockApi
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+        mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
+        mockFetchWorkspaceFolders.mockResolvedValue([
+            { id: 'folder-1', name: 'Engineering', workspaceId: '12345' },
+        ])
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    it('shows confirmation prompt without --yes', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+
+        await program.parseAsync(['node', 'td', 'folder', 'delete', 'id:folder-1'])
+
+        expect(mockApi.deleteFolder).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith('Would delete folder: Engineering')
+        expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
+        consoleSpy.mockRestore()
+    })
+
+    it('deletes folder with --yes', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+        mockApi.deleteFolder.mockResolvedValue(true)
+
+        await program.parseAsync(['node', 'td', 'folder', 'delete', 'id:folder-1', '--yes'])
+
+        expect(mockApi.deleteFolder).toHaveBeenCalledWith('folder-1')
+        expect(consoleSpy).toHaveBeenCalledWith('Deleted: Engineering (id:folder-1)')
+        consoleSpy.mockRestore()
+    })
+
+    it('shows dry-run preview with --dry-run', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+
+        await program.parseAsync(['node', 'td', 'folder', 'delete', 'id:folder-1', '--dry-run'])
+
+        expect(mockApi.deleteFolder).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would delete folder'))
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('folder view', () => {
+    let mockApi: MockApi
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+        mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
+        mockFetchWorkspaceFolders.mockResolvedValue([
+            { id: 'folder-1', name: 'Engineering', workspaceId: '12345' },
+        ])
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    it('shows folder details and contained projects', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+        mockApi.getProjects.mockResolvedValue({
+            results: [
+                {
+                    id: 'proj-1',
+                    name: 'Backend',
+                    workspaceId: '12345',
+                    folderId: 'folder-1',
+                },
+                {
+                    id: 'proj-2',
+                    name: 'Frontend',
+                    workspaceId: '12345',
+                    folderId: 'folder-1',
+                },
+                {
+                    id: 'proj-3',
+                    name: 'Other',
+                    workspaceId: '12345',
+                    folderId: 'folder-2',
+                },
+            ],
+            nextCursor: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'folder', 'view', 'id:folder-1'])
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Engineering'))
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Backend'))
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Frontend'))
+        consoleSpy.mockRestore()
+    })
+
+    it('shows "No projects in this folder." when empty', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+        mockApi.getProjects.mockResolvedValue({ results: [], nextCursor: null })
+
+        await program.parseAsync(['node', 'td', 'folder', 'view', 'id:folder-1'])
+
+        expect(consoleSpy).toHaveBeenCalledWith('No projects in this folder.')
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs JSON with --json flag', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+        mockApi.getProjects.mockResolvedValue({ results: [], nextCursor: null })
+
+        await program.parseAsync(['node', 'td', 'folder', 'view', 'id:folder-1', '--json'])
+
+        const output = consoleSpy.mock.calls[0][0]
+        const parsed = JSON.parse(output)
+        expect(parsed.folder).toBeDefined()
+        expect(parsed.folder.id).toBe('folder-1')
+        expect(parsed.projects).toBeDefined()
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('folder workspace auto-detection', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+        mockFetchWorkspaceFolders.mockResolvedValue([
+            { id: 'folder-1', name: 'Engineering', workspaceId: '12345' },
+        ])
+    })
+
+    it('auto-detects single workspace for folder resolution', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+        mockApi.getProjects.mockResolvedValue({ results: [], nextCursor: null })
+
+        await program.parseAsync(['node', 'td', 'folder', 'view', 'Engineering'])
+
+        expect(mockApi.getFolder).toHaveBeenCalledWith('folder-1')
+        consoleSpy.mockRestore()
+    })
+
+    it('errors when multiple workspaces and no --workspace', async () => {
+        const program = createProgram()
+        const secondWorkspace = { ...mockWorkspace, id: '67890', name: 'Other' }
+        mockFetchWorkspaces.mockResolvedValue([mockWorkspace, secondWorkspace])
+
+        await expect(
+            program.parseAsync(['node', 'td', 'folder', 'view', 'Engineering']),
+        ).rejects.toThrow('Multiple workspaces found')
+    })
+})

--- a/src/__tests__/folder.test.ts
+++ b/src/__tests__/folder.test.ts
@@ -68,7 +68,7 @@ describe('folder list', () => {
         await program.parseAsync(['node', 'td', 'folder', 'list', 'Acme'])
 
         expect(mockApi.getFolders).toHaveBeenCalledWith(
-            expect.objectContaining({ workspaceId: 12345 }),
+            expect.objectContaining({ workspaceId: '12345' }),
         )
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Engineering'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Design'))
@@ -148,7 +148,7 @@ describe('folder create', () => {
 
         expect(mockApi.addFolder).toHaveBeenCalledWith({
             name: 'Engineering',
-            workspaceId: 12345,
+            workspaceId: '12345',
             defaultOrder: undefined,
             childOrder: undefined,
         })

--- a/src/__tests__/helpers/mock-api.ts
+++ b/src/__tests__/helpers/mock-api.ts
@@ -188,6 +188,12 @@ export function createMockApi(overrides: Partial<TodoistApi> = {}): MockApi {
         getAppTestToken: vi.fn().mockResolvedValue({ accessToken: null }),
         getAppDistributionToken: vi.fn().mockResolvedValue({ distributionToken: '' }),
         getAppWebhook: vi.fn().mockResolvedValue(null),
+        // Folders
+        getFolders: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
+        getFolder: vi.fn(),
+        addFolder: vi.fn(),
+        updateFolder: vi.fn(),
+        deleteFolder: vi.fn().mockResolvedValue(true),
         ...overrides,
     } as unknown as MockApi
 }

--- a/src/commands/folder/create.ts
+++ b/src/commands/folder/create.ts
@@ -7,8 +7,8 @@ import { resolveWorkspaceRef } from '../../lib/refs.js'
 interface CreateFolderOptions {
     name: string
     workspace?: string
-    defaultOrder?: string
-    childOrder?: string
+    defaultOrder?: number
+    childOrder?: number
     json?: boolean
     dryRun?: boolean
 }
@@ -21,8 +21,10 @@ export async function createFolder(
         printDryRun('create folder', {
             Name: options.name,
             Workspace: workspaceRef,
-            'Default order': options.defaultOrder,
-            'Child order': options.childOrder,
+            'Default order':
+                options.defaultOrder !== undefined ? String(options.defaultOrder) : undefined,
+            'Child order':
+                options.childOrder !== undefined ? String(options.childOrder) : undefined,
         })
         return
     }
@@ -33,8 +35,8 @@ export async function createFolder(
     const folder = await api.addFolder({
         name: options.name,
         workspaceId: workspace.id,
-        defaultOrder: options.defaultOrder ? parseInt(options.defaultOrder, 10) : undefined,
-        childOrder: options.childOrder ? parseInt(options.childOrder, 10) : undefined,
+        defaultOrder: options.defaultOrder,
+        childOrder: options.childOrder,
     })
 
     if (options.json) {

--- a/src/commands/folder/create.ts
+++ b/src/commands/folder/create.ts
@@ -38,7 +38,7 @@ export async function createFolder(
     })
 
     if (options.json) {
-        console.log(formatJson(folder))
+        console.log(formatJson(folder, 'folder'))
         return
     }
 

--- a/src/commands/folder/create.ts
+++ b/src/commands/folder/create.ts
@@ -1,0 +1,52 @@
+import chalk from 'chalk'
+import { getApi } from '../../lib/api/core.js'
+import { isQuiet } from '../../lib/global-args.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
+import { resolveWorkspaceRef } from '../../lib/refs.js'
+
+interface CreateFolderOptions {
+    name: string
+    workspace?: string
+    defaultOrder?: string
+    childOrder?: string
+    json?: boolean
+    dryRun?: boolean
+}
+
+export async function createFolder(
+    workspaceRef: string,
+    options: CreateFolderOptions,
+): Promise<void> {
+    if (options.dryRun) {
+        printDryRun('create folder', {
+            Name: options.name,
+            Workspace: workspaceRef,
+            'Default order': options.defaultOrder,
+            'Child order': options.childOrder,
+        })
+        return
+    }
+
+    const workspace = await resolveWorkspaceRef(workspaceRef)
+    const api = await getApi()
+
+    const folder = await api.addFolder({
+        name: options.name,
+        workspaceId: parseInt(workspace.id, 10),
+        defaultOrder: options.defaultOrder ? parseInt(options.defaultOrder, 10) : undefined,
+        childOrder: options.childOrder ? parseInt(options.childOrder, 10) : undefined,
+    })
+
+    if (options.json) {
+        console.log(formatJson(folder))
+        return
+    }
+
+    if (isQuiet()) {
+        console.log(folder.id)
+        return
+    }
+
+    console.log(`Created: ${folder.name}`)
+    console.log(chalk.dim(`ID: ${folder.id}`))
+}

--- a/src/commands/folder/create.ts
+++ b/src/commands/folder/create.ts
@@ -32,7 +32,7 @@ export async function createFolder(
 
     const folder = await api.addFolder({
         name: options.name,
-        workspaceId: parseInt(workspace.id, 10),
+        workspaceId: workspace.id,
         defaultOrder: options.defaultOrder ? parseInt(options.defaultOrder, 10) : undefined,
         childOrder: options.childOrder ? parseInt(options.childOrder, 10) : undefined,
     })

--- a/src/commands/folder/delete.ts
+++ b/src/commands/folder/delete.ts
@@ -1,0 +1,26 @@
+import { getApi } from '../../lib/api/core.js'
+import { isQuiet } from '../../lib/global-args.js'
+import { printDryRun } from '../../lib/output.js'
+import { resolveFolderByRef } from './helpers.js'
+
+export async function deleteFolder(
+    ref: string,
+    options: { workspace?: string; yes?: boolean; dryRun?: boolean },
+): Promise<void> {
+    const folder = await resolveFolderByRef(ref, options)
+
+    if (options.dryRun) {
+        printDryRun('delete folder', { Folder: folder.name })
+        return
+    }
+
+    if (!options.yes) {
+        console.log(`Would delete folder: ${folder.name}`)
+        console.log('Use --yes to confirm.')
+        return
+    }
+
+    const api = await getApi()
+    await api.deleteFolder(folder.id)
+    if (!isQuiet()) console.log(`Deleted: ${folder.name} (id:${folder.id})`)
+}

--- a/src/commands/folder/folder.test.ts
+++ b/src/commands/folder/folder.test.ts
@@ -10,10 +10,10 @@ vi.mock('../../lib/api/workspaces.js', () => ({
     fetchWorkspaceFolders: vi.fn(),
 }))
 
-import { registerFolderCommand } from './index.js'
 import { getApi } from '../../lib/api/core.js'
 import { fetchWorkspaceFolders, fetchWorkspaces } from '../../lib/api/workspaces.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { registerFolderCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
 const mockFetchWorkspaces = vi.mocked(fetchWorkspaces)

--- a/src/commands/folder/folder.test.ts
+++ b/src/commands/folder/folder.test.ts
@@ -214,6 +214,42 @@ describe('folder create', () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would create folder'))
         consoleSpy.mockRestore()
     })
+
+    it('rejects invalid --default-order', async () => {
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'folder',
+                'create',
+                'Acme',
+                '--name',
+                'Engineering',
+                '--default-order',
+                'abc',
+            ]),
+        ).rejects.toHaveProperty('code', 'INVALID_ORDER')
+    })
+
+    it('rejects negative --child-order', async () => {
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'folder',
+                'create',
+                'Acme',
+                '--name',
+                'Engineering',
+                '--child-order',
+                '-1',
+            ]),
+        ).rejects.toHaveProperty('code', 'INVALID_ORDER')
+    })
 })
 
 describe('folder update', () => {

--- a/src/commands/folder/folder.test.ts
+++ b/src/commands/folder/folder.test.ts
@@ -1,0 +1,468 @@
+import { Command } from 'commander'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../lib/api/core.js', () => ({
+    getApi: vi.fn(),
+}))
+
+vi.mock('../../lib/api/workspaces.js', () => ({
+    fetchWorkspaces: vi.fn(),
+    fetchWorkspaceFolders: vi.fn(),
+}))
+
+import { registerFolderCommand } from './index.js'
+import { getApi } from '../../lib/api/core.js'
+import { fetchWorkspaceFolders, fetchWorkspaces } from '../../lib/api/workspaces.js'
+import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+
+const mockGetApi = vi.mocked(getApi)
+const mockFetchWorkspaces = vi.mocked(fetchWorkspaces)
+const mockFetchWorkspaceFolders = vi.mocked(fetchWorkspaceFolders)
+
+function createProgram() {
+    const program = new Command()
+    program.exitOverride()
+    registerFolderCommand(program)
+    return program
+}
+
+const mockWorkspace = {
+    id: '12345',
+    name: 'Acme',
+    role: 'ADMIN' as const,
+    plan: 'BUSINESS',
+    domainName: 'acme.com',
+    currentMemberCount: 10,
+    currentActiveProjects: 5,
+    memberCountByType: { adminCount: 1, memberCount: 8, guestCount: 1 },
+}
+
+const mockFolder = {
+    id: 'folder-1',
+    name: 'Engineering',
+    workspaceId: '12345',
+    isDeleted: false,
+    defaultOrder: 0,
+    childOrder: 1,
+}
+
+describe('folder list', () => {
+    let mockApi: MockApi
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+        mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    it('lists folders for a workspace', async () => {
+        const program = createProgram()
+        mockApi.getFolders.mockResolvedValue({
+            results: [mockFolder, { ...mockFolder, id: 'folder-2', name: 'Design' }],
+            nextCursor: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'folder', 'list', 'Acme'])
+
+        expect(mockApi.getFolders).toHaveBeenCalledWith(
+            expect.objectContaining({ workspaceId: 12345 }),
+        )
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Engineering'))
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Design'))
+        consoleSpy.mockRestore()
+    })
+
+    it('shows "No folders found." when empty', async () => {
+        const program = createProgram()
+        mockApi.getFolders.mockResolvedValue({ results: [], nextCursor: null })
+
+        await program.parseAsync(['node', 'td', 'folder', 'list', 'Acme'])
+
+        expect(consoleSpy).toHaveBeenCalledWith('No folders found.')
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs JSON with --json flag', async () => {
+        const program = createProgram()
+        mockApi.getFolders.mockResolvedValue({
+            results: [mockFolder],
+            nextCursor: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'folder', 'list', 'Acme', '--json'])
+
+        const output = consoleSpy.mock.calls[0][0]
+        const parsed = JSON.parse(output)
+        expect(parsed.results).toBeDefined()
+        expect(parsed.results[0].name).toBe('Engineering')
+        consoleSpy.mockRestore()
+    })
+
+    it('accepts --workspace flag instead of positional arg', async () => {
+        const program = createProgram()
+        mockApi.getFolders.mockResolvedValue({ results: [], nextCursor: null })
+
+        await program.parseAsync(['node', 'td', 'folder', 'list', '--workspace', 'Acme'])
+
+        expect(mockApi.getFolders).toHaveBeenCalled()
+        consoleSpy.mockRestore()
+    })
+
+    it('errors when both positional and --workspace are provided', async () => {
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'td', 'folder', 'list', 'Acme', '--workspace', 'Other']),
+        ).rejects.toThrow('Cannot specify workspace both as argument and --workspace flag')
+    })
+})
+
+describe('folder create', () => {
+    let mockApi: MockApi
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+        mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    it('creates folder in workspace', async () => {
+        const program = createProgram()
+        mockApi.addFolder.mockResolvedValue(mockFolder)
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'folder',
+            'create',
+            'Acme',
+            '--name',
+            'Engineering',
+        ])
+
+        expect(mockApi.addFolder).toHaveBeenCalledWith({
+            name: 'Engineering',
+            workspaceId: 12345,
+            defaultOrder: undefined,
+            childOrder: undefined,
+        })
+        expect(consoleSpy).toHaveBeenCalledWith('Created: Engineering')
+        consoleSpy.mockRestore()
+    })
+
+    it('shows folder ID after creation', async () => {
+        const program = createProgram()
+        mockApi.addFolder.mockResolvedValue(mockFolder)
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'folder',
+            'create',
+            'Acme',
+            '--name',
+            'Engineering',
+        ])
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('folder-1'))
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs created folder as JSON with --json', async () => {
+        const program = createProgram()
+        mockApi.addFolder.mockResolvedValue(mockFolder)
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'folder',
+            'create',
+            'Acme',
+            '--name',
+            'Engineering',
+            '--json',
+        ])
+
+        const output = consoleSpy.mock.calls[0][0]
+        const parsed = JSON.parse(output)
+        expect(parsed.id).toBe('folder-1')
+        expect(parsed.name).toBe('Engineering')
+        consoleSpy.mockRestore()
+    })
+
+    it('shows dry-run preview with --dry-run', async () => {
+        const program = createProgram()
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'folder',
+            'create',
+            'Acme',
+            '--name',
+            'Engineering',
+            '--dry-run',
+        ])
+
+        expect(mockApi.addFolder).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would create folder'))
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('folder update', () => {
+    let mockApi: MockApi
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+        mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
+        mockFetchWorkspaceFolders.mockResolvedValue([
+            { id: 'folder-1', name: 'Engineering', workspaceId: '12345' },
+        ])
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    it('updates folder name by id:xxx', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+        mockApi.updateFolder.mockResolvedValue({ ...mockFolder, name: 'Platform' })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'folder',
+            'update',
+            'id:folder-1',
+            '--name',
+            'Platform',
+        ])
+
+        expect(mockApi.updateFolder).toHaveBeenCalledWith('folder-1', { name: 'Platform' })
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Engineering → Platform'))
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs updated folder as JSON with --json', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+        mockApi.updateFolder.mockResolvedValue({ ...mockFolder, name: 'Platform' })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'folder',
+            'update',
+            'id:folder-1',
+            '--name',
+            'Platform',
+            '--json',
+        ])
+
+        const output = consoleSpy.mock.calls[0][0]
+        const parsed = JSON.parse(output)
+        expect(parsed.name).toBe('Platform')
+        consoleSpy.mockRestore()
+    })
+
+    it('errors with NO_CHANGES when no update flags provided', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+
+        await expect(
+            program.parseAsync(['node', 'td', 'folder', 'update', 'id:folder-1']),
+        ).rejects.toHaveProperty('code', 'NO_CHANGES')
+    })
+
+    it('shows dry-run preview with --dry-run', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'folder',
+            'update',
+            'id:folder-1',
+            '--name',
+            'Platform',
+            '--dry-run',
+        ])
+
+        expect(mockApi.updateFolder).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would update folder'))
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('folder delete', () => {
+    let mockApi: MockApi
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+        mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
+        mockFetchWorkspaceFolders.mockResolvedValue([
+            { id: 'folder-1', name: 'Engineering', workspaceId: '12345' },
+        ])
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    it('shows confirmation prompt without --yes', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+
+        await program.parseAsync(['node', 'td', 'folder', 'delete', 'id:folder-1'])
+
+        expect(mockApi.deleteFolder).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith('Would delete folder: Engineering')
+        expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
+        consoleSpy.mockRestore()
+    })
+
+    it('deletes folder with --yes', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+        mockApi.deleteFolder.mockResolvedValue(true)
+
+        await program.parseAsync(['node', 'td', 'folder', 'delete', 'id:folder-1', '--yes'])
+
+        expect(mockApi.deleteFolder).toHaveBeenCalledWith('folder-1')
+        expect(consoleSpy).toHaveBeenCalledWith('Deleted: Engineering (id:folder-1)')
+        consoleSpy.mockRestore()
+    })
+
+    it('shows dry-run preview with --dry-run', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+
+        await program.parseAsync(['node', 'td', 'folder', 'delete', 'id:folder-1', '--dry-run'])
+
+        expect(mockApi.deleteFolder).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would delete folder'))
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('folder view', () => {
+    let mockApi: MockApi
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+        mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
+        mockFetchWorkspaceFolders.mockResolvedValue([
+            { id: 'folder-1', name: 'Engineering', workspaceId: '12345' },
+        ])
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    it('shows folder details and contained projects', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+        mockApi.getProjects.mockResolvedValue({
+            results: [
+                {
+                    id: 'proj-1',
+                    name: 'Backend',
+                    workspaceId: '12345',
+                    folderId: 'folder-1',
+                },
+                {
+                    id: 'proj-2',
+                    name: 'Frontend',
+                    workspaceId: '12345',
+                    folderId: 'folder-1',
+                },
+                {
+                    id: 'proj-3',
+                    name: 'Other',
+                    workspaceId: '12345',
+                    folderId: 'folder-2',
+                },
+            ],
+            nextCursor: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'folder', 'view', 'id:folder-1'])
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Engineering'))
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Backend'))
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Frontend'))
+        consoleSpy.mockRestore()
+    })
+
+    it('shows "No projects in this folder." when empty', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+        mockApi.getProjects.mockResolvedValue({ results: [], nextCursor: null })
+
+        await program.parseAsync(['node', 'td', 'folder', 'view', 'id:folder-1'])
+
+        expect(consoleSpy).toHaveBeenCalledWith('No projects in this folder.')
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs JSON with --json flag', async () => {
+        const program = createProgram()
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+        mockApi.getProjects.mockResolvedValue({ results: [], nextCursor: null })
+
+        await program.parseAsync(['node', 'td', 'folder', 'view', 'id:folder-1', '--json'])
+
+        const output = consoleSpy.mock.calls[0][0]
+        const parsed = JSON.parse(output)
+        expect(parsed.folder).toBeDefined()
+        expect(parsed.folder.id).toBe('folder-1')
+        expect(parsed.projects).toBeDefined()
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('folder workspace auto-detection', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+        mockFetchWorkspaceFolders.mockResolvedValue([
+            { id: 'folder-1', name: 'Engineering', workspaceId: '12345' },
+        ])
+    })
+
+    it('auto-detects single workspace for folder resolution', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
+        mockApi.getFolder.mockResolvedValue(mockFolder)
+        mockApi.getProjects.mockResolvedValue({ results: [], nextCursor: null })
+
+        await program.parseAsync(['node', 'td', 'folder', 'view', 'Engineering'])
+
+        expect(mockApi.getFolder).toHaveBeenCalledWith('folder-1')
+        consoleSpy.mockRestore()
+    })
+
+    it('errors when multiple workspaces and no --workspace', async () => {
+        const program = createProgram()
+        const secondWorkspace = { ...mockWorkspace, id: '67890', name: 'Other' }
+        mockFetchWorkspaces.mockResolvedValue([mockWorkspace, secondWorkspace])
+
+        await expect(
+            program.parseAsync(['node', 'td', 'folder', 'view', 'Engineering']),
+        ).rejects.toThrow('Multiple workspaces found')
+    })
+})

--- a/src/commands/folder/folder.test.ts
+++ b/src/commands/folder/folder.test.ts
@@ -68,7 +68,7 @@ describe('folder list', () => {
         await program.parseAsync(['node', 'td', 'folder', 'list', 'Acme'])
 
         expect(mockApi.getFolders).toHaveBeenCalledWith(
-            expect.objectContaining({ workspaceId: 12345 }),
+            expect.objectContaining({ workspaceId: '12345' }),
         )
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Engineering'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Design'))
@@ -148,7 +148,7 @@ describe('folder create', () => {
 
         expect(mockApi.addFolder).toHaveBeenCalledWith({
             name: 'Engineering',
-            workspaceId: 12345,
+            workspaceId: '12345',
             defaultOrder: undefined,
             childOrder: undefined,
         })

--- a/src/commands/folder/helpers.ts
+++ b/src/commands/folder/helpers.ts
@@ -1,0 +1,47 @@
+import type { Folder } from '@doist/todoist-sdk'
+import { getApi } from '../../lib/api/core.js'
+import { fetchWorkspaces, type Workspace } from '../../lib/api/workspaces.js'
+import { CliError } from '../../lib/errors.js'
+import { resolveFolderRef, resolveWorkspaceRef } from '../../lib/refs.js'
+
+export async function resolveWorkspaceForFolder(options: {
+    workspace?: string
+}): Promise<Workspace> {
+    if (options.workspace) {
+        return resolveWorkspaceRef(options.workspace)
+    }
+    const workspaces = await fetchWorkspaces()
+    if (workspaces.length === 0) {
+        throw new CliError(
+            'WORKSPACE_NOT_FOUND',
+            'No workspaces found. Folders require a workspace.',
+        )
+    }
+    if (workspaces.length === 1) {
+        return workspaces[0]
+    }
+    throw new CliError('WORKSPACE_NOT_FOUND', 'Multiple workspaces found. Specify --workspace.', [
+        'Available workspaces:',
+        ...workspaces.map((w) => `  "${w.name}" (id:${w.id})`),
+    ])
+}
+
+export async function resolveFolderByRef(
+    ref: string,
+    options: { workspace?: string },
+): Promise<Folder> {
+    const api = await getApi()
+
+    // id:xxx reference — fetch directly, no workspace needed
+    if (ref.startsWith('id:')) {
+        const id = ref.slice(3)
+        return api.getFolder(id)
+    }
+
+    // Otherwise resolve via workspace-scoped folder list
+    const workspace = await resolveWorkspaceForFolder(options)
+    const folder = await resolveFolderRef(ref, workspace.id)
+
+    // Fetch the full Folder object from the REST API
+    return api.getFolder(folder.id)
+}

--- a/src/commands/folder/index.ts
+++ b/src/commands/folder/index.ts
@@ -1,0 +1,133 @@
+import { Command } from 'commander'
+import { CURSOR_DESCRIPTION } from '../../lib/constants.js'
+import { CliError } from '../../lib/errors.js'
+import type { PaginatedViewOptions } from '../../lib/options.js'
+import { createFolder } from './create.js'
+import { deleteFolder } from './delete.js'
+import { listFolders } from './list.js'
+import { updateFolder } from './update.js'
+import { viewFolder } from './view.js'
+
+export function registerFolderCommand(program: Command): void {
+    const folder = program
+        .command('folder')
+        .description('Manage workspace folders')
+        .addHelpText(
+            'after',
+            `
+Examples:
+  td folder list "Acme"
+  td folder view "Engineering"
+  td folder create "Acme" --name "Engineering"
+  td folder delete "Engineering" --workspace "Acme" --yes`,
+        )
+
+    const listCmd = folder
+        .command('list [workspace]')
+        .description('List folders in a workspace')
+        .option('--workspace <ref>', 'Workspace name or id:xxx')
+        .option('--limit <n>', 'Limit number of results')
+        .option('--cursor <cursor>', CURSOR_DESCRIPTION)
+        .option('--all', 'Fetch all results (no limit)')
+        .option('--json', 'Output as JSON')
+        .option('--ndjson', 'Output as newline-delimited JSON')
+        .action(
+            (
+                refArg: string | undefined,
+                options: PaginatedViewOptions & { workspace?: string },
+            ) => {
+                if (refArg && options.workspace) {
+                    throw new CliError(
+                        'CONFLICTING_OPTIONS',
+                        'Cannot specify workspace both as argument and --workspace flag',
+                    )
+                }
+                const ref = refArg || options.workspace
+                if (!ref) {
+                    listCmd.help()
+                    return
+                }
+                return listFolders(ref, options)
+            },
+        )
+
+    folder
+        .command('view [ref]', { isDefault: true })
+        .description('View folder details and contained projects')
+        .option('--workspace <ref>', 'Workspace name or id:xxx (for name-based lookup)')
+        .option('--json', 'Output as JSON')
+        .option('--full', 'Include all fields in JSON output')
+        .action((ref, options) => {
+            if (!ref) {
+                folder.help()
+                return
+            }
+            return viewFolder(ref, options)
+        })
+
+    const createCmd = folder
+        .command('create [workspace]')
+        .description('Create a folder')
+        .option('--workspace <ref>', 'Workspace name or id:xxx')
+        .option('--name <name>', 'Folder name (required)')
+        .option('--default-order <n>', 'Default order for projects in the folder')
+        .option('--child-order <n>', 'Order position of the folder')
+        .option('--json', 'Output the created folder as JSON')
+        .option('--dry-run', 'Preview what would happen without executing')
+        .action(
+            (
+                refArg: string | undefined,
+                options: {
+                    workspace?: string
+                    name?: string
+                    defaultOrder?: string
+                    childOrder?: string
+                    json?: boolean
+                    dryRun?: boolean
+                },
+            ) => {
+                if (refArg && options.workspace) {
+                    throw new CliError(
+                        'CONFLICTING_OPTIONS',
+                        'Cannot specify workspace both as argument and --workspace flag',
+                    )
+                }
+                const ref = refArg || options.workspace
+                if (!ref || !options.name) {
+                    createCmd.help()
+                    return
+                }
+                return createFolder(ref, options as { name: string } & typeof options)
+            },
+        )
+
+    const updateCmd = folder
+        .command('update [ref]')
+        .description('Update a folder')
+        .option('--workspace <ref>', 'Workspace name or id:xxx (for name-based lookup)')
+        .option('--name <name>', 'New folder name')
+        .option('--default-order <n>', 'New default order for projects')
+        .option('--json', 'Output the updated folder as JSON')
+        .option('--dry-run', 'Preview what would happen without executing')
+        .action((ref, options) => {
+            if (!ref) {
+                updateCmd.help()
+                return
+            }
+            return updateFolder(ref, options)
+        })
+
+    const deleteCmd = folder
+        .command('delete [ref]')
+        .description('Delete a folder')
+        .option('--workspace <ref>', 'Workspace name or id:xxx (for name-based lookup)')
+        .option('--yes', 'Confirm deletion')
+        .option('--dry-run', 'Preview what would happen without executing')
+        .action((ref, options) => {
+            if (!ref) {
+                deleteCmd.help()
+                return
+            }
+            return deleteFolder(ref, options)
+        })
+}

--- a/src/commands/folder/index.ts
+++ b/src/commands/folder/index.ts
@@ -8,6 +8,16 @@ import { listFolders } from './list.js'
 import { updateFolder } from './update.js'
 import { viewFolder } from './view.js'
 
+function parseOrderArg(val: string): number {
+    const n = Number(val)
+    if (!Number.isInteger(n) || n < 0) {
+        throw new CliError('INVALID_ORDER', `Invalid order value: "${val}"`, [
+            'Order must be a non-negative integer (e.g., 0 for top of list)',
+        ])
+    }
+    return n
+}
+
 export function registerFolderCommand(program: Command): void {
     const folder = program
         .command('folder')
@@ -70,8 +80,8 @@ Examples:
         .description('Create a folder')
         .option('--workspace <ref>', 'Workspace name or id:xxx')
         .option('--name <name>', 'Folder name (required)')
-        .option('--default-order <n>', 'Default order for projects in the folder')
-        .option('--child-order <n>', 'Order position of the folder')
+        .option('--default-order <n>', 'Default order for projects in the folder', parseOrderArg)
+        .option('--child-order <n>', 'Order position of the folder', parseOrderArg)
         .option('--json', 'Output the created folder as JSON')
         .option('--dry-run', 'Preview what would happen without executing')
         .action(
@@ -80,8 +90,8 @@ Examples:
                 options: {
                     workspace?: string
                     name?: string
-                    defaultOrder?: string
-                    childOrder?: string
+                    defaultOrder?: number
+                    childOrder?: number
                     json?: boolean
                     dryRun?: boolean
                 },
@@ -106,7 +116,7 @@ Examples:
         .description('Update a folder')
         .option('--workspace <ref>', 'Workspace name or id:xxx (for name-based lookup)')
         .option('--name <name>', 'New folder name')
-        .option('--default-order <n>', 'New default order for projects')
+        .option('--default-order <n>', 'New default order for projects', parseOrderArg)
         .option('--json', 'Output the updated folder as JSON')
         .option('--dry-run', 'Preview what would happen without executing')
         .action((ref, options) => {

--- a/src/commands/folder/list.ts
+++ b/src/commands/folder/list.ts
@@ -18,7 +18,7 @@ export async function listFolders(ref: string, options: PaginatedViewOptions): P
     const { results: folders, nextCursor } = await paginate(
         (cursor, limit) =>
             api.getFolders({
-                workspaceId: parseInt(workspace.id, 10),
+                workspaceId: workspace.id,
                 cursor: cursor ?? undefined,
                 limit,
             }),

--- a/src/commands/folder/list.ts
+++ b/src/commands/folder/list.ts
@@ -22,7 +22,7 @@ export async function listFolders(ref: string, options: PaginatedViewOptions): P
                 cursor: cursor ?? undefined,
                 limit,
             }),
-        { limit: targetLimit },
+        { limit: targetLimit, startCursor: options.cursor },
     )
 
     if (options.json) {

--- a/src/commands/folder/list.ts
+++ b/src/commands/folder/list.ts
@@ -1,0 +1,53 @@
+import chalk from 'chalk'
+import { getApi } from '../../lib/api/core.js'
+import type { PaginatedViewOptions } from '../../lib/options.js'
+import { formatNextCursorFooter } from '../../lib/output.js'
+import { paginate } from '../../lib/pagination.js'
+import { resolveWorkspaceRef } from '../../lib/refs.js'
+
+export async function listFolders(ref: string, options: PaginatedViewOptions): Promise<void> {
+    const workspace = await resolveWorkspaceRef(ref)
+    const api = await getApi()
+
+    const targetLimit = options.all
+        ? Number.MAX_SAFE_INTEGER
+        : options.limit
+          ? parseInt(options.limit, 10)
+          : 300
+
+    const { results: folders, nextCursor } = await paginate(
+        (cursor, limit) =>
+            api.getFolders({
+                workspaceId: parseInt(workspace.id, 10),
+                cursor: cursor ?? undefined,
+                limit,
+            }),
+        { limit: targetLimit },
+    )
+
+    if (options.json) {
+        console.log(JSON.stringify({ results: folders, nextCursor }, null, 2))
+        return
+    }
+
+    if (options.ndjson) {
+        for (const folder of folders) {
+            console.log(JSON.stringify(folder))
+        }
+        if (nextCursor) {
+            console.log(JSON.stringify({ _meta: true, nextCursor }))
+        }
+        return
+    }
+
+    if (folders.length === 0) {
+        console.log('No folders found.')
+        return
+    }
+
+    for (const folder of folders) {
+        const id = chalk.dim(folder.id)
+        console.log(`${id}  ${folder.name}`)
+    }
+    console.log(formatNextCursorFooter(nextCursor))
+}

--- a/src/commands/folder/update.ts
+++ b/src/commands/folder/update.ts
@@ -6,7 +6,7 @@ import { resolveFolderByRef } from './helpers.js'
 
 interface UpdateFolderOptions {
     name?: string
-    defaultOrder?: string
+    defaultOrder?: number
     workspace?: string
     json?: boolean
     dryRun?: boolean
@@ -20,7 +20,7 @@ export async function updateFolder(ref: string, options: UpdateFolderOptions): P
         defaultOrder?: number
     } = {}
     if (options.name) args.name = options.name
-    if (options.defaultOrder) args.defaultOrder = parseInt(options.defaultOrder, 10)
+    if (options.defaultOrder !== undefined) args.defaultOrder = options.defaultOrder
 
     if (Object.keys(args).length === 0) {
         throw new CliError('NO_CHANGES', 'No changes specified.')

--- a/src/commands/folder/update.ts
+++ b/src/commands/folder/update.ts
@@ -40,7 +40,7 @@ export async function updateFolder(ref: string, options: UpdateFolderOptions): P
     const updated = await api.updateFolder(folder.id, args)
 
     if (options.json) {
-        console.log(formatJson(updated))
+        console.log(formatJson(updated, 'folder'))
         return
     }
 

--- a/src/commands/folder/update.ts
+++ b/src/commands/folder/update.ts
@@ -1,0 +1,51 @@
+import { getApi } from '../../lib/api/core.js'
+import { CliError } from '../../lib/errors.js'
+import { isQuiet } from '../../lib/global-args.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
+import { resolveFolderByRef } from './helpers.js'
+
+interface UpdateFolderOptions {
+    name?: string
+    defaultOrder?: string
+    workspace?: string
+    json?: boolean
+    dryRun?: boolean
+}
+
+export async function updateFolder(ref: string, options: UpdateFolderOptions): Promise<void> {
+    const folder = await resolveFolderByRef(ref, options)
+
+    const args: {
+        name?: string
+        defaultOrder?: number
+    } = {}
+    if (options.name) args.name = options.name
+    if (options.defaultOrder) args.defaultOrder = parseInt(options.defaultOrder, 10)
+
+    if (Object.keys(args).length === 0) {
+        throw new CliError('NO_CHANGES', 'No changes specified.')
+    }
+
+    if (options.dryRun) {
+        printDryRun('update folder', {
+            Folder: folder.name,
+            Name: args.name,
+            'Default order':
+                args.defaultOrder !== undefined ? String(args.defaultOrder) : undefined,
+        })
+        return
+    }
+
+    const api = await getApi()
+    const updated = await api.updateFolder(folder.id, args)
+
+    if (options.json) {
+        console.log(formatJson(updated))
+        return
+    }
+
+    if (!isQuiet())
+        console.log(
+            `Updated: ${folder.name}${options.name ? ` → ${updated.name}` : ''} (id:${folder.id})`,
+        )
+}

--- a/src/commands/folder/view.ts
+++ b/src/commands/folder/view.ts
@@ -1,0 +1,70 @@
+import { isWorkspaceProject } from '@doist/todoist-sdk'
+import chalk from 'chalk'
+import { getApi } from '../../lib/api/core.js'
+import { paginate } from '../../lib/pagination.js'
+import { resolveWorkspaceRef } from '../../lib/refs.js'
+import { resolveFolderByRef } from './helpers.js'
+
+interface ViewFolderOptions {
+    workspace?: string
+    json?: boolean
+    full?: boolean
+}
+
+export async function viewFolder(ref: string, options: ViewFolderOptions): Promise<void> {
+    const folder = await resolveFolderByRef(ref, options)
+    const api = await getApi()
+
+    // Fetch workspace projects and filter to this folder
+    const { results: allProjects } = await paginate(
+        (cursor, limit) => api.getProjects({ cursor: cursor ?? undefined, limit }),
+        { limit: Number.MAX_SAFE_INTEGER },
+    )
+
+    const projects = allProjects.filter((p) => isWorkspaceProject(p) && p.folderId === folder.id)
+
+    if (options.json) {
+        const output = options.full
+            ? { folder, projects }
+            : {
+                  folder: {
+                      id: folder.id,
+                      name: folder.name,
+                      workspaceId: folder.workspaceId,
+                  },
+                  projects: projects.map((p) => ({
+                      id: p.id,
+                      name: p.name,
+                  })),
+              }
+        console.log(JSON.stringify(output, null, 2))
+        return
+    }
+
+    // Resolve workspace name for display
+    let workspaceName: string | undefined
+    try {
+        const workspace = await resolveWorkspaceRef(`id:${folder.workspaceId}`)
+        workspaceName = workspace.name
+    } catch {
+        // workspace lookup is best-effort for display
+    }
+
+    console.log(chalk.bold(folder.name))
+    console.log(chalk.dim(`ID:        ${folder.id}`))
+    if (workspaceName) {
+        console.log(chalk.dim(`Workspace: ${workspaceName}`))
+    }
+    console.log('')
+
+    if (projects.length === 0) {
+        console.log('No projects in this folder.')
+        return
+    }
+
+    console.log(chalk.dim(`Projects (${projects.length}):`))
+    for (const project of projects) {
+        const id = chalk.dim(project.id)
+        console.log(`  ${id}  ${project.name}`)
+    }
+}

--- a/src/commands/folder/view.ts
+++ b/src/commands/folder/view.ts
@@ -1,4 +1,3 @@
-import { isWorkspaceProject } from '@doist/todoist-sdk'
 import chalk from 'chalk'
 import { getApi } from '../../lib/api/core.js'
 import { paginate } from '../../lib/pagination.js'
@@ -15,13 +14,11 @@ export async function viewFolder(ref: string, options: ViewFolderOptions): Promi
     const folder = await resolveFolderByRef(ref, options)
     const api = await getApi()
 
-    // Fetch workspace projects and filter to this folder
-    const { results: allProjects } = await paginate(
-        (cursor, limit) => api.getProjects({ cursor: cursor ?? undefined, limit }),
+    const { results: projects } = await paginate(
+        (cursor, limit) =>
+            api.getProjects({ folderId: folder.id, cursor: cursor ?? undefined, limit }),
         { limit: Number.MAX_SAFE_INTEGER },
     )
-
-    const projects = allProjects.filter((p) => isWorkspaceProject(p) && p.folderId === folder.id)
 
     if (options.json) {
         const output = options.full

--- a/src/commands/project/index.ts
+++ b/src/commands/project/index.ts
@@ -124,6 +124,8 @@ Examples:
         .option('--color <color>', 'New color')
         .option('--favorite', 'Mark as favorite')
         .option('--no-favorite', 'Remove from favorites')
+        .option('--folder <ref>', 'Move into a folder by name or id:xxx (workspace projects only)')
+        .option('--no-folder', 'Remove from folder (workspace projects only)')
         .addOption(
             withCaseInsensitiveChoices(
                 new Option('--view-style <style>', 'View style (list, board, or calendar)'),

--- a/src/commands/project/project.test.ts
+++ b/src/commands/project/project.test.ts
@@ -1145,6 +1145,71 @@ describe('project update', () => {
             program.parseAsync(['node', 'td', 'project', 'update', 'id:proj-1']),
         ).rejects.toHaveProperty('code', 'NO_CHANGES')
     })
+
+    it('moves project into folder by id', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({
+            id: 'proj-1',
+            name: 'Roadmap',
+            workspaceId: '12345',
+        })
+        mockApi.getFolder.mockResolvedValue({
+            id: 'folder-1',
+            name: 'Engineering',
+            workspaceId: '12345',
+        })
+        mockApi.updateProject.mockResolvedValue({ id: 'proj-1', name: 'Roadmap' })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'project',
+            'update',
+            'id:proj-1',
+            '--folder',
+            'id:folder-1',
+        ])
+
+        expect(mockApi.updateProject).toHaveBeenCalledWith('proj-1', {
+            folderId: 'folder-1',
+        })
+    })
+
+    it('removes project from folder with --no-folder', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({
+            id: 'proj-1',
+            name: 'Roadmap',
+            workspaceId: '12345',
+        })
+        mockApi.updateProject.mockResolvedValue({ id: 'proj-1', name: 'Roadmap' })
+
+        await program.parseAsync(['node', 'td', 'project', 'update', 'id:proj-1', '--no-folder'])
+
+        expect(mockApi.updateProject).toHaveBeenCalledWith('proj-1', {
+            folderId: null,
+        })
+    })
+
+    it('rejects --folder on personal projects', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Personal Project' })
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'project',
+                'update',
+                'id:proj-1',
+                '--folder',
+                'id:folder-1',
+            ]),
+        ).rejects.toThrow('--folder can only be used on workspace projects')
+    })
 })
 
 describe('project create --json', () => {

--- a/src/commands/project/update.ts
+++ b/src/commands/project/update.ts
@@ -43,7 +43,9 @@ export async function updateProject(ref: string, options: UpdateOptions): Promis
         if (options.folder === false) {
             args.folderId = null
         } else {
-            const folder = await resolveFolderByRef(options.folder, {})
+            const folder = await resolveFolderByRef(options.folder, {
+                workspace: `id:${project.workspaceId}`,
+            })
             args.folderId = folder.id
         }
     }

--- a/src/commands/project/update.ts
+++ b/src/commands/project/update.ts
@@ -1,14 +1,16 @@
-import type { ColorKey, ProjectViewStyle } from '@doist/todoist-sdk'
+import { isWorkspaceProject, type ColorKey, type ProjectViewStyle } from '@doist/todoist-sdk'
 import { getApi } from '../../lib/api/core.js'
 import { CliError } from '../../lib/errors.js'
 import { isQuiet } from '../../lib/global-args.js'
 import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveProjectRef } from '../../lib/refs.js'
+import { resolveFolderByRef } from '../folder/helpers.js'
 
 export interface UpdateOptions {
     name?: string
     color?: ColorKey
     favorite?: boolean
+    folder?: string | false
     viewStyle?: string
     json?: boolean
     dryRun?: boolean
@@ -22,6 +24,7 @@ export async function updateProject(ref: string, options: UpdateOptions): Promis
         name?: string
         color?: ColorKey
         isFavorite?: boolean
+        folderId?: string | null
         viewStyle?: ProjectViewStyle
     } = {}
     if (options.name) args.name = options.name
@@ -29,6 +32,21 @@ export async function updateProject(ref: string, options: UpdateOptions): Promis
     if (options.favorite === true) args.isFavorite = true
     if (options.favorite === false) args.isFavorite = false
     if (options.viewStyle) args.viewStyle = options.viewStyle as ProjectViewStyle
+
+    if (options.folder !== undefined) {
+        if (!isWorkspaceProject(project)) {
+            throw new CliError(
+                'INVALID_OPTIONS',
+                '--folder can only be used on workspace projects.',
+            )
+        }
+        if (options.folder === false) {
+            args.folderId = null
+        } else {
+            const folder = await resolveFolderByRef(options.folder, {})
+            args.folderId = folder.id
+        }
+    }
 
     if (Object.keys(args).length === 0) {
         throw new CliError('NO_CHANGES', 'No changes specified.')
@@ -40,6 +58,12 @@ export async function updateProject(ref: string, options: UpdateOptions): Promis
             Name: args.name,
             Color: args.color,
             Favorite: args.isFavorite !== undefined ? String(args.isFavorite) : undefined,
+            Folder:
+                args.folderId === null
+                    ? '(none)'
+                    : args.folderId !== undefined
+                      ? args.folderId
+                      : undefined,
             'View style': args.viewStyle,
         })
         return

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,10 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
         'Manage filters',
         async () => (await import('./commands/filter/index.js')).registerFilterCommand,
     ],
+    folder: [
+        'Manage workspace folders',
+        async () => (await import('./commands/folder/index.js')).registerFolderCommand,
+    ],
     notification: [
         'Manage notifications',
         async () => (await import('./commands/notification/index.js')).registerNotificationCommand,

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,10 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
         'Manage filters',
         async () => (await import('./commands/filter/index.js')).registerFilterCommand,
     ],
+    folder: [
+        'Manage workspace folders',
+        async () => (await import('./commands/folder/index.js')).registerFolderCommand,
+    ],
     notification: [
         'Manage notifications',
         async () => (await import('./commands/notification/index.js')).registerNotificationCommand,

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -105,6 +105,12 @@ const API_SPINNER_MESSAGES: Record<string, { text: string; color?: 'blue' | 'gre
         getAppTestToken: { text: 'Loading app...', color: 'blue' },
         getAppDistributionToken: { text: 'Loading app...', color: 'blue' },
         getAppWebhook: { text: 'Loading app...', color: 'blue' },
+        // Folders
+        getFolders: { text: 'Loading folders...', color: 'blue' },
+        getFolder: { text: 'Loading folder...', color: 'blue' },
+        addFolder: { text: 'Creating folder...', color: 'green' },
+        updateFolder: { text: 'Updating folder...', color: 'yellow' },
+        deleteFolder: { text: 'Deleting folder...', color: 'yellow' },
     }
 
 function createSpinnerWrappedApi(api: TodoistApi): TodoistApi {

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -216,6 +216,7 @@ const LOCATION_REMINDER_ESSENTIAL_FIELDS = [
     'radius',
 ] as const
 const FILTER_ESSENTIAL_FIELDS = ['id', 'name', 'query', 'color', 'isFavorite'] as const
+const FOLDER_ESSENTIAL_FIELDS = ['id', 'name', 'workspaceId', 'defaultOrder', 'childOrder'] as const
 const NOTIFICATION_ESSENTIAL_FIELDS = [
     'id',
     'type',
@@ -273,6 +274,9 @@ function addWebUrl<T extends { id: string }>(item: T, type: EntityType): T & { w
         case 'notification':
             url = ''
             break
+        case 'folder':
+            url = ''
+            break
     }
     return { ...item, webUrl: url }
 }
@@ -286,6 +290,7 @@ export type EntityType =
     | 'reminder'
     | 'location-reminder'
     | 'filter'
+    | 'folder'
     | 'notification'
 
 function getEssentialFields(type: EntityType): readonly string[] {
@@ -306,6 +311,8 @@ function getEssentialFields(type: EntityType): readonly string[] {
             return LOCATION_REMINDER_ESSENTIAL_FIELDS
         case 'filter':
             return FILTER_ESSENTIAL_FIELDS
+        case 'folder':
+            return FOLDER_ESSENTIAL_FIELDS
         case 'notification':
             return NOTIFICATION_ESSENTIAL_FIELDS
     }

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -72,6 +72,9 @@ const KNOWN_SAFE_API_METHODS = new Set([
     'getAppTestToken',
     'getAppDistributionToken',
     'getAppWebhook',
+    // Folders
+    'getFolders',
+    'getFolder',
     // Sync is handled separately via payload inspection
     'sync',
 ])

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -55,7 +55,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Task lifecycle: \`td task list/view/add/quickadd/update/reschedule/move/complete/uncomplete/delete/browse\` (alias: \`td task qa\` for \`quickadd\`)
 - Projects: \`td project list/view/create/update/archive/unarchive/archived/delete/move/join/browse/collaborators/permissions\`
 - Project analytics: \`td project progress/health/health-context/activity-stats/analyze-health\`
-- Organization: \`td label ...\`, \`td filter ...\`, \`td section ...\`, \`td workspace ...\`
+- Organization: \`td label ...\`, \`td filter ...\`, \`td section ...\`, \`td folder ...\`, \`td workspace ...\`
 - Collaboration: \`td comment ...\`, \`td notification ...\`, \`td reminder ...\`
 - Templates and files: \`td template ...\`, \`td attachment view <file-url>\`, \`td backup ...\`
 - Account and tooling: \`td stats\`, \`td settings ...\`, \`td completion ...\`, \`td view <todoist-url>\`, \`td doctor\`, \`td update\`, \`td changelog\`
@@ -144,6 +144,11 @@ td workspace update "Acme" --description "Acme Inc." --dry-run   # admin-only
 td workspace delete "Old WS" --yes                                # admin-only
 td workspace user-tasks "Acme" --user alice@example.com
 td workspace activity "Acme" --json
+td folder list "Acme"
+td folder view "Engineering"
+td folder create "Acme" --name "Engineering"
+td folder update "Engineering" --name "Platform" --workspace "Acme"
+td folder delete "Engineering" --workspace "Acme" --yes
 \`\`\`
 
 ### Labels, Filters, And Sections

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -123,6 +123,8 @@ td project view "Roadmap" --detailed
 td project collaborators "Roadmap"
 td project create --name "New Project" --color blue
 td project update "Roadmap" --favorite
+td project update "Roadmap" --folder "Engineering"
+td project update "Roadmap" --no-folder
 td project archive "Roadmap"
 td project unarchive "Roadmap"
 td project move "Roadmap" --to-workspace "Acme" --folder "Engineering" --visibility team --yes

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -55,7 +55,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Task lifecycle: \`td task list/view/add/quickadd/update/reschedule/move/complete/uncomplete/delete/browse\` (alias: \`td task qa\` for \`quickadd\`)
 - Projects: \`td project list/view/create/update/archive/unarchive/archived/delete/move/join/browse/collaborators/permissions\`
 - Project analytics: \`td project progress/health/health-context/activity-stats/analyze-health\`
-- Organization: \`td label ...\`, \`td filter ...\`, \`td section ...\`, \`td workspace ...\`
+- Organization: \`td label ...\`, \`td filter ...\`, \`td section ...\`, \`td folder ...\`, \`td workspace ...\`
 - Collaboration: \`td comment ...\`, \`td notification ...\`, \`td reminder ...\`
 - Templates and files: \`td template ...\`, \`td attachment view <file-url>\`, \`td backup ...\`
 - Help Center: \`td hc locales/search/view\`
@@ -145,6 +145,11 @@ td workspace update "Acme" --description "Acme Inc." --dry-run   # admin-only
 td workspace delete "Old WS" --yes                                # admin-only
 td workspace user-tasks "Acme" --user alice@example.com
 td workspace activity "Acme" --json
+td folder list "Acme"
+td folder view "Engineering"
+td folder create "Acme" --name "Engineering"
+td folder update "Engineering" --name "Platform" --workspace "Acme"
+td folder delete "Engineering" --workspace "Acme" --yes
 \`\`\`
 
 ### Labels, Filters, And Sections

--- a/src/test-support/mock-api.ts
+++ b/src/test-support/mock-api.ts
@@ -188,6 +188,12 @@ export function createMockApi(overrides: Partial<TodoistApi> = {}): MockApi {
         getAppTestToken: vi.fn().mockResolvedValue({ accessToken: null }),
         getAppDistributionToken: vi.fn().mockResolvedValue({ distributionToken: '' }),
         getAppWebhook: vi.fn().mockResolvedValue(null),
+        // Folders
+        getFolders: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
+        getFolder: vi.fn(),
+        addFolder: vi.fn(),
+        updateFolder: vi.fn(),
+        deleteFolder: vi.fn().mockResolvedValue(true),
         ...overrides,
     } as unknown as MockApi
 }


### PR DESCRIPTION
## Summary
- Adds `td folder` command group with `list`, `view`, `create`, `update`, and `delete` subcommands
- Exposes the SDK's folder CRUD endpoints (`getFolders`, `getFolder`, `addFolder`, `updateFolder`, `deleteFolder`)
- Folders are workspace-scoped — `list` and `create` require a workspace ref (positional or `--workspace`), while `update`/`delete`/`view` support `id:xxx` directly or name-based lookup with `--workspace`
- Auto-detects workspace when only one exists

## Test plan
- [x] 21 new tests in `folder.test.ts` covering all subcommands, JSON output, dry-run, empty states, workspace auto-detection, and error cases
- [x] All 1271 existing tests still pass
- [x] Type check, lint, format, and skill sync all clean
- [ ] Manual test: `td folder list <workspace>`, `td folder create <workspace> --name "Test"`, `td folder view <ref>`, `td folder update <ref> --name "New"`, `td folder delete <ref> --yes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)