### PR TITLE
feat(apps): add td auth login --app-management and td apps list/view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@doist/todoist-sdk": "9.0.0",
+        "@doist/todoist-sdk": "9.1.1",
         "@napi-rs/keyring": "1.2.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
@@ -135,9 +135,9 @@
       }
     },
     "node_modules/@doist/todoist-sdk": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-9.0.0.tgz",
-      "integrity": "sha512-q1Zr+PzjVeDJm7So1odAspFw1ziLvg+96NYjQXk+FfjDaQ1+le34itDMK8GAANEGdA6Olj08bjtYYG//kJTSMg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-9.1.1.tgz",
+      "integrity": "sha512-q6TY7HbweKlt2Vs84f7DCHJURPYG9n+0PgWAhy45CeNhowtUMmJ+Bq66h8ei2qRuk+EKACkKCXtwH73WHpggOg==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@doist/todoist-sdk": "9.0.0",
+    "@doist/todoist-sdk": "9.1.1",
     "@napi-rs/keyring": "1.2.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -52,6 +52,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Collaboration: `td comment ...`, `td notification ...`, `td reminder ...`
 - Templates and files: `td template ...`, `td attachment view <file-url>`, `td backup ...`
 - Account and tooling: `td stats`, `td settings ...`, `td completion ...`, `td view <todoist-url>`, `td doctor`, `td update`, `td changelog`
+- Developer apps: `td apps list` (requires `td auth login --app-management`)
 
 ## References
 
@@ -214,6 +215,14 @@ td template import-id "Roadmap" --template-id product-launch --locale fr
 td backup list
 td backup download "2024-01-15_12:00" --output-file backup.zip
 ```
+
+### Developer Apps
+```bash
+td apps list
+td apps list --json
+```
+
+The `apps` command surface manages the user's registered Todoist developer apps (integrations). All `apps` subcommands require the `dev:app_console` OAuth scope — re-run `td auth login --app-management` to grant it. Without the scope, calls fail with a `MISSING_SCOPE` error pointing at the same hint. `td apps list` in plain mode shows id and display name with a dim description; `--json` / `--ndjson` dump the full app payload (id, displayName, status, userId, createdAt, serviceUrl, oauthRedirectUri, description, icons, appTokenScopes).
 
 ### Settings, Stats, And Utilities
 ```bash

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -31,10 +31,14 @@ Use this skill when the user wants to interact with their Todoist tasks.
 ```bash
 td auth login
 td auth login --read-only
+td auth login --app-management
+td auth login --app-management --read-only
 td auth token
 td auth status
 td auth logout
 ```
+
+`--app-management` adds the `dev:app_console` OAuth scope to the requested grant. Combine with `--read-only` to keep data access read-only while still gaining app-management access. Granting this scope is opt-in because it allows the token to manage your registered Todoist apps (rotate secrets, edit webhooks, etc.).
 
 Tokens are stored in the OS credential manager when available, with fallback to `~/.config/todoist-cli/config.json`. `TODOIST_API_TOKEN` takes precedence over stored credentials.
 

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -52,7 +52,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Collaboration: `td comment ...`, `td notification ...`, `td reminder ...`
 - Templates and files: `td template ...`, `td attachment view <file-url>`, `td backup ...`
 - Account and tooling: `td stats`, `td settings ...`, `td completion ...`, `td view <todoist-url>`, `td doctor`, `td update`, `td changelog`
-- Developer apps: `td apps list` (requires `td auth login --app-management`)
+- Developer apps: `td apps list/view` (requires `td auth login --app-management`)
 
 ## References
 
@@ -220,9 +220,17 @@ td backup download "2024-01-15_12:00" --output-file backup.zip
 ```bash
 td apps list
 td apps list --json
+td apps view "Todoist for VS Code"
+td apps view id:9909
+td apps view 9909
+td apps view id:9909 --json
 ```
 
-The `apps` command surface manages the user's registered Todoist developer apps (integrations). All `apps` subcommands require the `dev:app_console` OAuth scope — re-run `td auth login --app-management` to grant it. Without the scope, calls fail with a `MISSING_SCOPE` error pointing at the same hint. `td apps list` in plain mode shows id and display name with a dim description; `--json` / `--ndjson` dump the full app payload (id, displayName, status, userId, createdAt, serviceUrl, oauthRedirectUri, description, icons, appTokenScopes).
+The `apps` command surface manages the user's registered Todoist developer apps (integrations). All `apps` subcommands require the `dev:app_console` OAuth scope — re-run `td auth login --app-management` to grant it. Without the scope, calls fail with a `MISSING_SCOPE` error pointing at the same hint.
+
+`td apps list` plain output leads with the display name and follows it with `(id:N)` (self-describing in `--accessible` mode). `--json` / `--ndjson` dump the full app payload (id, displayName, status, userId, createdAt, serviceUrl, oauthRedirectUri, description, icons, appTokenScopes).
+
+`td apps view <ref>` accepts a name (fuzzy/case-insensitive), `id:N`, or a raw numeric id. Plain output shows display name as a header, then a labelled key/value block (id, status, users, created date, service URL, OAuth redirect, token scopes, icon URL) followed by the description. `--json` returns the AppWithUserCount payload (App + `userCount`).
 
 ### Settings, Stats, And Utilities
 ```bash

--- a/src/__tests__/apps.test.ts
+++ b/src/__tests__/apps.test.ts
@@ -267,6 +267,33 @@ describe('apps view', () => {
         expect(mockApi.getApps).not.toHaveBeenCalled()
     })
 
+    it('also converts a wrapped 404 to APP_NOT_FOUND for the id:N form (shared id-path handling)', async () => {
+        const program = createProgram()
+
+        mockApi.getApp.mockRejectedValue(new CliError('NOT_FOUND', 'HTTP 404: Not Found'))
+
+        await expect(
+            program.parseAsync(['node', 'td', 'apps', 'view', 'id:99999999']),
+        ).rejects.toMatchObject({ code: 'APP_NOT_FOUND' })
+        expect(mockApi.getApp).toHaveBeenCalledWith('99999999')
+        expect(mockApi.getApps).not.toHaveBeenCalled()
+    })
+
+    it('treats `td apps <ref>` as `td apps view <ref>` (implicit default subcommand)', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
+
+        await program.parseAsync(['node', 'td', 'apps', 'id:9909'])
+
+        expect(mockApi.getApp).toHaveBeenCalledWith('9909')
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('Todoist for VS Code')
+        expect(output).toContain('ID:             9909')
+        consoleSpy.mockRestore()
+    })
+
     it('does not attempt getApp() for alphanumeric refs (avoids the 400 from the apps endpoint)', async () => {
         const program = createProgram()
 
@@ -328,26 +355,42 @@ describe('apps view', () => {
 })
 
 describe('wrapApiError → MISSING_SCOPE detection', () => {
-    it('converts 403 + AUTH_INSUFFICIENT_TOKEN_SCOPE into a MISSING_SCOPE CliError with --app-management hint', () => {
-        const error = new TodoistRequestError('HTTP 403: Forbidden', 403, {
+    function scopeError() {
+        return new TodoistRequestError('HTTP 403: Forbidden', 403, {
             error: 'Insufficient Token scope',
             error_code: 403,
             error_extra: { access_type: 'access_token' },
             error_tag: 'AUTH_INSUFFICIENT_TOKEN_SCOPE',
             http_code: 403,
         })
+    }
 
-        const wrapped = wrapApiError(error)
+    it('emits the --app-management hint for app-management methods (getApps, getApp)', () => {
+        for (const method of ['getApps', 'getApp']) {
+            const wrapped = wrapApiError(scopeError(), method) as CliError
+            expect(wrapped.code).toBe('MISSING_SCOPE')
+            expect(wrapped.hints?.[0]).toContain('--app-management')
+            expect(wrapped.hints?.[0]).toContain('dev:app_console')
+        }
+    })
 
-        expect(wrapped).toBeInstanceOf(CliError)
-        expect((wrapped as CliError).code).toBe('MISSING_SCOPE')
-        expect((wrapped as CliError).hints?.some((h) => h.includes('--app-management'))).toBe(true)
+    it('emits the generic re-auth hint for non-app methods (e.g. getBackups)', () => {
+        const wrapped = wrapApiError(scopeError(), 'getBackups') as CliError
+        expect(wrapped.code).toBe('MISSING_SCOPE')
+        expect(wrapped.hints?.[0]).not.toContain('--app-management')
+        expect(wrapped.hints?.[0]).toContain('td auth login')
+    })
+
+    it('falls back to the standard hint when no method name is supplied', () => {
+        const wrapped = wrapApiError(scopeError()) as CliError
+        expect(wrapped.code).toBe('MISSING_SCOPE')
+        expect(wrapped.hints?.[0]).not.toContain('--app-management')
     })
 
     it('falls through to AUTH_ERROR for a generic 403 without the scope tag', () => {
         const error = new TodoistRequestError('HTTP 403: Forbidden', 403, { error: 'Forbidden' })
 
-        const wrapped = wrapApiError(error)
+        const wrapped = wrapApiError(error, 'getApps')
 
         expect(wrapped).toBeInstanceOf(CliError)
         expect((wrapped as CliError).code).toBe('AUTH_ERROR')
@@ -356,7 +399,7 @@ describe('wrapApiError → MISSING_SCOPE detection', () => {
     it('falls through to AUTH_ERROR for 403 with non-object responseData', () => {
         const error = new TodoistRequestError('HTTP 403: Forbidden', 403, 'Forbidden')
 
-        const wrapped = wrapApiError(error)
+        const wrapped = wrapApiError(error, 'getApps')
 
         expect((wrapped as CliError).code).toBe('AUTH_ERROR')
     })
@@ -366,7 +409,7 @@ describe('wrapApiError → MISSING_SCOPE detection', () => {
             error_tag: 'AUTH_INSUFFICIENT_TOKEN_SCOPE',
         })
 
-        const wrapped = wrapApiError(error)
+        const wrapped = wrapApiError(error, 'getApps')
 
         expect((wrapped as CliError).code).toBe('API_ERROR')
     })

--- a/src/__tests__/apps.test.ts
+++ b/src/__tests__/apps.test.ts
@@ -54,6 +54,19 @@ const APP_B = {
     appTokenScopes: ['data:read'],
 }
 
+const APP_A_DETAIL = {
+    ...APP_A,
+    description: 'Helps you manage tasks from VS Code',
+    appTokenScopes: ['data:read', 'data:read_write'],
+    iconMd: 'https://cdn.example.com/icon.png',
+    userCount: 42,
+}
+
+const APP_B_DETAIL = {
+    ...APP_B,
+    userCount: 7,
+}
+
 describe('apps list', () => {
     let mockApi: MockApi
 
@@ -122,6 +135,194 @@ describe('apps list', () => {
         expect(lines).toHaveLength(2)
         expect(JSON.parse(lines[0]).id).toBe('9909')
         expect(JSON.parse(lines[1]).id).toBe('9910')
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('apps view', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+    })
+
+    it('resolves id:N directly via getApp without listing', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
+
+        await program.parseAsync(['node', 'td', 'apps', 'view', 'id:9909'])
+
+        expect(mockApi.getApp).toHaveBeenCalledWith('9909')
+        expect(mockApi.getApps).not.toHaveBeenCalled()
+        consoleSpy.mockRestore()
+    })
+
+    it('resolves a raw numeric id via getApp directly (no listing roundtrip)', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
+
+        await program.parseAsync(['node', 'td', 'apps', 'view', '9909'])
+
+        expect(mockApi.getApp).toHaveBeenCalledWith('9909')
+        expect(mockApi.getApps).not.toHaveBeenCalled()
+        consoleSpy.mockRestore()
+    })
+
+    it('resolves a name via fuzzy match then re-fetches via getApp to enrich with userCount', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getApps.mockResolvedValue([APP_A, APP_B])
+        mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
+
+        await program.parseAsync(['node', 'td', 'apps', 'view', 'Todoist for VS Code'])
+
+        // Listing roundtrip for the name match, then a single detail fetch
+        // (no third call from inside viewApp).
+        expect(mockApi.getApps).toHaveBeenCalledTimes(1)
+        expect(mockApi.getApp).toHaveBeenCalledTimes(1)
+        expect(mockApi.getApp).toHaveBeenCalledWith('9909')
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('Todoist for VS Code')
+        expect(output).toContain('ID:             9909')
+        expect(output).toContain('Status:         public')
+        expect(output).toContain('Users:          42')
+        expect(output).toContain('Created:        2020-03-13')
+        expect(output).toContain('Service URL:    http://localhost')
+        expect(output).toContain('OAuth redirect: vscode://doist.todoist-vs-code/auth-complete')
+        expect(output).toContain('Token scopes:   data:read, data:read_write')
+        expect(output).toContain('Helps you manage tasks from VS Code')
+        consoleSpy.mockRestore()
+    })
+
+    it('does not call getApp twice on id:N (no redundant detail fetch)', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
+
+        await program.parseAsync(['node', 'td', 'apps', 'view', 'id:9909'])
+
+        expect(mockApi.getApp).toHaveBeenCalledTimes(1)
+        consoleSpy.mockRestore()
+    })
+
+    it('shows fallback strings for null fields and (none) for empty token scopes', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getApp.mockResolvedValue(APP_B_DETAIL)
+
+        await program.parseAsync(['node', 'td', 'apps', 'view', 'id:9910'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('Service URL:    (none)')
+        expect(output).toContain('OAuth redirect: (none)')
+        expect(output).toContain('Token scopes:   data:read')
+        expect(output).toContain('(no description)')
+        consoleSpy.mockRestore()
+    })
+
+    it('throws AMBIGUOUS_APP when a substring matches multiple apps', async () => {
+        const program = createProgram()
+
+        mockApi.getApps.mockResolvedValue([
+            { ...APP_A, displayName: 'Todoist for VS Code' },
+            { ...APP_B, displayName: 'Todoist for Twist' },
+        ])
+
+        await expect(
+            program.parseAsync(['node', 'td', 'apps', 'view', 'todoist for']),
+        ).rejects.toMatchObject({ code: 'AMBIGUOUS_APP' })
+        expect(mockApi.getApp).not.toHaveBeenCalled()
+    })
+
+    it('throws APP_NOT_FOUND when nothing matches', async () => {
+        const program = createProgram()
+
+        mockApi.getApps.mockResolvedValue([APP_A])
+
+        await expect(
+            program.parseAsync(['node', 'td', 'apps', 'view', 'nope']),
+        ).rejects.toMatchObject({ code: 'APP_NOT_FOUND' })
+    })
+
+    it('converts a wrapped 404 from getApp into APP_NOT_FOUND for a non-existent numeric id', async () => {
+        const program = createProgram()
+
+        // The api Proxy in core.ts wraps TodoistRequestError(404) → CliError('NOT_FOUND').
+        // resolveAppRef must catch that wrapped form too, not just the raw SDK error.
+        mockApi.getApp.mockRejectedValue(new CliError('NOT_FOUND', 'HTTP 404: Not Found'))
+
+        await expect(
+            program.parseAsync(['node', 'td', 'apps', 'view', '99999999']),
+        ).rejects.toMatchObject({ code: 'APP_NOT_FOUND' })
+        expect(mockApi.getApps).not.toHaveBeenCalled()
+    })
+
+    it('does not attempt getApp() for alphanumeric refs (avoids the 400 from the apps endpoint)', async () => {
+        const program = createProgram()
+
+        mockApi.getApps.mockResolvedValue([APP_A])
+
+        await expect(
+            program.parseAsync(['node', 'td', 'apps', 'view', 'doesnotexist-xyz123']),
+        ).rejects.toMatchObject({ code: 'APP_NOT_FOUND' })
+        expect(mockApi.getApp).not.toHaveBeenCalled()
+    })
+
+    it('treats empty-string serviceUrl/oauthRedirectUri the same as null', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getApp.mockResolvedValue({
+            ...APP_A_DETAIL,
+            serviceUrl: '',
+            oauthRedirectUri: '',
+        })
+
+        await program.parseAsync(['node', 'td', 'apps', 'view', 'id:9909'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('Service URL:    (none)')
+        expect(output).toContain('OAuth redirect: (none)')
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs full JSON of AppWithUserCount with --json', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
+
+        await program.parseAsync(['node', 'td', 'apps', 'view', 'id:9909', '--json'])
+
+        const output = consoleSpy.mock.calls[0][0] as string
+        const parsed = JSON.parse(output)
+        expect(parsed.id).toBe('9909')
+        expect(parsed.userCount).toBe(42)
+        expect(parsed.appTokenScopes).toEqual(['data:read', 'data:read_write'])
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs single-line JSON with --ndjson', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
+
+        await program.parseAsync(['node', 'td', 'apps', 'view', 'id:9909', '--ndjson'])
+
+        const output = consoleSpy.mock.calls[0][0] as string
+        expect(output.split('\n')).toHaveLength(1)
+        expect(JSON.parse(output).id).toBe('9909')
         consoleSpy.mockRestore()
     })
 })

--- a/src/__tests__/apps.test.ts
+++ b/src/__tests__/apps.test.ts
@@ -1,0 +1,172 @@
+import { TodoistRequestError } from '@doist/todoist-sdk'
+import { Command } from 'commander'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/api/core.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../lib/api/core.js')>()
+    return {
+        ...actual,
+        getApi: vi.fn(),
+    }
+})
+
+import { registerAppsCommand } from '../commands/apps/index.js'
+import { getApi, wrapApiError } from '../lib/api/core.js'
+import { CliError } from '../lib/errors.js'
+import { createMockApi, type MockApi } from './helpers/mock-api.js'
+
+const mockGetApi = vi.mocked(getApi)
+
+function createProgram() {
+    const program = new Command()
+    program.exitOverride()
+    registerAppsCommand(program)
+    return program
+}
+
+const APP_A = {
+    id: '9909',
+    status: 'public',
+    displayName: 'Todoist for VS Code',
+    userId: '6080840',
+    createdAt: new Date('2020-03-13T16:56:05Z'),
+    serviceUrl: 'http://localhost',
+    oauthRedirectUri: 'vscode://doist.todoist-vs-code/auth-complete',
+    description: 'Todoist for VS Code',
+    iconSm: null,
+    iconMd: null,
+    iconLg: null,
+    appTokenScopes: null,
+}
+
+const APP_B = {
+    id: '9910',
+    status: 'public',
+    displayName: 'Zapier Connector',
+    userId: '6080840',
+    createdAt: new Date('2021-06-01T00:00:00Z'),
+    serviceUrl: null,
+    oauthRedirectUri: null,
+    description: null,
+    iconSm: null,
+    iconMd: null,
+    iconLg: null,
+    appTokenScopes: ['data:read'],
+}
+
+describe('apps list', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+    })
+
+    it('lists apps with displayName followed by (id:N) and a description line', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getApps.mockResolvedValue([APP_A, APP_B])
+
+        await program.parseAsync(['node', 'td', 'apps', 'list'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        // Name leads, id follows in the (id:N) form so it's distinguishable in --accessible mode
+        expect(output).toContain('Todoist for VS Code (id:9909)')
+        expect(output).toContain('Zapier Connector (id:9910)')
+        // App B has no description → fallback string
+        expect(output).toContain('(no description)')
+        consoleSpy.mockRestore()
+    })
+
+    it('shows "No apps found." when empty', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getApps.mockResolvedValue([])
+
+        await program.parseAsync(['node', 'td', 'apps', 'list'])
+
+        expect(consoleSpy).toHaveBeenCalledWith('No apps found.')
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs full JSON with --json flag', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getApps.mockResolvedValue([APP_A])
+
+        await program.parseAsync(['node', 'td', 'apps', 'list', '--json'])
+
+        const output = consoleSpy.mock.calls[0][0] as string
+        const parsed = JSON.parse(output)
+        expect(Array.isArray(parsed)).toBe(true)
+        expect(parsed[0].id).toBe('9909')
+        expect(parsed[0].displayName).toBe('Todoist for VS Code')
+        expect(parsed[0].oauthRedirectUri).toBe('vscode://doist.todoist-vs-code/auth-complete')
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs NDJSON with --ndjson flag', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getApps.mockResolvedValue([APP_A, APP_B])
+
+        await program.parseAsync(['node', 'td', 'apps', 'list', '--ndjson'])
+
+        const output = consoleSpy.mock.calls[0][0] as string
+        const lines = output.split('\n')
+        expect(lines).toHaveLength(2)
+        expect(JSON.parse(lines[0]).id).toBe('9909')
+        expect(JSON.parse(lines[1]).id).toBe('9910')
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('wrapApiError → MISSING_SCOPE detection', () => {
+    it('converts 403 + AUTH_INSUFFICIENT_TOKEN_SCOPE into a MISSING_SCOPE CliError with --app-management hint', () => {
+        const error = new TodoistRequestError('HTTP 403: Forbidden', 403, {
+            error: 'Insufficient Token scope',
+            error_code: 403,
+            error_extra: { access_type: 'access_token' },
+            error_tag: 'AUTH_INSUFFICIENT_TOKEN_SCOPE',
+            http_code: 403,
+        })
+
+        const wrapped = wrapApiError(error)
+
+        expect(wrapped).toBeInstanceOf(CliError)
+        expect((wrapped as CliError).code).toBe('MISSING_SCOPE')
+        expect((wrapped as CliError).hints?.some((h) => h.includes('--app-management'))).toBe(true)
+    })
+
+    it('falls through to AUTH_ERROR for a generic 403 without the scope tag', () => {
+        const error = new TodoistRequestError('HTTP 403: Forbidden', 403, { error: 'Forbidden' })
+
+        const wrapped = wrapApiError(error)
+
+        expect(wrapped).toBeInstanceOf(CliError)
+        expect((wrapped as CliError).code).toBe('AUTH_ERROR')
+    })
+
+    it('falls through to AUTH_ERROR for 403 with non-object responseData', () => {
+        const error = new TodoistRequestError('HTTP 403: Forbidden', 403, 'Forbidden')
+
+        const wrapped = wrapApiError(error)
+
+        expect((wrapped as CliError).code).toBe('AUTH_ERROR')
+    })
+
+    it('does not match on non-403 statuses even with the scope tag in body', () => {
+        const error = new TodoistRequestError('HTTP 500: Internal Server Error', 500, {
+            error_tag: 'AUTH_INSUFFICIENT_TOKEN_SCOPE',
+        })
+
+        const wrapped = wrapApiError(error)
+
+        expect((wrapped as CliError).code).toBe('API_ERROR')
+    })
+})

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -286,6 +286,68 @@ describe('auth command', () => {
             })
         })
 
+        it('appends dev:app_console scope when --app-management is set', async () => {
+            const program = createProgram()
+            const authCode = 'oauth_auth_code_app'
+            const accessToken = 'oauth_access_token_app'
+
+            mockStartCallbackServer.mockResolvedValue({
+                promise: Promise.resolve(authCode),
+                port: 8765,
+                cleanup: vi.fn(),
+            })
+            mockExchangeCodeForToken.mockResolvedValue(accessToken)
+            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
+            mockOpen.mockResolvedValue({} as Awaited<ReturnType<typeof open>>)
+
+            await program.parseAsync(['node', 'td', 'auth', 'login', '--app-management'])
+
+            expect(mockBuildAuthorizationUrl).toHaveBeenCalledWith(
+                'test_code_challenge',
+                'test_state',
+                { readOnly: undefined, appManagement: true, port: 8765 },
+            )
+            expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
+                authMode: 'read-write',
+                authScope:
+                    'data:read_write,data:delete,project:delete,backups:read,dev:app_console',
+            })
+        })
+
+        it('combines --app-management with --read-only', async () => {
+            const program = createProgram()
+            const authCode = 'oauth_auth_code_app_ro'
+            const accessToken = 'oauth_access_token_app_ro'
+
+            mockStartCallbackServer.mockResolvedValue({
+                promise: Promise.resolve(authCode),
+                port: 8765,
+                cleanup: vi.fn(),
+            })
+            mockExchangeCodeForToken.mockResolvedValue(accessToken)
+            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
+            mockOpen.mockResolvedValue({} as Awaited<ReturnType<typeof open>>)
+
+            await program.parseAsync([
+                'node',
+                'td',
+                'auth',
+                'login',
+                '--app-management',
+                '--read-only',
+            ])
+
+            expect(mockBuildAuthorizationUrl).toHaveBeenCalledWith(
+                'test_code_challenge',
+                'test_state',
+                { readOnly: true, appManagement: true, port: 8765 },
+            )
+            expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
+                authMode: 'read-only',
+                authScope: 'data:read,backups:read,dev:app_console',
+            })
+        })
+
         it('handles OAuth callback server error', async () => {
             const program = createProgram()
             const mockCleanup = vi.fn()

--- a/src/__tests__/helpers/mock-api.ts
+++ b/src/__tests__/helpers/mock-api.ts
@@ -180,6 +180,8 @@ export function createMockApi(overrides: Partial<TodoistApi> = {}): MockApi {
         // Backups
         getBackups: vi.fn().mockResolvedValue([]),
         downloadBackup: vi.fn(),
+        // Apps
+        getApps: vi.fn().mockResolvedValue([]),
         ...overrides,
     } as unknown as MockApi
 }

--- a/src/__tests__/helpers/mock-api.ts
+++ b/src/__tests__/helpers/mock-api.ts
@@ -182,6 +182,7 @@ export function createMockApi(overrides: Partial<TodoistApi> = {}): MockApi {
         downloadBackup: vi.fn(),
         // Apps
         getApps: vi.fn().mockResolvedValue([]),
+        getApp: vi.fn(),
         ...overrides,
     } as unknown as MockApi
 }

--- a/src/commands/apps/index.ts
+++ b/src/commands/apps/index.ts
@@ -26,14 +26,13 @@ Requires authenticating with the dev:app_console scope:
         .option('--ndjson', 'Output as newline-delimited JSON')
         .action(listApps)
 
-    const viewCmd = apps
-        .command('view [ref]')
+    apps.command('view [ref]', { isDefault: true })
         .description('View details for a single app (by name, id:N, or raw id)')
         .option('--json', 'Output as JSON')
         .option('--ndjson', 'Output as newline-delimited JSON')
         .action((ref, options) => {
             if (!ref) {
-                viewCmd.help()
+                apps.help()
                 return
             }
             return viewApp(ref, options)

--- a/src/commands/apps/index.ts
+++ b/src/commands/apps/index.ts
@@ -1,0 +1,24 @@
+import { Command } from 'commander'
+import { listApps } from './list.js'
+
+export function registerAppsCommand(program: Command): void {
+    const apps = program
+        .command('apps')
+        .description('Manage your registered Todoist developer apps')
+        .addHelpText(
+            'after',
+            `
+Examples:
+  td apps list
+  td apps list --json
+
+Requires authenticating with the dev:app_console scope:
+  td auth login --app-management`,
+        )
+
+    apps.command('list')
+        .description('List your registered Todoist apps')
+        .option('--json', 'Output as JSON')
+        .option('--ndjson', 'Output as newline-delimited JSON')
+        .action(listApps)
+}

--- a/src/commands/apps/index.ts
+++ b/src/commands/apps/index.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander'
 import { listApps } from './list.js'
+import { viewApp } from './view.js'
 
 export function registerAppsCommand(program: Command): void {
     const apps = program
@@ -11,6 +12,9 @@ export function registerAppsCommand(program: Command): void {
 Examples:
   td apps list
   td apps list --json
+  td apps view "Todoist for VS Code"
+  td apps view id:9909
+  td apps view 9909
 
 Requires authenticating with the dev:app_console scope:
   td auth login --app-management`,
@@ -21,4 +25,17 @@ Requires authenticating with the dev:app_console scope:
         .option('--json', 'Output as JSON')
         .option('--ndjson', 'Output as newline-delimited JSON')
         .action(listApps)
+
+    const viewCmd = apps
+        .command('view [ref]')
+        .description('View details for a single app (by name, id:N, or raw id)')
+        .option('--json', 'Output as JSON')
+        .option('--ndjson', 'Output as newline-delimited JSON')
+        .action((ref, options) => {
+            if (!ref) {
+                viewCmd.help()
+                return
+            }
+            return viewApp(ref, options)
+        })
 }

--- a/src/commands/apps/list.ts
+++ b/src/commands/apps/list.ts
@@ -1,0 +1,32 @@
+import chalk from 'chalk'
+import { getApi } from '../../lib/api/core.js'
+
+export interface ListAppsOptions {
+    json?: boolean
+    ndjson?: boolean
+}
+
+export async function listApps(options: ListAppsOptions = {}): Promise<void> {
+    const api = await getApi()
+    const apps = await api.getApps()
+
+    if (options.json) {
+        console.log(JSON.stringify(apps, null, 2))
+        return
+    }
+
+    if (options.ndjson) {
+        console.log(apps.map((app) => JSON.stringify(app)).join('\n'))
+        return
+    }
+
+    if (apps.length === 0) {
+        console.log('No apps found.')
+        return
+    }
+
+    for (const app of apps) {
+        console.log(`${app.displayName} ${chalk.dim(`(id:${app.id})`)}`)
+        console.log(`   ${chalk.dim(app.description ?? '(no description)')}`)
+    }
+}

--- a/src/commands/apps/view.ts
+++ b/src/commands/apps/view.ts
@@ -1,0 +1,45 @@
+import chalk from 'chalk'
+import { getApi } from '../../lib/api/core.js'
+import { resolveAppRef } from '../../lib/refs.js'
+
+export interface ViewAppOptions {
+    json?: boolean
+    ndjson?: boolean
+}
+
+export async function viewApp(ref: string, options: ViewAppOptions = {}): Promise<void> {
+    const api = await getApi()
+    const app = await resolveAppRef(api, ref)
+
+    if (options.json) {
+        console.log(JSON.stringify(app, null, 2))
+        return
+    }
+
+    if (options.ndjson) {
+        console.log(JSON.stringify(app))
+        return
+    }
+
+    const created = app.createdAt.toISOString().slice(0, 10)
+    const scopes =
+        app.appTokenScopes && app.appTokenScopes.length > 0
+            ? app.appTokenScopes.join(', ')
+            : '(none)'
+
+    console.log(chalk.bold(app.displayName))
+    console.log('')
+    console.log(`  ID:             ${app.id}`)
+    console.log(`  Status:         ${app.status}`)
+    console.log(`  Users:          ${app.userCount}`)
+    console.log(`  Created:        ${created}`)
+    console.log(`  Service URL:    ${app.serviceUrl || '(none)'}`)
+    console.log(`  OAuth redirect: ${app.oauthRedirectUri || '(none)'}`)
+    console.log(`  Token scopes:   ${scopes}`)
+    if (app.iconMd) {
+        console.log(`  Icon:           ${chalk.dim(app.iconMd)}`)
+    }
+
+    console.log('')
+    console.log(app.description ?? chalk.dim('(no description)'))
+}

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -10,6 +10,10 @@ export function registerAuthCommand(program: Command): void {
     auth.command('login')
         .description('Authenticate with Todoist via OAuth')
         .option('--read-only', 'Authenticate with read-only scope (data:read,backups:read)')
+        .option(
+            '--app-management',
+            'Also request the dev:app_console scope (manage your Todoist apps). Combine with --read-only if desired.',
+        )
         .action(loginWithOAuth)
 
     auth.command('token [token]')

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -2,16 +2,13 @@ import chalk from 'chalk'
 import open from 'open'
 import { saveApiToken } from '../../lib/auth.js'
 import { startCallbackServer } from '../../lib/oauth-server.js'
-import {
-    READ_ONLY_SCOPES,
-    READ_WRITE_SCOPES,
-    buildAuthorizationUrl,
-    exchangeCodeForToken,
-} from '../../lib/oauth.js'
+import { buildAuthorizationUrl, exchangeCodeForToken, resolveAuthScope } from '../../lib/oauth.js'
 import { generateCodeChallenge, generateCodeVerifier, generateState } from '../../lib/pkce.js'
 import { logTokenStorageResult } from './helpers.js'
 
-export async function loginWithOAuth(options: { readOnly?: boolean } = {}): Promise<void> {
+export async function loginWithOAuth(
+    options: { readOnly?: boolean; appManagement?: boolean } = {},
+): Promise<void> {
     const codeVerifier = generateCodeVerifier()
     const codeChallenge = generateCodeChallenge(codeVerifier)
     const state = generateState()
@@ -21,6 +18,7 @@ export async function loginWithOAuth(options: { readOnly?: boolean } = {}): Prom
     const { promise: callbackPromise, port, cleanup } = await startCallbackServer(state)
     const authUrl = buildAuthorizationUrl(codeChallenge, state, {
         readOnly: options.readOnly,
+        appManagement: options.appManagement,
         port,
     })
 
@@ -34,7 +32,7 @@ export async function loginWithOAuth(options: { readOnly?: boolean } = {}): Prom
         const accessToken = await exchangeCodeForToken(code, codeVerifier, port)
         const result = await saveApiToken(accessToken, {
             authMode: options.readOnly ? 'read-only' : 'read-write',
-            authScope: options.readOnly ? READ_ONLY_SCOPES : READ_WRITE_SCOPES,
+            authScope: resolveAuthScope(options),
         })
 
         console.log(chalk.green('✓'), 'Successfully logged in!')

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,10 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
         'Manage authentication',
         async () => (await import('./commands/auth/index.js')).registerAuthCommand,
     ],
+    apps: [
+        'Manage your registered Todoist developer apps',
+        async () => (await import('./commands/apps/index.js')).registerAppsCommand,
+    ],
     backup: [
         'Manage backups',
         async () => (await import('./commands/backup/index.js')).registerBackupCommand,

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -95,6 +95,7 @@ const API_SPINNER_MESSAGES: Record<string, { text: string; color?: 'blue' | 'gre
         downloadBackup: { text: 'Downloading backup...', color: 'blue' },
         // Apps
         getApps: { text: 'Loading apps...', color: 'blue' },
+        getApp: { text: 'Loading app...', color: 'blue' },
     }
 
 function createSpinnerWrappedApi(api: TodoistApi): TodoistApi {

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -93,6 +93,8 @@ const API_SPINNER_MESSAGES: Record<string, { text: string; color?: 'blue' | 'gre
         // Backups
         getBackups: { text: 'Loading backups...', color: 'blue' },
         downloadBackup: { text: 'Downloading backup...', color: 'blue' },
+        // Apps
+        getApps: { text: 'Loading apps...', color: 'blue' },
     }
 
 function createSpinnerWrappedApi(api: TodoistApi): TodoistApi {
@@ -161,10 +163,26 @@ function createSpinnerWrappedApi(api: TodoistApi): TodoistApi {
     })
 }
 
-function wrapApiError(error: unknown): Error {
+function isInsufficientScopeError(error: TodoistRequestError): boolean {
+    if (error.httpStatusCode !== 403) return false
+    const data = error.responseData
+    if (typeof data !== 'object' || data === null) return false
+    return (data as { error_tag?: unknown }).error_tag === 'AUTH_INSUFFICIENT_TOKEN_SCOPE'
+}
+
+export function wrapApiError(error: unknown): Error {
     if (error instanceof CliError) return error
     if (error instanceof TodoistRequestError) {
         const status = error.httpStatusCode
+        if (status === 403 && isInsufficientScopeError(error)) {
+            return new CliError(
+                'MISSING_SCOPE',
+                'Your token is missing the OAuth scope required for this command.',
+                [
+                    'For app management commands: re-run `td auth login --app-management` (combine with --read-only if desired).',
+                ],
+            )
+        }
         if (status === 401 || status === 403) {
             return new CliError('AUTH_ERROR', error.message, [
                 'Check your API token: td auth status',

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -157,7 +157,7 @@ function createSpinnerWrappedApi(api: TodoistApi): TodoistApi {
                             (error as Error).message,
                         )
                     }
-                    throw wrapApiError(error)
+                    throw wrapApiError(error, property)
                 }
             }
         },
@@ -171,7 +171,37 @@ function isInsufficientScopeError(error: TodoistRequestError): boolean {
     return (data as { error_tag?: unknown }).error_tag === 'AUTH_INSUFFICIENT_TOKEN_SCOPE'
 }
 
-export function wrapApiError(error: unknown): Error {
+/**
+ * Group SDK methods by the OAuth scope they require, so a 403
+ * `AUTH_INSUFFICIENT_TOKEN_SCOPE` can surface a *command-specific* remediation
+ * hint instead of a generic "re-auth" line. Add new methods here as scope-
+ * gated SDK surface lands.
+ *
+ * Methods not listed fall back to the `standard` group — that's the safe
+ * default for endpoints gated by scopes that are already part of the standard
+ * grant (e.g. `backups:read` for `td backup …`), where the right fix is just
+ * `td auth login` rather than any specific opt-in flag.
+ */
+type ScopeGroup = 'app-management' | 'standard'
+
+const METHOD_SCOPE_GROUP: Record<string, ScopeGroup> = {
+    getApps: 'app-management',
+    getApp: 'app-management',
+}
+
+const SCOPE_REMEDIATION: Record<ScopeGroup, string> = {
+    'app-management':
+        'This command requires the dev:app_console scope. Re-run `td auth login --app-management` (combine with --read-only if desired).',
+    standard:
+        'Re-authenticate with `td auth login` (or `td auth login --read-only`) to refresh your token with the standard scopes.',
+}
+
+function getScopeRemediation(methodName: string | undefined): string {
+    const group: ScopeGroup = (methodName && METHOD_SCOPE_GROUP[methodName]) || 'standard'
+    return SCOPE_REMEDIATION[group]
+}
+
+export function wrapApiError(error: unknown, methodName?: string): Error {
     if (error instanceof CliError) return error
     if (error instanceof TodoistRequestError) {
         const status = error.httpStatusCode
@@ -179,9 +209,7 @@ export function wrapApiError(error: unknown): Error {
             return new CliError(
                 'MISSING_SCOPE',
                 'Your token is missing the OAuth scope required for this command.',
-                [
-                    'For app management commands: re-run `td auth login --app-management` (combine with --read-only if desired).',
-                ],
+                [getScopeRemediation(methodName)],
             )
         }
         if (status === 401 || status === 403) {

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -6,13 +6,19 @@ const OAUTH_AUTHORIZE_URL = 'https://todoist.com/oauth/authorize'
 const OAUTH_TOKEN_URL = 'https://todoist.com/oauth/access_token'
 export const READ_WRITE_SCOPES = 'data:read_write,data:delete,project:delete,backups:read'
 export const READ_ONLY_SCOPES = 'data:read,backups:read'
+export const APP_MANAGEMENT_SCOPE = 'dev:app_console'
+
+export function resolveAuthScope(options: { readOnly?: boolean; appManagement?: boolean }): string {
+    const baseScope = options.readOnly ? READ_ONLY_SCOPES : READ_WRITE_SCOPES
+    return options.appManagement ? `${baseScope},${APP_MANAGEMENT_SCOPE}` : baseScope
+}
 
 export function buildAuthorizationUrl(
     codeChallenge: string,
     state: string,
-    options: { readOnly?: boolean; port?: number } = {},
+    options: { readOnly?: boolean; appManagement?: boolean; port?: number } = {},
 ): string {
-    const scope = options.readOnly ? READ_ONLY_SCOPES : READ_WRITE_SCOPES
+    const scope = resolveAuthScope(options)
     const redirectUri = getRedirectUri(options.port ?? DEFAULT_PORT)
     const params = new URLSearchParams({
         client_id: TODOIST_CLIENT_ID,

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -64,6 +64,8 @@ const KNOWN_SAFE_API_METHODS = new Set([
     // Backups
     'getBackups',
     'downloadBackup',
+    // Apps (developer app management — gated by dev:app_console scope)
+    'getApps',
     // Sync is handled separately via payload inspection
     'sync',
 ])

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -66,6 +66,7 @@ const KNOWN_SAFE_API_METHODS = new Set([
     'downloadBackup',
     // Apps (developer app management — gated by dev:app_console scope)
     'getApps',
+    'getApp',
     // Sync is handled separately via payload inspection
     'sync',
 ])

--- a/src/lib/refs.ts
+++ b/src/lib/refs.ts
@@ -304,13 +304,15 @@ export async function resolveAppRef(api: TodoistApi, ref: string): Promise<AppWi
         throw new CliError('INVALID_APP', 'app reference cannot be empty.')
     }
 
-    if (isIdRef(ref)) {
-        return api.getApp(extractId(ref))
-    }
+    // Both `id:N` and a pure-numeric ref are direct id-bearing forms — share
+    // a single fetch + friendly-404 path so both surface APP_NOT_FOUND on miss
+    // (rather than `id:9999` falling through to the generic NOT_FOUND).
+    const explicitId = isIdRef(ref) ? extractId(ref) : null
+    const idToFetch = explicitId ?? (/^\d+$/.test(ref) ? ref : null)
 
-    if (/^\d+$/.test(ref)) {
+    if (idToFetch !== null) {
         try {
-            return await api.getApp(ref)
+            return await api.getApp(idToFetch)
         } catch (error) {
             // The api Proxy in core.ts already wraps TodoistRequestError into a
             // generic CliError('NOT_FOUND', …). Catch both shapes so the

--- a/src/lib/refs.ts
+++ b/src/lib/refs.ts
@@ -1,4 +1,4 @@
-import { TodoistApi, TodoistRequestError } from '@doist/todoist-sdk'
+import { type AppWithUserCount, TodoistApi, TodoistRequestError } from '@doist/todoist-sdk'
 import type { Project, Task } from './api/core.js'
 import {
     fetchWorkspaceFolders,
@@ -280,6 +280,55 @@ export async function resolveProjectRef(api: TodoistApi, ref: string): Promise<P
         (p) => p.name,
         'project',
     )
+}
+
+/**
+ * App IDs are pure-numeric strings (the apps endpoint 400s on alphanumeric IDs
+ * — unlike most entities, where IDs can mix letters and digits). So we can't
+ * use the generic `resolveRef`'s `looksLikeRawId` fallback, which would
+ * happily try `getApp('abc123')` and surface a confusing 400.
+ *
+ * Always returns `AppWithUserCount` — the only caller (`apps view`) wants the
+ * detail record, and folding the guarantee in here avoids a redundant fetch
+ * on the id and raw-numeric paths (which already return the detail shape).
+ *
+ * Resolution order:
+ *  1. `id:N` prefix → `getApp(N)` directly
+ *  2. Pure-numeric ref → `getApp(ref)` directly (skip the listing roundtrip)
+ *  3. Otherwise → `getApps()` then exact / substring match on `displayName`
+ *     via the in-memory `resolveFromList`, then `getApp(matchedId)` to
+ *     enrich with `userCount`
+ */
+export async function resolveAppRef(api: TodoistApi, ref: string): Promise<AppWithUserCount> {
+    if (!ref.trim()) {
+        throw new CliError('INVALID_APP', 'app reference cannot be empty.')
+    }
+
+    if (isIdRef(ref)) {
+        return api.getApp(extractId(ref))
+    }
+
+    if (/^\d+$/.test(ref)) {
+        try {
+            return await api.getApp(ref)
+        } catch (error) {
+            // The api Proxy in core.ts already wraps TodoistRequestError into a
+            // generic CliError('NOT_FOUND', …). Catch both shapes so the
+            // user-facing error names the entity (App "…" not found) instead
+            // of the raw HTTP message.
+            if (error instanceof CliError && error.code === 'NOT_FOUND') {
+                throw new CliError('APP_NOT_FOUND', `App "${ref}" not found.`)
+            }
+            if (error instanceof TodoistRequestError && error.httpStatusCode === 404) {
+                throw new CliError('APP_NOT_FOUND', `App "${ref}" not found.`)
+            }
+            throw error
+        }
+    }
+
+    const apps = await api.getApps()
+    const matched = resolveFromList(ref, apps, (a) => a.displayName, 'app')
+    return api.getApp(matched.id)
 }
 
 export async function resolveProjectId(api: TodoistApi, ref: string): Promise<string> {

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -30,10 +30,14 @@ Use this skill when the user wants to interact with their Todoist tasks.
 \`\`\`bash
 td auth login
 td auth login --read-only
+td auth login --app-management
+td auth login --app-management --read-only
 td auth token
 td auth status
 td auth logout
 \`\`\`
+
+\`--app-management\` adds the \`dev:app_console\` OAuth scope to the requested grant. Combine with \`--read-only\` to keep data access read-only while still gaining app-management access. Granting this scope is opt-in because it allows the token to manage your registered Todoist apps (rotate secrets, edit webhooks, etc.).
 
 Tokens are stored in the OS credential manager when available, with fallback to \`~/.config/todoist-cli/config.json\`. \`TODOIST_API_TOKEN\` takes precedence over stored credentials.
 

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -51,7 +51,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Collaboration: \`td comment ...\`, \`td notification ...\`, \`td reminder ...\`
 - Templates and files: \`td template ...\`, \`td attachment view <file-url>\`, \`td backup ...\`
 - Account and tooling: \`td stats\`, \`td settings ...\`, \`td completion ...\`, \`td view <todoist-url>\`, \`td doctor\`, \`td update\`, \`td changelog\`
-- Developer apps: \`td apps list\` (requires \`td auth login --app-management\`)
+- Developer apps: \`td apps list/view\` (requires \`td auth login --app-management\`)
 
 ## References
 
@@ -219,9 +219,17 @@ td backup download "2024-01-15_12:00" --output-file backup.zip
 \`\`\`bash
 td apps list
 td apps list --json
+td apps view "Todoist for VS Code"
+td apps view id:9909
+td apps view 9909
+td apps view id:9909 --json
 \`\`\`
 
-The \`apps\` command surface manages the user's registered Todoist developer apps (integrations). All \`apps\` subcommands require the \`dev:app_console\` OAuth scope — re-run \`td auth login --app-management\` to grant it. Without the scope, calls fail with a \`MISSING_SCOPE\` error pointing at the same hint. \`td apps list\` in plain mode shows id and display name with a dim description; \`--json\` / \`--ndjson\` dump the full app payload (id, displayName, status, userId, createdAt, serviceUrl, oauthRedirectUri, description, icons, appTokenScopes).
+The \`apps\` command surface manages the user's registered Todoist developer apps (integrations). All \`apps\` subcommands require the \`dev:app_console\` OAuth scope — re-run \`td auth login --app-management\` to grant it. Without the scope, calls fail with a \`MISSING_SCOPE\` error pointing at the same hint.
+
+\`td apps list\` plain output leads with the display name and follows it with \`(id:N)\` (self-describing in \`--accessible\` mode). \`--json\` / \`--ndjson\` dump the full app payload (id, displayName, status, userId, createdAt, serviceUrl, oauthRedirectUri, description, icons, appTokenScopes).
+
+\`td apps view <ref>\` accepts a name (fuzzy/case-insensitive), \`id:N\`, or a raw numeric id. Plain output shows display name as a header, then a labelled key/value block (id, status, users, created date, service URL, OAuth redirect, token scopes, icon URL) followed by the description. \`--json\` returns the AppWithUserCount payload (App + \`userCount\`).
 
 ### Settings, Stats, And Utilities
 \`\`\`bash

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -51,6 +51,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Collaboration: \`td comment ...\`, \`td notification ...\`, \`td reminder ...\`
 - Templates and files: \`td template ...\`, \`td attachment view <file-url>\`, \`td backup ...\`
 - Account and tooling: \`td stats\`, \`td settings ...\`, \`td completion ...\`, \`td view <todoist-url>\`, \`td doctor\`, \`td update\`, \`td changelog\`
+- Developer apps: \`td apps list\` (requires \`td auth login --app-management\`)
 
 ## References
 
@@ -213,6 +214,14 @@ td template import-id "Roadmap" --template-id product-launch --locale fr
 td backup list
 td backup download "2024-01-15_12:00" --output-file backup.zip
 \`\`\`
+
+### Developer Apps
+\`\`\`bash
+td apps list
+td apps list --json
+\`\`\`
+
+The \`apps\` command surface manages the user's registered Todoist developer apps (integrations). All \`apps\` subcommands require the \`dev:app_console\` OAuth scope — re-run \`td auth login --app-management\` to grant it. Without the scope, calls fail with a \`MISSING_SCOPE\` error pointing at the same hint. \`td apps list\` in plain mode shows id and display name with a dim description; \`--json\` / \`--ndjson\` dump the full app payload (id, displayName, status, userId, createdAt, serviceUrl, oauthRedirectUri, description, icons, appTokenScopes).
 
 ### Settings, Stats, And Utilities
 \`\`\`bash


### PR DESCRIPTION
## Summary

Adds opt-in support for managing the user's registered Todoist developer apps. Three commits so each piece is reviewable in isolation:

1. **feat(auth): add --app-management flag to td auth login** (`91fefeb`)
   - Bumps `@doist/todoist-sdk` to 9.1.1.
   - New `--app-management` flag on `td auth login` requests the `dev:app_console` OAuth scope alongside the standard data scopes.
   - Composable with `--read-only` so users can keep data access read-only while still managing their apps.
   - Off by default — granting this scope lets the token rotate client secrets, edit webhooks, delete apps, etc.

2. **feat(apps): add td apps list** (`dc457c5`)
   - New top-level `apps` command surface backed by the SDK's new `AppClient`.
   - Plain output: `<displayName> (id:N)` then a dim description. The `(id:N)` form keeps rows self-describing in `--accessible` mode (no reliance on dim colour as the only id/name separator).
   - `--json` / `--ndjson` dump the full app payload — surface is small and stable enough to round-trip cleanly.
   - Wires a generic missing-scope detector into `wrapApiError`: any 403 with `error_tag: AUTH_INSUFFICIENT_TOKEN_SCOPE` is now surfaced as a friendly `MISSING_SCOPE` error pointing at `td auth login --app-management`. Endpoint-agnostic — any future scope-gated API gets the same hint for free.

3. **feat(apps): add td apps view <ref>** (`b7c2cdb`)
   - Resolves a name (fuzzy/case-insensitive substring), `id:N`, or raw numeric id, then prints the detail record with a labelled key/value block (id, status, users, created date, service URL, OAuth redirect, token scopes, icon URL).
   - `--json` returns the full `AppWithUserCount` payload.
   - Dedicated `resolveAppRef` (not the shared `resolveRef`) because app IDs are pure-numeric — the shared `looksLikeRawId` fallback would 400 on alphanumeric refs.
   - Single fetch on `id:N` / numeric paths, two fetches on the name path (list + detail enrichment for `userCount`).

## What is *not* in this PR

Write operations (`add`, `update`, `delete`, webhooks, installations, user authorizations, app secrets / tokens). The SDK exposes the full surface; this PR is deliberately the read-only foundation. Follow-ups will build on top.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm test` — 1368 tests pass (20 new for apps + scope-detection)
- [x] `npm run check` — lint and format clean
- [x] `npm run check:skill-sync` — SKILL.md in sync
- [x] **Live verified end-to-end against a real account:**
  - [x] `td auth login --app-management` → authorize URL contains `scope=…,dev:app_console`; persisted `auth_scope` reflects it; `GET /apps` returns 200
  - [x] `td auth login --app-management --read-only` → combined scope `data:read,backups:read,dev:app_console`
  - [x] `td apps list` / `--json` / `--ndjson` against an account with 16 registered apps
  - [x] `td apps view "Mark as Completed"` / `id:19550` / `19550` / `--json` / `--accessible`
  - [x] `td apps view "doesnotexist-xyz123"` → friendly `APP_NOT_FOUND` (no spurious 400)
  - [x] `td apps view 99999999` → friendly `APP_NOT_FOUND` (wrapped 404 caught)
  - [x] With an insufficient-scope token: SDK call → friendly `MISSING_SCOPE` with `td auth login --app-management` hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)