### PR TITLE
feat: add backup list and download commands

### DIFF
--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -46,7 +46,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Project analytics: `td project progress/health/health-context/activity-stats/analyze-health`
 - Organization: `td label ...`, `td filter ...`, `td section ...`, `td workspace ...`
 - Collaboration: `td comment ...`, `td notification ...`, `td reminder ...`
-- Templates and files: `td template ...`, `td attachment view <file-url>`
+- Templates and files: `td template ...`, `td attachment view <file-url>`, `td backup ...`
 - Account and tooling: `td stats`, `td settings ...`, `td completion ...`, `td view <todoist-url>`, `td doctor`, `td update`, `td changelog`
 
 ## References
@@ -182,6 +182,12 @@ td template export-url "Roadmap"
 td template create --name "New Project" --file template.csv --workspace "Acme"
 td template import-file "Roadmap" --file template.csv
 td template import-id "Roadmap" --template-id product-launch --locale fr
+```
+
+### Backups
+```bash
+td backup list
+td backup download "2024-01-15_12:00" --output-file backup.zip
 ```
 
 ### Settings, Stats, And Utilities

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -251,7 +251,7 @@ describe('auth command', () => {
             )
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-write',
-                authScope: 'data:read_write,data:delete,project:delete',
+                authScope: 'data:read_write,data:delete,project:delete,backups:read',
             })
             expect(consoleSpy).toHaveBeenCalledWith('✓', 'Successfully logged in!')
             expect(consoleSpy).toHaveBeenCalledWith(
@@ -282,7 +282,7 @@ describe('auth command', () => {
             )
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-only',
-                authScope: 'data:read',
+                authScope: 'data:read,backups:read',
             })
         })
 

--- a/src/__tests__/backup.test.ts
+++ b/src/__tests__/backup.test.ts
@@ -1,0 +1,165 @@
+import fs from 'node:fs'
+import { Command } from 'commander'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/api/core.js', () => ({
+    getApi: vi.fn(),
+}))
+
+import { registerBackupCommand } from '../commands/backup/index.js'
+import { getApi } from '../lib/api/core.js'
+import { createMockApi, type MockApi } from './helpers/mock-api.js'
+
+const mockGetApi = vi.mocked(getApi)
+
+function createProgram() {
+    const program = new Command()
+    program.exitOverride()
+    registerBackupCommand(program)
+    return program
+}
+
+describe('backup list', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+    })
+
+    it('lists available backups', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getBackups.mockResolvedValue([
+            { version: '2024-01-15_12:00', url: 'https://example.com/backup1.zip' },
+            { version: '2024-01-14_12:00', url: 'https://example.com/backup2.zip' },
+        ])
+
+        await program.parseAsync(['node', 'td', 'backup', 'list'])
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('2024-01-15_12:00'))
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('2024-01-14_12:00'))
+        consoleSpy.mockRestore()
+    })
+
+    it('shows "No backups found." when empty', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getBackups.mockResolvedValue([])
+
+        await program.parseAsync(['node', 'td', 'backup', 'list'])
+
+        expect(consoleSpy).toHaveBeenCalledWith('No backups found.')
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs JSON with --json flag', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getBackups.mockResolvedValue([
+            { version: '2024-01-15_12:00', url: 'https://example.com/backup1.zip' },
+        ])
+
+        await program.parseAsync(['node', 'td', 'backup', 'list', '--json'])
+
+        const output = consoleSpy.mock.calls[0][0]
+        const parsed = JSON.parse(output)
+        expect(parsed.results).toHaveLength(1)
+        expect(parsed.results[0].version).toBe('2024-01-15_12:00')
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs NDJSON with --ndjson flag', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getBackups.mockResolvedValue([
+            { version: '2024-01-15_12:00', url: 'https://example.com/backup1.zip' },
+            { version: '2024-01-14_12:00', url: 'https://example.com/backup2.zip' },
+        ])
+
+        await program.parseAsync(['node', 'td', 'backup', 'list', '--ndjson'])
+
+        expect(consoleSpy).toHaveBeenCalledTimes(2)
+        const line1 = JSON.parse(consoleSpy.mock.calls[0][0])
+        expect(line1._type).toBe('backup')
+        expect(line1.version).toBe('2024-01-15_12:00')
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('backup download', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+    })
+
+    it('downloads a backup to the specified output path', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const writeSpy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {})
+
+        mockApi.getBackups.mockResolvedValue([
+            { version: '2024-01-15_12:00', url: 'https://example.com/backup1.zip' },
+        ])
+        mockApi.downloadBackup.mockResolvedValue({
+            arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+        })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'backup',
+            'download',
+            '2024-01-15_12:00',
+            '--output-file',
+            '/tmp/backup.zip',
+        ])
+
+        expect(mockApi.downloadBackup).toHaveBeenCalledWith({
+            file: 'https://example.com/backup1.zip',
+        })
+        expect(writeSpy).toHaveBeenCalledWith('/tmp/backup.zip', expect.any(Buffer))
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('/tmp/backup.zip'))
+        consoleSpy.mockRestore()
+        writeSpy.mockRestore()
+    })
+
+    it('errors when --output-file is not provided', async () => {
+        const program = createProgram()
+        const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        await expect(
+            program.parseAsync(['node', 'td', 'backup', 'download', '2024-01-15_12:00']),
+        ).rejects.toThrow()
+
+        stderrSpy.mockRestore()
+    })
+
+    it('throws error when version is not found', async () => {
+        const program = createProgram()
+
+        mockApi.getBackups.mockResolvedValue([
+            { version: '2024-01-15_12:00', url: 'https://example.com/backup1.zip' },
+        ])
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'backup',
+                'download',
+                'nonexistent',
+                '--output-file',
+                '/tmp/backup.zip',
+            ]),
+        ).rejects.toThrow('Backup version "nonexistent" not found')
+    })
+})

--- a/src/__tests__/backup.test.ts
+++ b/src/__tests__/backup.test.ts
@@ -6,11 +6,17 @@ vi.mock('../lib/api/core.js', () => ({
     getApi: vi.fn(),
 }))
 
+vi.mock('../lib/auth.js', () => ({
+    getAuthMetadata: vi.fn(),
+}))
+
 import { registerBackupCommand } from '../commands/backup/index.js'
 import { getApi } from '../lib/api/core.js'
+import { getAuthMetadata } from '../lib/auth.js'
 import { createMockApi, type MockApi } from './helpers/mock-api.js'
 
 const mockGetApi = vi.mocked(getApi)
+const mockGetAuthMetadata = vi.mocked(getAuthMetadata)
 
 function createProgram() {
     const program = new Command()
@@ -26,6 +32,11 @@ describe('backup list', () => {
         vi.clearAllMocks()
         mockApi = createMockApi()
         mockGetApi.mockResolvedValue(mockApi)
+        mockGetAuthMetadata.mockResolvedValue({
+            authMode: 'read-write',
+            authScope: 'data:read_write,data:delete,project:delete,backups:read',
+            source: 'secure-store',
+        })
     })
 
     it('lists available backups', async () => {
@@ -70,6 +81,7 @@ describe('backup list', () => {
         const parsed = JSON.parse(output)
         expect(parsed.results).toHaveLength(1)
         expect(parsed.results[0].version).toBe('2024-01-15_12:00')
+        expect(parsed.nextCursor).toBeNull()
         consoleSpy.mockRestore()
     })
 
@@ -84,11 +96,26 @@ describe('backup list', () => {
 
         await program.parseAsync(['node', 'td', 'backup', 'list', '--ndjson'])
 
-        expect(consoleSpy).toHaveBeenCalledTimes(2)
-        const line1 = JSON.parse(consoleSpy.mock.calls[0][0])
-        expect(line1._type).toBe('backup')
+        const output = consoleSpy.mock.calls[0][0]
+        const lines = output.split('\n')
+        expect(lines).toHaveLength(2)
+        const line1 = JSON.parse(lines[0])
         expect(line1.version).toBe('2024-01-15_12:00')
         consoleSpy.mockRestore()
+    })
+
+    it('throws error when token is missing backups:read scope', async () => {
+        const program = createProgram()
+
+        mockGetAuthMetadata.mockResolvedValue({
+            authMode: 'read-write',
+            authScope: 'data:read_write,data:delete,project:delete',
+            source: 'secure-store',
+        })
+
+        await expect(program.parseAsync(['node', 'td', 'backup', 'list'])).rejects.toThrow(
+            'missing the backups:read scope',
+        )
     })
 })
 
@@ -99,6 +126,11 @@ describe('backup download', () => {
         vi.clearAllMocks()
         mockApi = createMockApi()
         mockGetApi.mockResolvedValue(mockApi)
+        mockGetAuthMetadata.mockResolvedValue({
+            authMode: 'read-write',
+            authScope: 'data:read_write,data:delete,project:delete,backups:read',
+            source: 'secure-store',
+        })
     })
 
     it('downloads a backup to the specified output path', async () => {
@@ -110,6 +142,9 @@ describe('backup download', () => {
             { version: '2024-01-15_12:00', url: 'https://example.com/backup1.zip' },
         ])
         mockApi.downloadBackup.mockResolvedValue({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
             arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
         })
 
@@ -130,6 +165,32 @@ describe('backup download', () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('/tmp/backup.zip'))
         consoleSpy.mockRestore()
         writeSpy.mockRestore()
+    })
+
+    it('throws error when download response is not ok', async () => {
+        const program = createProgram()
+
+        mockApi.getBackups.mockResolvedValue([
+            { version: '2024-01-15_12:00', url: 'https://example.com/backup1.zip' },
+        ])
+        mockApi.downloadBackup.mockResolvedValue({
+            ok: false,
+            status: 404,
+            statusText: 'Not Found',
+            arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+        })
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'backup',
+                'download',
+                '2024-01-15_12:00',
+                '--output-file',
+                '/tmp/backup.zip',
+            ]),
+        ).rejects.toThrow('Failed to download backup: 404 Not Found')
     })
 
     it('errors when --output-file is not provided', async () => {

--- a/src/__tests__/helpers/mock-api.ts
+++ b/src/__tests__/helpers/mock-api.ts
@@ -166,6 +166,9 @@ export function createMockApi(overrides: Partial<TodoistApi> = {}): MockApi {
         // Reminders (REST)
         getReminders: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
         getLocationReminders: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
+        // Backups
+        getBackups: vi.fn().mockResolvedValue([]),
+        downloadBackup: vi.fn(),
         ...overrides,
     } as unknown as MockApi
 }

--- a/src/__tests__/oauth.test.ts
+++ b/src/__tests__/oauth.test.ts
@@ -6,21 +6,21 @@ describe('buildAuthorizationUrl', () => {
         const url = buildAuthorizationUrl('challenge', 'state')
         const params = new URL(url).searchParams
 
-        expect(params.get('scope')).toBe('data:read_write,data:delete,project:delete')
+        expect(params.get('scope')).toBe('data:read_write,data:delete,project:delete,backups:read')
     })
 
     it('uses read-only scope when requested', () => {
         const url = buildAuthorizationUrl('challenge', 'state', { readOnly: true })
         const params = new URL(url).searchParams
 
-        expect(params.get('scope')).toBe('data:read')
+        expect(params.get('scope')).toBe('data:read,backups:read')
     })
 
     it('uses read-write scope when readOnly is false', () => {
         const url = buildAuthorizationUrl('challenge', 'state', { readOnly: false })
         const params = new URL(url).searchParams
 
-        expect(params.get('scope')).toBe('data:read_write,data:delete,project:delete')
+        expect(params.get('scope')).toBe('data:read_write,data:delete,project:delete,backups:read')
     })
 
     it('uses the specified port in redirect_uri', () => {

--- a/src/__tests__/permissions.test.ts
+++ b/src/__tests__/permissions.test.ts
@@ -34,7 +34,7 @@ describe('permissions', () => {
     it('allows writes in read-write mode', async () => {
         mockGetAuthMetadata.mockResolvedValue({
             authMode: 'read-write',
-            authScope: 'data:read_write,data:delete,project:delete',
+            authScope: 'data:read_write,data:delete,project:delete,backups:read',
             source: 'secure-store',
         })
 
@@ -83,6 +83,8 @@ describe('permissions', () => {
         expect(isMutatingApiMethod('exportTemplateAsFile')).toBe(false)
         expect(isMutatingApiMethod('getReminders')).toBe(false)
         expect(isMutatingApiMethod('getWorkspaceInsights')).toBe(false)
+        expect(isMutatingApiMethod('getBackups')).toBe(false)
+        expect(isMutatingApiMethod('downloadBackup')).toBe(false)
         expect(isMutatingApiMethod('sync')).toBe(false)
     })
 

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -9,7 +9,7 @@ export function registerAuthCommand(program: Command): void {
 
     auth.command('login')
         .description('Authenticate with Todoist via OAuth')
-        .option('--read-only', 'Authenticate with read-only scope (data:read)')
+        .option('--read-only', 'Authenticate with read-only scope (data:read,backups:read)')
         .action(loginWithOAuth)
 
     auth.command('token [token]')

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -4,7 +4,7 @@ import { type AuthMode, getAuthMetadata } from '../../lib/auth.js'
 
 function formatAuthMode(authMode: AuthMode, authScope?: string): string {
     if (authMode === 'read-only') {
-        return `read-only (OAuth scope ${authScope ?? 'data:read'})`
+        return `read-only (OAuth scope ${authScope ?? 'data:read,backups:read'})`
     }
     if (authMode === 'read-write') {
         return 'read-write'

--- a/src/commands/backup/download.ts
+++ b/src/commands/backup/download.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { getApi } from '../../lib/api/core.js'
+import { CliError } from '../../lib/errors.js'
+import { isQuiet } from '../../lib/global-args.js'
+
+interface DownloadBackupOptions {
+    outputFile: string
+}
+
+export async function downloadBackup(
+    version: string,
+    options: DownloadBackupOptions,
+): Promise<void> {
+    const api = await getApi()
+
+    let backups
+    try {
+        backups = await api.getBackups()
+    } catch (error) {
+        if (error instanceof CliError && error.code === 'AUTH_ERROR') {
+            throw new CliError(
+                'AUTH_ERROR',
+                'Failed to access backups. Your token may be missing the backups:read scope.',
+                [
+                    'Re-authenticate to grant backup access: td auth login',
+                    'If using an API token, ensure it has the backups:read scope',
+                ],
+            )
+        }
+        throw error
+    }
+
+    const backup = backups.find((b) => b.version === version)
+    if (!backup) {
+        throw new CliError('NOT_FOUND', `Backup version "${version}" not found`, [
+            'Run `td backup list` to see available backup versions',
+        ])
+    }
+
+    const response = await api.downloadBackup({ file: backup.url })
+    const arrayBuffer = await response.arrayBuffer()
+    const buffer = Buffer.from(arrayBuffer)
+
+    const outputPath = path.resolve(options.outputFile)
+    fs.writeFileSync(outputPath, buffer)
+
+    if (!isQuiet()) {
+        console.log(`Backup written to ${outputPath}`)
+    }
+}

--- a/src/commands/backup/download.ts
+++ b/src/commands/backup/download.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { getApi } from '../../lib/api/core.js'
 import { CliError } from '../../lib/errors.js'
 import { isQuiet } from '../../lib/global-args.js'
+import { fetchBackups } from './helpers.js'
 
 interface DownloadBackupOptions {
     outputFile: string
@@ -13,23 +14,7 @@ export async function downloadBackup(
     options: DownloadBackupOptions,
 ): Promise<void> {
     const api = await getApi()
-
-    let backups
-    try {
-        backups = await api.getBackups()
-    } catch (error) {
-        if (error instanceof CliError && error.code === 'AUTH_ERROR') {
-            throw new CliError(
-                'AUTH_ERROR',
-                'Failed to access backups. Your token may be missing the backups:read scope.',
-                [
-                    'Re-authenticate to grant backup access: td auth login',
-                    'If using an API token, ensure it has the backups:read scope',
-                ],
-            )
-        }
-        throw error
-    }
+    const backups = await fetchBackups(api)
 
     const backup = backups.find((b) => b.version === version)
     if (!backup) {
@@ -39,6 +24,13 @@ export async function downloadBackup(
     }
 
     const response = await api.downloadBackup({ file: backup.url })
+    if (!response.ok) {
+        throw new CliError(
+            'API_ERROR',
+            `Failed to download backup: ${response.status} ${response.statusText}`,
+        )
+    }
+
     const arrayBuffer = await response.arrayBuffer()
     const buffer = Buffer.from(arrayBuffer)
 

--- a/src/commands/backup/helpers.ts
+++ b/src/commands/backup/helpers.ts
@@ -1,0 +1,14 @@
+import type { Backup, TodoistApi } from '@doist/todoist-sdk'
+import { getAuthMetadata } from '../../lib/auth.js'
+import { CliError } from '../../lib/errors.js'
+
+export async function fetchBackups(api: TodoistApi): Promise<Backup[]> {
+    const metadata = await getAuthMetadata()
+    if (metadata.authScope && !metadata.authScope.includes('backups:read')) {
+        throw new CliError('AUTH_ERROR', 'Your current token is missing the backups:read scope', [
+            'Re-authenticate to grant backup access: td auth login',
+        ])
+    }
+
+    return api.getBackups()
+}

--- a/src/commands/backup/index.ts
+++ b/src/commands/backup/index.ts
@@ -1,0 +1,36 @@
+import { Command } from 'commander'
+import { downloadBackup } from './download.js'
+import { listBackups } from './list.js'
+
+export function registerBackupCommand(program: Command): void {
+    const backup = program
+        .command('backup')
+        .description('Manage backups')
+        .addHelpText(
+            'after',
+            `
+Examples:
+  td backup list
+  td backup list --json
+  td backup download "2024-01-15_12:00" --output-file backup.zip`,
+        )
+
+    backup
+        .command('list')
+        .description('List available backups')
+        .option('--json', 'Output as JSON')
+        .option('--ndjson', 'Output as newline-delimited JSON')
+        .action(listBackups)
+
+    const downloadCmd = backup
+        .command('download [version]')
+        .description('Download a backup file')
+        .requiredOption('--output-file <path>', 'Output file path')
+        .action((version, options) => {
+            if (!version) {
+                downloadCmd.help()
+                return
+            }
+            return downloadBackup(version, options)
+        })
+}

--- a/src/commands/backup/list.ts
+++ b/src/commands/backup/list.ts
@@ -1,0 +1,50 @@
+import chalk from 'chalk'
+import { getApi } from '../../lib/api/core.js'
+import { CliError } from '../../lib/errors.js'
+
+interface ListBackupsOptions {
+    json?: boolean
+    ndjson?: boolean
+}
+
+export async function listBackups(options: ListBackupsOptions): Promise<void> {
+    const api = await getApi()
+
+    let backups
+    try {
+        backups = await api.getBackups()
+    } catch (error) {
+        if (error instanceof CliError && error.code === 'AUTH_ERROR') {
+            throw new CliError(
+                'AUTH_ERROR',
+                'Failed to access backups. Your token may be missing the backups:read scope.',
+                [
+                    'Re-authenticate to grant backup access: td auth login',
+                    'If using an API token, ensure it has the backups:read scope',
+                ],
+            )
+        }
+        throw error
+    }
+
+    if (options.json) {
+        console.log(JSON.stringify({ results: backups }, null, 2))
+        return
+    }
+
+    if (options.ndjson) {
+        for (const backup of backups) {
+            console.log(JSON.stringify({ _type: 'backup', ...backup }))
+        }
+        return
+    }
+
+    if (backups.length === 0) {
+        console.log('No backups found.')
+        return
+    }
+
+    for (const backup of backups) {
+        console.log(`${backup.version}  ${chalk.dim(backup.url)}`)
+    }
+}

--- a/src/commands/backup/list.ts
+++ b/src/commands/backup/list.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import { getApi } from '../../lib/api/core.js'
-import { CliError } from '../../lib/errors.js'
+import { formatPaginatedJson, formatPaginatedNdjson } from '../../lib/output.js'
+import { fetchBackups } from './helpers.js'
 
 interface ListBackupsOptions {
     json?: boolean
@@ -9,33 +10,16 @@ interface ListBackupsOptions {
 
 export async function listBackups(options: ListBackupsOptions): Promise<void> {
     const api = await getApi()
-
-    let backups
-    try {
-        backups = await api.getBackups()
-    } catch (error) {
-        if (error instanceof CliError && error.code === 'AUTH_ERROR') {
-            throw new CliError(
-                'AUTH_ERROR',
-                'Failed to access backups. Your token may be missing the backups:read scope.',
-                [
-                    'Re-authenticate to grant backup access: td auth login',
-                    'If using an API token, ensure it has the backups:read scope',
-                ],
-            )
-        }
-        throw error
-    }
+    const backups = await fetchBackups(api)
+    const paginated = { results: backups, nextCursor: null }
 
     if (options.json) {
-        console.log(JSON.stringify({ results: backups }, null, 2))
+        console.log(formatPaginatedJson(paginated))
         return
     }
 
     if (options.ndjson) {
-        for (const backup of backups) {
-            console.log(JSON.stringify({ _type: 'backup', ...backup }))
-        }
+        console.log(formatPaginatedNdjson(paginated))
         return
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,10 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
         'Manage authentication',
         async () => (await import('./commands/auth/index.js')).registerAuthCommand,
     ],
+    backup: [
+        'Manage backups',
+        async () => (await import('./commands/backup/index.js')).registerBackupCommand,
+    ],
     stats: [
         'View productivity stats and karma',
         async () => (await import('./commands/stats/index.js')).registerStatsCommand,
@@ -175,7 +179,13 @@ if (process.argv[2] === 'completion-server') {
         try {
             // Preload markdown renderer in parallel with the command module
             // when output will be pretty-printed (not JSON/NDJSON/raw)
-            const noMarkdownCommands = new Set(['changelog', 'doctor', 'update', 'completion'])
+            const noMarkdownCommands = new Set([
+                'backup',
+                'changelog',
+                'doctor',
+                'update',
+                'completion',
+            ])
             const needsMarkdown =
                 !noMarkdownCommands.has(commandName) &&
                 !isJsonMode() &&

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -75,6 +75,9 @@ const API_SPINNER_MESSAGES: Record<string, { text: string; color?: 'blue' | 'gre
         importTemplateFromId: { text: 'Importing template...', color: 'green' },
         getReminders: { text: 'Loading reminders...', color: 'blue' },
         getLocationReminders: { text: 'Loading location reminders...', color: 'blue' },
+        // Backups
+        getBackups: { text: 'Loading backups...', color: 'blue' },
+        downloadBackup: { text: 'Downloading backup...', color: 'blue' },
     }
 
 function createSpinnerWrappedApi(api: TodoistApi): TodoistApi {

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -4,8 +4,8 @@ import { DEFAULT_PORT, getRedirectUri } from './oauth-server.js'
 const TODOIST_CLIENT_ID = '04863cc1e3584830a578622f50224d5b'
 const OAUTH_AUTHORIZE_URL = 'https://todoist.com/oauth/authorize'
 const OAUTH_TOKEN_URL = 'https://todoist.com/oauth/access_token'
-export const READ_WRITE_SCOPES = 'data:read_write,data:delete,project:delete'
-export const READ_ONLY_SCOPES = 'data:read'
+export const READ_WRITE_SCOPES = 'data:read_write,data:delete,project:delete,backups:read'
+export const READ_ONLY_SCOPES = 'data:read,backups:read'
 
 export function buildAuthorizationUrl(
     codeChallenge: string,

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -56,6 +56,9 @@ const KNOWN_SAFE_API_METHODS = new Set([
     // Reminders (REST read)
     'getReminders',
     'getLocationReminders',
+    // Backups
+    'getBackups',
+    'downloadBackup',
     // Sync is handled separately via payload inspection
     'sync',
 ])

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -45,7 +45,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Project analytics: \`td project progress/health/health-context/activity-stats/analyze-health\`
 - Organization: \`td label ...\`, \`td filter ...\`, \`td section ...\`, \`td workspace ...\`
 - Collaboration: \`td comment ...\`, \`td notification ...\`, \`td reminder ...\`
-- Templates and files: \`td template ...\`, \`td attachment view <file-url>\`
+- Templates and files: \`td template ...\`, \`td attachment view <file-url>\`, \`td backup ...\`
 - Account and tooling: \`td stats\`, \`td settings ...\`, \`td completion ...\`, \`td view <todoist-url>\`, \`td doctor\`, \`td update\`, \`td changelog\`
 
 ## References
@@ -181,6 +181,12 @@ td template export-url "Roadmap"
 td template create --name "New Project" --file template.csv --workspace "Acme"
 td template import-file "Roadmap" --file template.csv
 td template import-id "Roadmap" --template-id product-launch --locale fr
+\`\`\`
+
+### Backups
+\`\`\`bash
+td backup list
+td backup download "2024-01-15_12:00" --output-file backup.zip
 \`\`\`
 
 ### Settings, Stats, And Utilities


### PR DESCRIPTION
## Summary

- Add `td backup list` and `td backup download <version> --output-file <path>` commands using the SDK's `getBackups()` and `downloadBackup()` methods
- Add `backups:read` OAuth scope to both read-write and read-only scope sets so new logins get backup access
- Existing tokens missing the scope get a clear error message directing users to re-authenticate via `td auth login`

## Test plan

- [x] `npm run type-check` passes
- [x] `npm test` — all 1281 tests pass (7 new backup tests)
- [x] `npm run check` — lint and format clean
- [x] `npm run sync:skill` — skill file regenerated
- [x] Verified `td backup list` with existing token shows actionable scope error
- [ ] After re-auth with new scopes, verify `td backup list` returns backups
- [ ] Verify `td backup download <version> --output-file backup.zip` saves a valid ZIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)