### PR TITLE
fix(goal): use *TaskCount progress fields from SDK 9.1.0-next.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@doist/todoist-sdk": "9.1.0-next.1",
+        "@doist/todoist-sdk": "9.1.0-next.2",
         "@napi-rs/keyring": "1.2.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@doist/todoist-sdk": {
-      "version": "9.1.0-next.1",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-9.1.0-next.1.tgz",
-      "integrity": "sha512-sKkKF0v7p9GC5m7kMlh+JN7Jfh0z7T7l3O0sc6ehquoEW+G/sd+F8M5OMhbOWYhixdoNdxIH+vZpEAKeG7Q7jw==",
+      "version": "9.1.0-next.2",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-9.1.0-next.2.tgz",
+      "integrity": "sha512-0B6NBSFawyj9v5XZbw1YSUPRZ44rko/5QMU3AXs7JfyQf29pMbIPe6H0eOZnT8HjniST6p/J524I8mYS6388Tw==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@doist/todoist-sdk": "9.1.0-next.1",
+    "@doist/todoist-sdk": "9.1.0-next.2",
     "@napi-rs/keyring": "1.2.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",

--- a/src/__tests__/helpers/fixtures.ts
+++ b/src/__tests__/helpers/fixtures.ts
@@ -284,8 +284,8 @@ export const fixtures = {
             responsibleUid: null,
             isDeleted: false,
             progress: {
-                totalItemCount: 5,
-                completedItemCount: 2,
+                totalTaskCount: 5,
+                completedTaskCount: 2,
                 percentage: 40,
             },
             creatorUid: 'user-1',
@@ -306,8 +306,8 @@ export const fixtures = {
             responsibleUid: null,
             isDeleted: false,
             progress: {
-                totalItemCount: 3,
-                completedItemCount: 3,
+                totalTaskCount: 3,
+                completedTaskCount: 3,
                 percentage: 100,
             },
             creatorUid: 'user-1',

--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -123,7 +123,7 @@ async function viewGoal(ref: string, options: PaginatedViewOptions): Promise<voi
     if (goal.description) console.log(`Desc:     ${goal.description}`)
     if (goal.deadline) console.log(`Deadline: ${chalk.green(goal.deadline)}`)
     console.log(
-        `Progress: ${formatProgressBar(goal.progress?.percentage ?? 0)} (${goal.progress?.completedItemCount ?? 0}/${goal.progress?.totalItemCount ?? 0})`,
+        `Progress: ${formatProgressBar(goal.progress?.percentage ?? 0)} (${goal.progress?.completedTaskCount ?? 0}/${goal.progress?.totalTaskCount ?? 0})`,
     )
     if (goal.isCompleted) {
         console.log(chalk.green(isAccessible() ? 'Goal completed' : '✓ Completed'))


### PR DESCRIPTION
## Summary
- Bump `@doist/todoist-sdk` to `9.1.0-next.2` which ships Doist/todoist-sdk-typescript#567 — the SDK's `GoalProgressSchema` now normalizes the REST API's `total_item_count` / `completed_item_count` to the public `totalTaskCount` / `completedTaskCount` fields.
- Rename the two goal-progress call sites (`commands/goal.ts` view output, `__tests__/helpers/fixtures.ts` fixtures) to match the corrected SDK field names.
- Fixes Carrie's report on [Twist thread 7678534](https://twist.com/a/1585/ch/140545/t/7678534/c/101658680): on `td@1.43.0-next.1` every `td goal list/view/link` was failing with `expected: number, path: ["progress","totalTaskCount"]` because the SDK schema wanted `*TaskCount` but nothing was renaming the camelCased `*ItemCount` fields.

## Test plan
- [x] `npm run type-check`
- [x] `npm test` — 1302/1302 pass
- [x] `npm run check` (oxlint + oxfmt) clean
- [ ] Smoke against a real workspace once a `-next.2` CLI build is out:
  - `td goal list --json`
  - `td goal view <id> --json`
  - `td goal link <goal-id> --task <task-id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)