### PR TITLE
feat: add td task quickadd subcommand with qa alias

### DIFF
--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -41,7 +41,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 ## Quick Reference
 
 - Daily views: `td today`, `td inbox`, `td upcoming`, `td completed`, `td activity`
-- Task lifecycle: `td task list/view/add/update/reschedule/move/complete/uncomplete/delete/browse`
+- Task lifecycle: `td task list/view/add/quickadd/update/reschedule/move/complete/uncomplete/delete/browse` (alias: `td task qa` for `quickadd`)
 - Projects: `td project list/view/create/update/archive/unarchive/archived/delete/move/join/browse/collaborators/permissions`
 - Project analytics: `td project progress/health/health-context/activity-stats/analyze-health`
 - Organization: `td label ...`, `td filter ...`, `td section ...`, `td workspace ...`
@@ -75,6 +75,8 @@ td activity --type task --event completed
 ### Tasks
 ```bash
 td task add "Buy milk" --due tomorrow
+td task quickadd "Buy milk tomorrow p1 #Shopping"
+td task qa "Review PR @urgent +Alice"
 td task list --project "Work" --label "urgent" --priority p1
 td task view "Buy milk"
 td task add "Plan sprint" --project "Work" --section "Planning" --labels "urgent,review"
@@ -87,8 +89,13 @@ td task delete "Plan sprint" --yes
 td task browse "Plan sprint"
 ```
 
+Choosing between `task add` and `task quickadd`:
+- `td task quickadd` (alias `td task qa`) uses Todoist's natural-language parser. Inline syntax covers dates ("tomorrow at 2pm"), priority (`p1`–`p4`), project (`#Project`), labels (`@label`), sections (`/Section`), and assignee (`+Person` on shared projects). **Prefer `quickadd` when all task attributes can be expressed inline and you do not need to set additional structured fields** — it's one call and no name-resolution lookups are required.
+- Use `td task add` when you need flags that Quick Add syntax can't express (`--deadline`, `--description`, `--parent`, `--duration`, `--uncompletable`, `--order`), when the text is being composed programmatically, or when you need explicit `id:` / URL references for project/section/parent.
+- `td task quickadd` supports `--stdin`, `--json`, and `--dry-run` only; everything else is embedded in the text.
+
 Useful task flags:
-- `--stdin` reads the task description from stdin.
+- `--stdin` on `task add` reads the task description from stdin; on `task quickadd` it reads the full natural-language text from stdin.
 - `--parent`, `--section`, `--project`, `--workspace`, `--assignee`, `--labels`, `--due`, `--deadline`, `--duration`, and `--priority` cover most task workflows.
 - `td task complete --forever` stops recurrence; `td task update --no-deadline` clears deadlines; `td task move --no-parent` and `--no-section` detach from hierarchy.
 

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -93,6 +93,7 @@ Choosing between `task add` and `task quickadd`:
 - `td task quickadd` (alias `td task qa`) uses Todoist's natural-language parser. Inline syntax covers dates ("tomorrow at 2pm"), priority (`p1`–`p4`), project (`#Project`), labels (`@label`), sections (`/Section`), and assignee (`+Person` on shared projects). **Prefer `quickadd` when all task attributes can be expressed inline and you do not need to set additional structured fields** — it's one call and no name-resolution lookups are required.
 - Use `td task add` when you need flags that Quick Add syntax can't express (`--deadline`, `--description`, `--parent`, `--duration`, `--uncompletable`, `--order`), when the text is being composed programmatically, or when you need explicit `id:` / URL references for project/section/parent.
 - `td task quickadd` supports `--stdin`, `--json`, and `--dry-run` only; everything else is embedded in the text.
+- The top-level `td add <text>` is a human shorthand for `td task quickadd` — same parser, same flag surface (`--stdin`, `--json`, `--dry-run`). Agents should prefer `td task quickadd` / `qa` for discoverability alongside the other task subcommands.
 
 Useful task flags:
 - `--stdin` on `task add` reads the task description from stdin; on `task quickadd` (and the top-level `td add`) it reads the full natural-language text from stdin.

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -95,7 +95,7 @@ Choosing between `task add` and `task quickadd`:
 - `td task quickadd` supports `--stdin`, `--json`, and `--dry-run` only; everything else is embedded in the text.
 
 Useful task flags:
-- `--stdin` on `task add` reads the task description from stdin; on `task quickadd` it reads the full natural-language text from stdin.
+- `--stdin` on `task add` reads the task description from stdin; on `task quickadd` (and the top-level `td add`) it reads the full natural-language text from stdin.
 - `--parent`, `--section`, `--project`, `--workspace`, `--assignee`, `--labels`, `--due`, `--deadline`, `--duration`, and `--priority` cover most task workflows.
 - `td task complete --forever` stops recurrence; `td task update --no-deadline` clears deadlines; `td task move --no-parent` and `--no-section` detach from hierarchy.
 

--- a/src/__tests__/add.test.ts
+++ b/src/__tests__/add.test.ts
@@ -5,11 +5,17 @@ vi.mock('../lib/api/core.js', () => ({
     getApi: vi.fn(),
 }))
 
+vi.mock('../lib/stdin.js', () => ({
+    readStdin: vi.fn(),
+}))
+
 import { registerAddCommand } from '../commands/add.js'
 import { getApi } from '../lib/api/core.js'
+import { readStdin } from '../lib/stdin.js'
 import { createMockApi, type MockApi } from './helpers/mock-api.js'
 
 const mockGetApi = vi.mocked(getApi)
+const mockReadStdin = vi.mocked(readStdin)
 
 function createProgram() {
     const program = new Command()
@@ -120,32 +126,48 @@ describe('add command', () => {
         consoleSpy.mockRestore()
     })
 
-    it('assigns task with --assignee flag', async () => {
+    it('reads text from stdin with --stdin', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockReadStdin.mockResolvedValue('Buy milk tomorrow\n')
+        mockApi.quickAddTask.mockResolvedValue({
+            id: 'task-1',
+            content: 'Buy milk',
+            due: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'add', '--stdin'])
+
+        expect(mockReadStdin).toHaveBeenCalled()
+        expect(mockApi.quickAddTask).toHaveBeenCalledWith({ text: 'Buy milk tomorrow' })
+        consoleSpy.mockRestore()
+    })
+
+    it('errors when both text and --stdin are provided', async () => {
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'td', 'add', 'Buy milk', '--stdin']),
+        ).rejects.toThrow(/Cannot specify text both as argument and --stdin/)
+    })
+
+    it('--json outputs JSON of created task', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         mockApi.quickAddTask.mockResolvedValue({
             id: 'task-1',
-            content: 'Review PR',
-            projectId: 'proj-1',
-            due: null,
-        })
-        mockApi.getProject.mockResolvedValue({
-            id: 'proj-1',
-            name: 'Work',
-            isShared: true,
-        })
-        mockApi.updateTask.mockResolvedValue({
-            id: 'task-1',
-            content: 'Review PR',
+            content: 'Buy milk',
             due: null,
         })
 
-        await program.parseAsync(['node', 'td', 'add', 'Review PR', '--assignee', 'id:user-123'])
+        await program.parseAsync(['node', 'td', 'add', 'Buy milk', '--json'])
 
-        expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', {
-            assigneeId: 'user-123',
-        })
+        expect(mockApi.quickAddTask).toHaveBeenCalled()
+        const output = consoleSpy.mock.calls[0][0] as string
+        expect(() => JSON.parse(output)).not.toThrow()
+        expect(JSON.parse(output)).toMatchObject({ id: 'task-1', content: 'Buy milk' })
         consoleSpy.mockRestore()
     })
 })

--- a/src/__tests__/task-quickadd.test.ts
+++ b/src/__tests__/task-quickadd.test.ts
@@ -1,0 +1,142 @@
+import { Command } from 'commander'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/api/core.js', () => ({
+    getApi: vi.fn(),
+    completeTaskForever: vi.fn(),
+    rescheduleTask: vi.fn(),
+}))
+
+vi.mock('../lib/stdin.js', () => ({
+    readStdin: vi.fn(),
+}))
+
+import { registerTaskCommand } from '../commands/task/index.js'
+import { getApi } from '../lib/api/core.js'
+import { resetGlobalArgs } from '../lib/global-args.js'
+import { readStdin } from '../lib/stdin.js'
+import { createMockApi, type MockApi } from './helpers/mock-api.js'
+
+const mockGetApi = vi.mocked(getApi)
+const mockReadStdin = vi.mocked(readStdin)
+
+function createProgram() {
+    const program = new Command()
+    program.exitOverride()
+    registerTaskCommand(program)
+    return program
+}
+
+describe('task quickadd command', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        resetGlobalArgs()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+    })
+
+    it('calls quickAddTask with positional text', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.quickAddTask.mockResolvedValue({
+            id: 'task-1',
+            content: 'Buy milk',
+            due: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'task', 'quickadd', 'Buy milk tomorrow p1'])
+
+        expect(mockApi.quickAddTask).toHaveBeenCalledWith({ text: 'Buy milk tomorrow p1' })
+        consoleSpy.mockRestore()
+    })
+
+    it('works via qa alias', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.quickAddTask.mockResolvedValue({
+            id: 'task-1',
+            content: 'Buy milk',
+            due: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'task', 'qa', 'Buy milk'])
+
+        expect(mockApi.quickAddTask).toHaveBeenCalledWith({ text: 'Buy milk' })
+        consoleSpy.mockRestore()
+    })
+
+    it('reads text from stdin with --stdin', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockReadStdin.mockResolvedValue('Buy milk tomorrow\n')
+        mockApi.quickAddTask.mockResolvedValue({
+            id: 'task-1',
+            content: 'Buy milk',
+            due: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'task', 'qa', '--stdin'])
+
+        expect(mockReadStdin).toHaveBeenCalled()
+        expect(mockApi.quickAddTask).toHaveBeenCalledWith({ text: 'Buy milk tomorrow' })
+        consoleSpy.mockRestore()
+    })
+
+    it('errors when both text and --stdin are provided', async () => {
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'td', 'task', 'qa', 'Buy milk', '--stdin']),
+        ).rejects.toThrow(/Cannot specify text both as argument and --stdin/)
+    })
+
+    it('--dry-run skips API call and prints preview', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'td', 'task', 'qa', 'Buy milk', '--dry-run'])
+
+        expect(mockApi.quickAddTask).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would quick add task'))
+        consoleSpy.mockRestore()
+    })
+
+    it('--json outputs task as JSON', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.quickAddTask.mockResolvedValue({
+            id: 'task-1',
+            content: 'Buy milk',
+            due: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'task', 'qa', 'Buy milk', '--json'])
+
+        const output = consoleSpy.mock.calls[0][0] as string
+        expect(() => JSON.parse(output)).not.toThrow()
+        expect(JSON.parse(output)).toMatchObject({ id: 'task-1', content: 'Buy milk' })
+        consoleSpy.mockRestore()
+    })
+
+    it('displays due date when present', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.quickAddTask.mockResolvedValue({
+            id: 'task-1',
+            content: 'Meeting',
+            due: { date: '2026-01-10', string: 'tomorrow' },
+        })
+
+        await program.parseAsync(['node', 'td', 'task', 'qa', 'Meeting tomorrow'])
+
+        expect(consoleSpy).toHaveBeenCalledWith('Due: tomorrow')
+        consoleSpy.mockRestore()
+    })
+})

--- a/src/__tests__/task-quickadd.test.ts
+++ b/src/__tests__/task-quickadd.test.ts
@@ -95,6 +95,34 @@ describe('task quickadd command', () => {
         ).rejects.toThrow(/Cannot specify text both as argument and --stdin/)
     })
 
+    it('errors when empty-string text and --stdin are both provided', async () => {
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'td', 'task', 'qa', '', '--stdin']),
+        ).rejects.toThrow(/Cannot specify text both as argument and --stdin/)
+        expect(mockReadStdin).not.toHaveBeenCalled()
+    })
+
+    it('errors on whitespace-only text without hitting the API', async () => {
+        const program = createProgram()
+
+        await expect(program.parseAsync(['node', 'td', 'task', 'qa', '   '])).rejects.toThrow(
+            /No text provided for quick add/,
+        )
+        expect(mockApi.quickAddTask).not.toHaveBeenCalled()
+    })
+
+    it('errors on whitespace-only stdin without hitting the API', async () => {
+        const program = createProgram()
+        mockReadStdin.mockResolvedValue('   \n')
+
+        await expect(program.parseAsync(['node', 'td', 'task', 'qa', '--stdin'])).rejects.toThrow(
+            /No text provided for quick add/,
+        )
+        expect(mockApi.quickAddTask).not.toHaveBeenCalled()
+    })
+
     it('--dry-run skips API call and prints preview', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,47 +1,20 @@
-import chalk from 'chalk'
 import { Command } from 'commander'
-import { getApi } from '../lib/api/core.js'
-import { resolveAssigneeId } from '../lib/collaborators.js'
-import { formatDue, printDryRun } from '../lib/output.js'
-
-interface AddOptions {
-    assignee?: string
-    dryRun?: boolean
-}
+import { quickaddTask, type QuickaddOptions } from './task/quickadd.js'
 
 export function registerAddCommand(program: Command): void {
     const addCmd = program
         .command('add [text]')
         .description(
-            'Quick add with natural language (human shorthand; agents should use "task add")',
+            'Quick add with natural language (human shorthand for "td task quickadd" / "td task qa")',
         )
-        .option('--assignee <ref>', 'Assign to user (name, email, id:xxx, or "me")')
+        .option('--stdin', 'Read text from stdin')
+        .option('--json', 'Output the created task as JSON')
         .option('--dry-run', 'Preview what would happen without executing')
-        .action(async (text: string | undefined, options: AddOptions) => {
-            if (!text) {
+        .action((text: string | undefined, options: QuickaddOptions) => {
+            if (!text && !options.stdin) {
                 addCmd.help()
                 return
             }
-
-            if (options.dryRun) {
-                printDryRun('quick add task', {
-                    Text: text,
-                    Assignee: options.assignee,
-                })
-                return
-            }
-
-            const api = await getApi()
-            let task = await api.quickAddTask({ text })
-
-            if (options.assignee) {
-                const project = await api.getProject(task.projectId)
-                const assigneeId = await resolveAssigneeId(api, options.assignee, project)
-                task = await api.updateTask(task.id, { assigneeId })
-            }
-
-            console.log(`Created: ${task.content}`)
-            if (task.due) console.log(`Due: ${formatDue(task.due)}`)
-            console.log(chalk.dim(`ID: ${task.id}`))
+            return quickaddTask({ ...options, text })
         })
 }

--- a/src/commands/task/index.ts
+++ b/src/commands/task/index.ts
@@ -10,6 +10,8 @@ import { completeTask } from './complete.js'
 import { deleteTask } from './delete.js'
 import { listTasks } from './list.js'
 import { moveTask } from './move.js'
+import type { QuickaddOptions } from './quickadd.js'
+import { quickaddTask } from './quickadd.js'
 import { rescheduleTask } from './reschedule.js'
 import { uncompleteTask } from './uncomplete.js'
 import { updateTask } from './update.js'
@@ -26,6 +28,7 @@ export function registerTaskCommand(program: Command): void {
             `
 Examples:
   td task add "Buy milk" --due tomorrow
+  td task qa "Buy milk tomorrow p1 #Shopping"
   td task list --project "Work" --priority p1
   td task view "Buy milk"`,
         )
@@ -153,6 +156,23 @@ Examples:
                 return
             }
             return addTask({ ...options, content })
+        })
+
+    const quickaddCmd = task
+        .command('quickadd [text]')
+        .alias('qa')
+        .description(
+            'Quick add a task using natural language (e.g. "Buy milk tomorrow p1 #Shopping +John")',
+        )
+        .option('--stdin', 'Read text from stdin')
+        .option('--json', 'Output the created task as JSON')
+        .option('--dry-run', 'Preview what would happen without executing')
+        .action((text: string | undefined, options: QuickaddOptions) => {
+            if (!text && !options.stdin) {
+                quickaddCmd.help()
+                return
+            }
+            return quickaddTask({ ...options, text })
         })
 
     const updateCmd = task

--- a/src/commands/task/index.ts
+++ b/src/commands/task/index.ts
@@ -162,7 +162,7 @@ Examples:
         .command('quickadd [text]')
         .alias('qa')
         .description(
-            'Quick add a task using natural language (e.g. "Buy milk tomorrow p1 #Shopping +John")',
+            'Quick add a task using natural language (e.g. "Buy milk tomorrow p1 #Shopping")',
         )
         .option('--stdin', 'Read text from stdin')
         .option('--json', 'Output the created task as JSON')

--- a/src/commands/task/quickadd.ts
+++ b/src/commands/task/quickadd.ts
@@ -1,0 +1,52 @@
+import chalk from 'chalk'
+import { getApi } from '../../lib/api/core.js'
+import { CliError } from '../../lib/errors.js'
+import { isQuiet } from '../../lib/global-args.js'
+import { formatDue, formatJson, printDryRun } from '../../lib/output.js'
+import { readStdin } from '../../lib/stdin.js'
+
+export interface QuickaddOptions {
+    text?: string
+    stdin?: boolean
+    json?: boolean
+    dryRun?: boolean
+}
+
+export async function quickaddTask(options: QuickaddOptions): Promise<void> {
+    if (options.text && options.stdin) {
+        throw new CliError(
+            'CONFLICTING_OPTIONS',
+            'Cannot specify text both as argument and --stdin',
+        )
+    }
+
+    const text = options.stdin ? (await readStdin()).trim() : options.text
+
+    if (!text) {
+        throw new CliError('MISSING_CONTENT', 'No text provided for quick add')
+    }
+
+    if (options.dryRun) {
+        printDryRun('quick add task', {
+            Text: text,
+        })
+        return
+    }
+
+    const api = await getApi()
+    const task = await api.quickAddTask({ text })
+
+    if (options.json) {
+        console.log(formatJson(task, 'task'))
+        return
+    }
+
+    if (isQuiet()) {
+        console.log(task.id)
+        return
+    }
+
+    console.log(`Created: ${task.content}`)
+    if (task.due) console.log(`Due: ${formatDue(task.due)}`)
+    console.log(chalk.dim(`ID: ${task.id}`))
+}

--- a/src/commands/task/quickadd.ts
+++ b/src/commands/task/quickadd.ts
@@ -13,14 +13,15 @@ export interface QuickaddOptions {
 }
 
 export async function quickaddTask(options: QuickaddOptions): Promise<void> {
-    if (options.text && options.stdin) {
+    if (options.text !== undefined && options.stdin) {
         throw new CliError(
             'CONFLICTING_OPTIONS',
             'Cannot specify text both as argument and --stdin',
         )
     }
 
-    const text = options.stdin ? (await readStdin()).trim() : options.text
+    const raw = options.stdin ? await readStdin() : (options.text ?? '')
+    const text = raw.trim()
 
     if (!text) {
         throw new CliError('MISSING_CONTENT', 'No text provided for quick add')

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -92,6 +92,7 @@ Choosing between \`task add\` and \`task quickadd\`:
 - \`td task quickadd\` (alias \`td task qa\`) uses Todoist's natural-language parser. Inline syntax covers dates ("tomorrow at 2pm"), priority (\`p1\`–\`p4\`), project (\`#Project\`), labels (\`@label\`), sections (\`/Section\`), and assignee (\`+Person\` on shared projects). **Prefer \`quickadd\` when all task attributes can be expressed inline and you do not need to set additional structured fields** — it's one call and no name-resolution lookups are required.
 - Use \`td task add\` when you need flags that Quick Add syntax can't express (\`--deadline\`, \`--description\`, \`--parent\`, \`--duration\`, \`--uncompletable\`, \`--order\`), when the text is being composed programmatically, or when you need explicit \`id:\` / URL references for project/section/parent.
 - \`td task quickadd\` supports \`--stdin\`, \`--json\`, and \`--dry-run\` only; everything else is embedded in the text.
+- The top-level \`td add <text>\` is a human shorthand for \`td task quickadd\` — same parser, same flag surface (\`--stdin\`, \`--json\`, \`--dry-run\`). Agents should prefer \`td task quickadd\` / \`qa\` for discoverability alongside the other task subcommands.
 
 Useful task flags:
 - \`--stdin\` on \`task add\` reads the task description from stdin; on \`task quickadd\` (and the top-level \`td add\`) it reads the full natural-language text from stdin.

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -40,7 +40,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 ## Quick Reference
 
 - Daily views: \`td today\`, \`td inbox\`, \`td upcoming\`, \`td completed\`, \`td activity\`
-- Task lifecycle: \`td task list/view/add/update/reschedule/move/complete/uncomplete/delete/browse\`
+- Task lifecycle: \`td task list/view/add/quickadd/update/reschedule/move/complete/uncomplete/delete/browse\` (alias: \`td task qa\` for \`quickadd\`)
 - Projects: \`td project list/view/create/update/archive/unarchive/archived/delete/move/join/browse/collaborators/permissions\`
 - Project analytics: \`td project progress/health/health-context/activity-stats/analyze-health\`
 - Organization: \`td label ...\`, \`td filter ...\`, \`td section ...\`, \`td workspace ...\`
@@ -74,6 +74,8 @@ td activity --type task --event completed
 ### Tasks
 \`\`\`bash
 td task add "Buy milk" --due tomorrow
+td task quickadd "Buy milk tomorrow p1 #Shopping"
+td task qa "Review PR @urgent +Alice"
 td task list --project "Work" --label "urgent" --priority p1
 td task view "Buy milk"
 td task add "Plan sprint" --project "Work" --section "Planning" --labels "urgent,review"
@@ -86,8 +88,13 @@ td task delete "Plan sprint" --yes
 td task browse "Plan sprint"
 \`\`\`
 
+Choosing between \`task add\` and \`task quickadd\`:
+- \`td task quickadd\` (alias \`td task qa\`) uses Todoist's natural-language parser. Inline syntax covers dates ("tomorrow at 2pm"), priority (\`p1\`–\`p4\`), project (\`#Project\`), labels (\`@label\`), sections (\`/Section\`), and assignee (\`+Person\` on shared projects). **Prefer \`quickadd\` when all task attributes can be expressed inline and you do not need to set additional structured fields** — it's one call and no name-resolution lookups are required.
+- Use \`td task add\` when you need flags that Quick Add syntax can't express (\`--deadline\`, \`--description\`, \`--parent\`, \`--duration\`, \`--uncompletable\`, \`--order\`), when the text is being composed programmatically, or when you need explicit \`id:\` / URL references for project/section/parent.
+- \`td task quickadd\` supports \`--stdin\`, \`--json\`, and \`--dry-run\` only; everything else is embedded in the text.
+
 Useful task flags:
-- \`--stdin\` reads the task description from stdin.
+- \`--stdin\` on \`task add\` reads the task description from stdin; on \`task quickadd\` it reads the full natural-language text from stdin.
 - \`--parent\`, \`--section\`, \`--project\`, \`--workspace\`, \`--assignee\`, \`--labels\`, \`--due\`, \`--deadline\`, \`--duration\`, and \`--priority\` cover most task workflows.
 - \`td task complete --forever\` stops recurrence; \`td task update --no-deadline\` clears deadlines; \`td task move --no-parent\` and \`--no-section\` detach from hierarchy.
 

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -94,7 +94,7 @@ Choosing between \`task add\` and \`task quickadd\`:
 - \`td task quickadd\` supports \`--stdin\`, \`--json\`, and \`--dry-run\` only; everything else is embedded in the text.
 
 Useful task flags:
-- \`--stdin\` on \`task add\` reads the task description from stdin; on \`task quickadd\` it reads the full natural-language text from stdin.
+- \`--stdin\` on \`task add\` reads the task description from stdin; on \`task quickadd\` (and the top-level \`td add\`) it reads the full natural-language text from stdin.
 - \`--parent\`, \`--section\`, \`--project\`, \`--workspace\`, \`--assignee\`, \`--labels\`, \`--due\`, \`--deadline\`, \`--duration\`, and \`--priority\` cover most task workflows.
 - \`td task complete --forever\` stops recurrence; \`td task update --no-deadline\` clears deadlines; \`td task move --no-parent\` and \`--no-section\` detach from hierarchy.
 


### PR DESCRIPTION
## Summary
- New `td task quickadd` subcommand (alias `td task qa`) that pipes natural-language text through Todoist's Quick Add parser via `api.quickAddTask`. Supports `--stdin`, `--json`, and `--dry-run`.
- Refactors top-level `td add` to delegate to the same shared `quickaddTask` implementation. Drops the post-create `--assignee` fallback (Quick Add parses `+Person Name` inline on shared projects) and gains `--stdin` / `--json` in return.
- Updates `SKILL_CONTENT` with examples plus agent guidance on choosing between `task add` (structured flags: `--deadline`, `--parent`, `--duration`, etc.) and `task quickadd` (inline natural-language).

`td task add` itself (the detailed add with `--assignee`, `--project`, `--due`, ...) is unchanged.

## Test plan
- [x] `npm run type-check`
- [x] `npm test` — 1343/1343 passing, including 8 new tests for `task quickadd` and updated tests for top-level `add`
- [x] `npm run check` (lint + format)
- [x] `npm run sync:skill`
- [x] Manual: `td task quickadd --help`, `td task qa "Buy milk tomorrow p1 #Shopping" --dry-run`, `echo "Buy milk tomorrow" | td task qa --stdin --dry-run`, `td add "Buy milk" --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)