### PR TITLE
feat: add label search, rename-shared, and remove-shared commands

### DIFF
--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -125,6 +125,7 @@ td label update "urgent" --color orange
 td label delete "urgent" --yes
 td label browse "urgent"
 td label rename-shared "oldname" --name "newname"
+td label remove-shared "oldname" --yes
 
 td filter list
 td filter view "Urgent work"
@@ -142,7 +143,7 @@ td section delete id:123 --yes
 td section browse id:123
 ```
 
-Shared labels can appear in `td label list` and `td label view`, but standard update and delete actions only work for labels with IDs.
+Shared labels can appear in `td label list` and `td label view`, but standard update and delete actions only work for labels with IDs. Use `td label rename-shared` and `td label remove-shared` for shared labels.
 
 ### Comments, Attachments, Notifications, And Reminders
 ```bash

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -118,6 +118,7 @@ td workspace insights "Acme" --project-ids "id1,id2"
 ### Labels, Filters, And Sections
 ```bash
 td label list
+td label list --search "bug"
 td label view "urgent"
 td label create --name "urgent" --color red
 td label update "urgent" --color orange

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -124,6 +124,7 @@ td label create --name "urgent" --color red
 td label update "urgent" --color orange
 td label delete "urgent" --yes
 td label browse "urgent"
+td label rename-shared "oldname" --name "newname"
 
 td filter list
 td filter view "Urgent work"

--- a/src/__tests__/helpers/mock-api.ts
+++ b/src/__tests__/helpers/mock-api.ts
@@ -65,6 +65,7 @@ export function createMockApi(overrides: Partial<TodoistApi> = {}): MockApi {
         deleteLabel: vi.fn(),
         getSharedLabels: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
         searchLabels: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
+        renameSharedLabel: vi.fn().mockResolvedValue(true),
         updateLabel: vi.fn(),
         // Comments
         getComments: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),

--- a/src/__tests__/helpers/mock-api.ts
+++ b/src/__tests__/helpers/mock-api.ts
@@ -64,6 +64,7 @@ export function createMockApi(overrides: Partial<TodoistApi> = {}): MockApi {
         addLabel: vi.fn(),
         deleteLabel: vi.fn(),
         getSharedLabels: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
+        searchLabels: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
         updateLabel: vi.fn(),
         // Comments
         getComments: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),

--- a/src/__tests__/helpers/mock-api.ts
+++ b/src/__tests__/helpers/mock-api.ts
@@ -66,6 +66,7 @@ export function createMockApi(overrides: Partial<TodoistApi> = {}): MockApi {
         getSharedLabels: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
         searchLabels: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
         renameSharedLabel: vi.fn().mockResolvedValue(true),
+        removeSharedLabel: vi.fn().mockResolvedValue(true),
         updateLabel: vi.fn(),
         // Comments
         getComments: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),

--- a/src/__tests__/label.test.ts
+++ b/src/__tests__/label.test.ts
@@ -155,6 +155,78 @@ describe('label list --search', () => {
     })
 })
 
+describe('label rename-shared', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+    })
+
+    it('renames a shared label', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'label',
+            'rename-shared',
+            'oldname',
+            '--name',
+            'newname',
+        ])
+
+        expect(mockApi.renameSharedLabel).toHaveBeenCalledWith({
+            name: 'oldname',
+            newName: 'newname',
+        })
+        expect(consoleSpy).toHaveBeenCalledWith('Renamed: @oldname → @newname')
+        consoleSpy.mockRestore()
+    })
+
+    it('strips @ prefix from name', async () => {
+        const program = createProgram()
+        vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'label',
+            'rename-shared',
+            '@oldname',
+            '--name',
+            'newname',
+        ])
+
+        expect(mockApi.renameSharedLabel).toHaveBeenCalledWith({
+            name: 'oldname',
+            newName: 'newname',
+        })
+    })
+
+    it('previews rename with --dry-run', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'label',
+            'rename-shared',
+            'oldname',
+            '--name',
+            'newname',
+            '--dry-run',
+        ])
+
+        expect(mockApi.renameSharedLabel).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[dry-run]'))
+        consoleSpy.mockRestore()
+    })
+})
+
 describe('label create --json', () => {
     let mockApi: MockApi
 

--- a/src/__tests__/label.test.ts
+++ b/src/__tests__/label.test.ts
@@ -97,6 +97,64 @@ describe('label list', () => {
     })
 })
 
+describe('label list --search', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+    })
+
+    it('searches labels by name', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.searchLabels.mockResolvedValue({
+            results: [{ id: 'label-1', name: 'bugfix', color: 'red', isFavorite: false }],
+            nextCursor: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'label', 'list', '--search', 'bug'])
+
+        expect(mockApi.searchLabels).toHaveBeenCalledWith(expect.objectContaining({ query: 'bug' }))
+        expect(mockApi.getLabels).not.toHaveBeenCalled()
+        expect(mockApi.getSharedLabels).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('@bugfix'))
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs search results as JSON', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.searchLabels.mockResolvedValue({
+            results: [{ id: 'label-1', name: 'bugfix', color: 'red', isFavorite: false }],
+            nextCursor: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'label', 'list', '--search', 'bug', '--json'])
+
+        const output = consoleSpy.mock.calls[0][0]
+        const parsed = JSON.parse(output)
+        expect(parsed.results).toBeDefined()
+        expect(parsed.results[0].name).toBe('bugfix')
+        consoleSpy.mockRestore()
+    })
+
+    it('shows "No labels found" when search has no results', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.searchLabels.mockResolvedValue({ results: [], nextCursor: null })
+
+        await program.parseAsync(['node', 'td', 'label', 'list', '--search', 'nonexistent'])
+
+        expect(consoleSpy).toHaveBeenCalledWith('No labels found.')
+        consoleSpy.mockRestore()
+    })
+})
+
 describe('label create --json', () => {
     let mockApi: MockApi
 

--- a/src/__tests__/label.test.ts
+++ b/src/__tests__/label.test.ts
@@ -227,6 +227,59 @@ describe('label rename-shared', () => {
     })
 })
 
+describe('label remove-shared', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+    })
+
+    it('removes a shared label with --yes', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'td', 'label', 'remove-shared', 'oldname', '--yes'])
+
+        expect(mockApi.removeSharedLabel).toHaveBeenCalledWith({ name: 'oldname' })
+        expect(consoleSpy).toHaveBeenCalledWith('Removed shared label: @oldname')
+        consoleSpy.mockRestore()
+    })
+
+    it('strips @ prefix from name', async () => {
+        const program = createProgram()
+        vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'td', 'label', 'remove-shared', '@oldname', '--yes'])
+
+        expect(mockApi.removeSharedLabel).toHaveBeenCalledWith({ name: 'oldname' })
+    })
+
+    it('shows confirmation prompt without --yes', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'td', 'label', 'remove-shared', 'oldname'])
+
+        expect(mockApi.removeSharedLabel).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith('Would remove shared label: @oldname')
+        expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
+        consoleSpy.mockRestore()
+    })
+
+    it('previews removal with --dry-run', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'td', 'label', 'remove-shared', 'oldname', '--dry-run'])
+
+        expect(mockApi.removeSharedLabel).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[dry-run]'))
+        consoleSpy.mockRestore()
+    })
+})
+
 describe('label create --json', () => {
     let mockApi: MockApi
 

--- a/src/__tests__/label.test.ts
+++ b/src/__tests__/label.test.ts
@@ -119,8 +119,24 @@ describe('label list --search', () => {
 
         expect(mockApi.searchLabels).toHaveBeenCalledWith(expect.objectContaining({ query: 'bug' }))
         expect(mockApi.getLabels).not.toHaveBeenCalled()
-        expect(mockApi.getSharedLabels).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('@bugfix'))
+        consoleSpy.mockRestore()
+    })
+
+    it('includes matching shared labels in search results', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.searchLabels.mockResolvedValue({ results: [], nextCursor: null })
+        mockApi.getSharedLabels.mockResolvedValue({
+            results: ['team-bug', 'team-review'],
+            nextCursor: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'label', 'list', '--search', 'bug'])
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('@team-bug'))
+        expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('@team-review'))
         consoleSpy.mockRestore()
     })
 
@@ -167,6 +183,10 @@ describe('label rename-shared', () => {
     it('renames a shared label', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getSharedLabels.mockResolvedValue({
+            results: ['oldname'],
+            nextCursor: null,
+        })
 
         await program.parseAsync([
             'node',
@@ -189,6 +209,10 @@ describe('label rename-shared', () => {
     it('strips @ prefix from name', async () => {
         const program = createProgram()
         vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getSharedLabels.mockResolvedValue({
+            results: ['oldname'],
+            nextCursor: null,
+        })
 
         await program.parseAsync([
             'node',
@@ -209,6 +233,10 @@ describe('label rename-shared', () => {
     it('previews rename with --dry-run', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getSharedLabels.mockResolvedValue({
+            results: ['oldname'],
+            nextCursor: null,
+        })
 
         await program.parseAsync([
             'node',
@@ -225,6 +253,23 @@ describe('label rename-shared', () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[dry-run]'))
         consoleSpy.mockRestore()
     })
+
+    it('throws when shared label not found', async () => {
+        const program = createProgram()
+        vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'label',
+                'rename-shared',
+                'nonexistent',
+                '--name',
+                'newname',
+            ]),
+        ).rejects.toThrow('Shared label "nonexistent" not found.')
+    })
 })
 
 describe('label remove-shared', () => {
@@ -239,6 +284,10 @@ describe('label remove-shared', () => {
     it('removes a shared label with --yes', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getSharedLabels.mockResolvedValue({
+            results: ['oldname'],
+            nextCursor: null,
+        })
 
         await program.parseAsync(['node', 'td', 'label', 'remove-shared', 'oldname', '--yes'])
 
@@ -250,6 +299,10 @@ describe('label remove-shared', () => {
     it('strips @ prefix from name', async () => {
         const program = createProgram()
         vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getSharedLabels.mockResolvedValue({
+            results: ['oldname'],
+            nextCursor: null,
+        })
 
         await program.parseAsync(['node', 'td', 'label', 'remove-shared', '@oldname', '--yes'])
 
@@ -259,6 +312,10 @@ describe('label remove-shared', () => {
     it('shows confirmation prompt without --yes', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getSharedLabels.mockResolvedValue({
+            results: ['oldname'],
+            nextCursor: null,
+        })
 
         await program.parseAsync(['node', 'td', 'label', 'remove-shared', 'oldname'])
 
@@ -271,12 +328,25 @@ describe('label remove-shared', () => {
     it('previews removal with --dry-run', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getSharedLabels.mockResolvedValue({
+            results: ['oldname'],
+            nextCursor: null,
+        })
 
         await program.parseAsync(['node', 'td', 'label', 'remove-shared', 'oldname', '--dry-run'])
 
         expect(mockApi.removeSharedLabel).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[dry-run]'))
         consoleSpy.mockRestore()
+    })
+
+    it('throws when shared label not found', async () => {
+        const program = createProgram()
+        vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await expect(
+            program.parseAsync(['node', 'td', 'label', 'remove-shared', 'nonexistent', '--yes']),
+        ).rejects.toThrow('Shared label "nonexistent" not found.')
     })
 })
 

--- a/src/commands/label/helpers.ts
+++ b/src/commands/label/helpers.ts
@@ -4,6 +4,23 @@ import { CliError } from '../../lib/errors.js'
 import { paginate } from '../../lib/pagination.js'
 import { isIdRef, lenientIdRef, looksLikeRawId, parseTodoistUrl } from '../../lib/refs.js'
 
+// Resolves a shared label name by checking it exists in the shared labels list.
+// Returns the canonical casing of the label name.
+export async function resolveSharedLabelName(nameArg: string): Promise<string> {
+    const name = nameArg.startsWith('@') ? nameArg.slice(1) : nameArg
+    const lower = name.toLowerCase()
+
+    const api = await getApi()
+    const { results: sharedLabels } = await paginate(
+        (cursor, limit) => api.getSharedLabels({ cursor: cursor ?? undefined, limit }),
+        { limit: Number.MAX_SAFE_INTEGER },
+    )
+
+    const match = sharedLabels.find((s) => s.toLowerCase() === lower)
+    if (!match) throw new CliError('LABEL_NOT_FOUND', `Shared label "${name}" not found.`)
+    return match
+}
+
 // Resolves a label ref to a personal Label object. Used by delete/update/browse
 // which require an ID. Does NOT fall back to shared labels — use
 // resolveLabelNameForView() for view which only needs a name.

--- a/src/commands/label/index.ts
+++ b/src/commands/label/index.ts
@@ -3,6 +3,7 @@ import { browseLabel } from './browse.js'
 import { createLabel } from './create.js'
 import { deleteLabel } from './delete.js'
 import { listLabels } from './list.js'
+import { removeSharedLabel } from './remove-shared.js'
 import { renameSharedLabel } from './rename-shared.js'
 import { updateLabel } from './update.js'
 import { viewLabel } from './view.js'
@@ -21,7 +22,8 @@ Examples:
   td label list --search "bug"
   td label create --name "urgent" --color red
   td label view "urgent"
-  td label rename-shared "oldname" --name "newname"`,
+  td label rename-shared "oldname" --name "newname"
+  td label remove-shared "oldname" --yes`,
         )
 
     label
@@ -121,5 +123,18 @@ Examples:
                 return
             }
             return renameSharedLabel(name, options)
+        })
+
+    const removeSharedCmd = label
+        .command('remove-shared [name]')
+        .description('Remove a shared label')
+        .option('--yes', 'Confirm removal')
+        .option('--dry-run', 'Preview what would happen without executing')
+        .action((name, options) => {
+            if (!name) {
+                removeSharedCmd.help()
+                return
+            }
+            return removeSharedLabel(name, options)
         })
 }

--- a/src/commands/label/index.ts
+++ b/src/commands/label/index.ts
@@ -17,6 +17,7 @@ export function registerLabelCommand(program: Command): void {
             `
 Examples:
   td label list
+  td label list --search "bug"
   td label create --name "urgent" --color red
   td label view "urgent"`,
         )
@@ -40,7 +41,8 @@ Examples:
 
     label
         .command('list')
-        .description('List all labels')
+        .description('List or search labels')
+        .option('--search <term>', 'Search labels by name')
         .option('--limit <n>', 'Limit number of results (default: 300)')
         .option('--all', 'Fetch all results (no limit)')
         .option('--json', 'Output as JSON')

--- a/src/commands/label/index.ts
+++ b/src/commands/label/index.ts
@@ -3,6 +3,7 @@ import { browseLabel } from './browse.js'
 import { createLabel } from './create.js'
 import { deleteLabel } from './delete.js'
 import { listLabels } from './list.js'
+import { renameSharedLabel } from './rename-shared.js'
 import { updateLabel } from './update.js'
 import { viewLabel } from './view.js'
 
@@ -19,7 +20,8 @@ Examples:
   td label list
   td label list --search "bug"
   td label create --name "urgent" --color red
-  td label view "urgent"`,
+  td label view "urgent"
+  td label rename-shared "oldname" --name "newname"`,
         )
 
     label
@@ -106,5 +108,18 @@ Examples:
                 return
             }
             return browseLabel(ref)
+        })
+
+    const renameSharedCmd = label
+        .command('rename-shared [name]')
+        .description('Rename a shared label')
+        .option('--name <name>', 'New name (required)')
+        .option('--dry-run', 'Preview what would happen without executing')
+        .action((name, options) => {
+            if (!name || !options.name) {
+                renameSharedCmd.help()
+                return
+            }
+            return renameSharedLabel(name, options)
         })
 }

--- a/src/commands/label/list.ts
+++ b/src/commands/label/list.ts
@@ -31,21 +31,23 @@ export async function listLabels(options: ListLabelsOptions): Promise<void> {
         { limit: targetLimit },
     )
 
-    // Fetch shared-only labels (not in personal labels) — skip when searching
-    // since searchLabels only covers personal labels
-    const sharedLabels: string[] = options.search
-        ? []
-        : (
-              await paginate(
-                  (cursor, limit) =>
-                      api.getSharedLabels({
-                          omitPersonal: true,
-                          cursor: cursor ?? undefined,
-                          limit,
-                      }),
-                  { limit: targetLimit },
-              )
-          ).results
+    // Fetch shared-only labels (not in personal labels)
+    const { results: allSharedLabels } = await paginate(
+        (cursor, limit) =>
+            api.getSharedLabels({
+                omitPersonal: true,
+                cursor: cursor ?? undefined,
+                limit,
+            }),
+        { limit: targetLimit },
+    )
+
+    // When searching, filter shared labels client-side to match the search term
+    const sharedLabels = options.search
+        ? allSharedLabels.filter((name) =>
+              name.toLowerCase().includes(options.search!.toLowerCase()),
+          )
+        : allSharedLabels
 
     if (options.json) {
         const base = JSON.parse(

--- a/src/commands/label/list.ts
+++ b/src/commands/label/list.ts
@@ -2,6 +2,10 @@ import chalk from 'chalk'
 import { getApi } from '../../lib/api/core.js'
 import { isAccessible } from '../../lib/global-args.js'
 import type { PaginatedViewOptions } from '../../lib/options.js'
+
+export interface ListLabelsOptions extends PaginatedViewOptions {
+    search?: string
+}
 import {
     formatNextCursorFooter,
     formatPaginatedJson,
@@ -10,7 +14,7 @@ import {
 import { LIMITS, paginate } from '../../lib/pagination.js'
 import { labelUrl } from '../../lib/urls.js'
 
-export async function listLabels(options: PaginatedViewOptions): Promise<void> {
+export async function listLabels(options: ListLabelsOptions): Promise<void> {
     const api = await getApi()
 
     const targetLimit = options.all
@@ -20,20 +24,28 @@ export async function listLabels(options: PaginatedViewOptions): Promise<void> {
           : LIMITS.labels
 
     const { results: labels, nextCursor } = await paginate(
-        (cursor, limit) => api.getLabels({ cursor: cursor ?? undefined, limit }),
+        (cursor, limit) =>
+            options.search
+                ? api.searchLabels({ query: options.search, cursor: cursor ?? undefined, limit })
+                : api.getLabels({ cursor: cursor ?? undefined, limit }),
         { limit: targetLimit },
     )
 
-    // Fetch shared-only labels (not in personal labels)
-    const { results: sharedLabels } = await paginate(
-        (cursor, limit) =>
-            api.getSharedLabels({
-                omitPersonal: true,
-                cursor: cursor ?? undefined,
-                limit,
-            }),
-        { limit: targetLimit },
-    )
+    // Fetch shared-only labels (not in personal labels) — skip when searching
+    // since searchLabels only covers personal labels
+    const sharedLabels: string[] = options.search
+        ? []
+        : (
+              await paginate(
+                  (cursor, limit) =>
+                      api.getSharedLabels({
+                          omitPersonal: true,
+                          cursor: cursor ?? undefined,
+                          limit,
+                      }),
+                  { limit: targetLimit },
+              )
+          ).results
 
     if (options.json) {
         const base = JSON.parse(

--- a/src/commands/label/remove-shared.ts
+++ b/src/commands/label/remove-shared.ts
@@ -1,12 +1,13 @@
 import { getApi } from '../../lib/api/core.js'
 import { isQuiet } from '../../lib/global-args.js'
 import { printDryRun } from '../../lib/output.js'
+import { resolveSharedLabelName } from './helpers.js'
 
 export async function removeSharedLabel(
     nameArg: string,
     options: { yes?: boolean; dryRun?: boolean },
 ): Promise<void> {
-    const name = nameArg.startsWith('@') ? nameArg.slice(1) : nameArg
+    const name = await resolveSharedLabelName(nameArg)
 
     if (options.dryRun) {
         printDryRun('remove shared label', { Label: `@${name}` })

--- a/src/commands/label/remove-shared.ts
+++ b/src/commands/label/remove-shared.ts
@@ -1,0 +1,25 @@
+import { getApi } from '../../lib/api/core.js'
+import { isQuiet } from '../../lib/global-args.js'
+import { printDryRun } from '../../lib/output.js'
+
+export async function removeSharedLabel(
+    nameArg: string,
+    options: { yes?: boolean; dryRun?: boolean },
+): Promise<void> {
+    const name = nameArg.startsWith('@') ? nameArg.slice(1) : nameArg
+
+    if (options.dryRun) {
+        printDryRun('remove shared label', { Label: `@${name}` })
+        return
+    }
+
+    if (!options.yes) {
+        console.log(`Would remove shared label: @${name}`)
+        console.log('Use --yes to confirm.')
+        return
+    }
+
+    const api = await getApi()
+    await api.removeSharedLabel({ name })
+    if (!isQuiet()) console.log(`Removed shared label: @${name}`)
+}

--- a/src/commands/label/rename-shared.ts
+++ b/src/commands/label/rename-shared.ts
@@ -1,0 +1,19 @@
+import { getApi } from '../../lib/api/core.js'
+import { isQuiet } from '../../lib/global-args.js'
+import { printDryRun } from '../../lib/output.js'
+
+export async function renameSharedLabel(
+    nameArg: string,
+    options: { name?: string; dryRun?: boolean },
+): Promise<void> {
+    const name = nameArg.startsWith('@') ? nameArg.slice(1) : nameArg
+
+    if (options.dryRun) {
+        printDryRun('rename shared label', { From: `@${name}`, To: `@${options.name}` })
+        return
+    }
+
+    const api = await getApi()
+    await api.renameSharedLabel({ name, newName: options.name! })
+    if (!isQuiet()) console.log(`Renamed: @${name} → @${options.name}`)
+}

--- a/src/commands/label/rename-shared.ts
+++ b/src/commands/label/rename-shared.ts
@@ -1,12 +1,13 @@
 import { getApi } from '../../lib/api/core.js'
 import { isQuiet } from '../../lib/global-args.js'
 import { printDryRun } from '../../lib/output.js'
+import { resolveSharedLabelName } from './helpers.js'
 
 export async function renameSharedLabel(
     nameArg: string,
     options: { name?: string; dryRun?: boolean },
 ): Promise<void> {
-    const name = nameArg.startsWith('@') ? nameArg.slice(1) : nameArg
+    const name = await resolveSharedLabelName(nameArg)
 
     if (options.dryRun) {
         printDryRun('rename shared label', { From: `@${name}`, To: `@${options.name}` })

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -26,6 +26,7 @@ const API_SPINNER_MESSAGES: Record<string, { text: string; color?: 'blue' | 'gre
         getLabels: { text: 'Loading labels...', color: 'blue' },
         getSharedLabels: { text: 'Loading shared labels...', color: 'blue' },
         searchLabels: { text: 'Searching labels...', color: 'blue' },
+        renameSharedLabel: { text: 'Renaming shared label...', color: 'yellow' },
         getSections: { text: 'Loading sections...', color: 'blue' },
         getComments: { text: 'Loading comments...', color: 'blue' },
         addTask: { text: 'Creating task...', color: 'green' },

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -27,6 +27,7 @@ const API_SPINNER_MESSAGES: Record<string, { text: string; color?: 'blue' | 'gre
         getSharedLabels: { text: 'Loading shared labels...', color: 'blue' },
         searchLabels: { text: 'Searching labels...', color: 'blue' },
         renameSharedLabel: { text: 'Renaming shared label...', color: 'yellow' },
+        removeSharedLabel: { text: 'Removing shared label...', color: 'yellow' },
         getSections: { text: 'Loading sections...', color: 'blue' },
         getComments: { text: 'Loading comments...', color: 'blue' },
         addTask: { text: 'Creating task...', color: 'green' },

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -25,6 +25,7 @@ const API_SPINNER_MESSAGES: Record<string, { text: string; color?: 'blue' | 'gre
         getProjects: { text: 'Loading projects...', color: 'blue' },
         getLabels: { text: 'Loading labels...', color: 'blue' },
         getSharedLabels: { text: 'Loading shared labels...', color: 'blue' },
+        searchLabels: { text: 'Searching labels...', color: 'blue' },
         getSections: { text: 'Loading sections...', color: 'blue' },
         getComments: { text: 'Loading comments...', color: 'blue' },
         addTask: { text: 'Creating task...', color: 'green' },

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -25,6 +25,7 @@ const KNOWN_SAFE_API_METHODS = new Set([
     'getLabels',
     'getLabel',
     'getSharedLabels',
+    'searchLabels',
     // Sections
     'getSections',
     'getSection',

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -124,6 +124,7 @@ td label update "urgent" --color orange
 td label delete "urgent" --yes
 td label browse "urgent"
 td label rename-shared "oldname" --name "newname"
+td label remove-shared "oldname" --yes
 
 td filter list
 td filter view "Urgent work"
@@ -141,7 +142,7 @@ td section delete id:123 --yes
 td section browse id:123
 \`\`\`
 
-Shared labels can appear in \`td label list\` and \`td label view\`, but standard update and delete actions only work for labels with IDs.
+Shared labels can appear in \`td label list\` and \`td label view\`, but standard update and delete actions only work for labels with IDs. Use \`td label rename-shared\` and \`td label remove-shared\` for shared labels.
 
 ### Comments, Attachments, Notifications, And Reminders
 \`\`\`bash

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -117,6 +117,7 @@ td workspace insights "Acme" --project-ids "id1,id2"
 ### Labels, Filters, And Sections
 \`\`\`bash
 td label list
+td label list --search "bug"
 td label view "urgent"
 td label create --name "urgent" --color red
 td label update "urgent" --color orange

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -123,6 +123,7 @@ td label create --name "urgent" --color red
 td label update "urgent" --color orange
 td label delete "urgent" --yes
 td label browse "urgent"
+td label rename-shared "oldname" --name "newname"
 
 td filter list
 td filter view "Urgent work"


### PR DESCRIPTION
## Summary

- **`td label list --search <term>`** — server-side label search using the SDK's `searchLabels()` method
- **`td label rename-shared <name> --name <new_name>`** — rename a shared label (identified by name, not ID)
- **`td label remove-shared <name> --yes`** — remove a shared label with `--yes` confirmation and `--dry-run` support

These three commands expose SDK methods (`searchLabels`, `renameSharedLabel`, `removeSharedLabel`) that were previously unavailable in the CLI.

## Test plan

- [ ] `td label list --search "bug"` returns matching labels
- [ ] `td label list` (without --search) behaves unchanged
- [ ] `td label rename-shared "old" --name "new" --dry-run` previews rename
- [ ] `td label rename-shared "old" --name "new"` renames the shared label
- [ ] `td label remove-shared "old"` shows confirmation prompt
- [ ] `td label remove-shared "old" --yes` removes the shared label
- [ ] `td label remove-shared "old" --dry-run` previews removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)