### PR TITLE
feat(auth): make backups:read opt-in and persist login flags

### DIFF
--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -33,12 +33,16 @@ td auth login
 td auth login --read-only
 td auth login --app-management
 td auth login --app-management --read-only
+td auth login --backups
+td auth login --read-only --backups
 td auth token
 td auth status
 td auth logout
 ```
 
 `--app-management` adds the `dev:app_console` OAuth scope to the requested grant. Combine with `--read-only` to keep data access read-only while still gaining app-management access. Granting this scope is opt-in because it allows the token to manage your registered Todoist apps (rotate secrets, edit webhooks, etc.).
+
+`--backups` adds the `backups:read` OAuth scope, required by `td backup list` and `td backup download`. It is opt-in for the same reason as `--app-management`: users who never pull backups should not grant access to them. Flags combine freely (e.g. `td auth login --read-only --backups`). When a backup command fails for lack of the scope, the error suggests a re-login command that preserves whichever flags were originally used.
 
 Tokens are stored in the OS credential manager when available, with fallback to `~/.config/todoist-cli/config.json`. `TODOIST_API_TOKEN` takes precedence over stored credentials.
 
@@ -53,6 +57,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Templates and files: `td template ...`, `td attachment view <file-url>`, `td backup ...`
 - Account and tooling: `td stats`, `td settings ...`, `td completion ...`, `td view <todoist-url>`, `td doctor`, `td update`, `td changelog`
 - Developer apps: `td apps list/view` (requires `td auth login --app-management`)
+- Backups: `td backup list/download` (requires `td auth login --backups`)
 
 ## References
 
@@ -215,6 +220,8 @@ td template import-id "Roadmap" --template-id product-launch --locale fr
 td backup list
 td backup download "2024-01-15_12:00" --output-file backup.zip
 ```
+
+The `backup` command surface requires the `backups:read` OAuth scope — re-run `td auth login --backups` to grant it. Without the scope, calls fail with an `AUTH_ERROR` whose hint preserves any previously used flags (e.g. a read-only user sees `td auth login --read-only --backups`).
 
 ### Developer Apps
 ```bash

--- a/src/__tests__/apps.test.ts
+++ b/src/__tests__/apps.test.ts
@@ -374,10 +374,20 @@ describe('wrapApiError → MISSING_SCOPE detection', () => {
         }
     })
 
-    it('emits the generic re-auth hint for non-app methods (e.g. getBackups)', () => {
-        const wrapped = wrapApiError(scopeError(), 'getBackups') as CliError
+    it('emits the --backups hint for backup methods (getBackups, downloadBackup)', () => {
+        for (const method of ['getBackups', 'downloadBackup']) {
+            const wrapped = wrapApiError(scopeError(), method) as CliError
+            expect(wrapped.code).toBe('MISSING_SCOPE')
+            expect(wrapped.hints?.[0]).toContain('--backups')
+            expect(wrapped.hints?.[0]).toContain('backups:read')
+        }
+    })
+
+    it('emits the generic re-auth hint for methods without a scope group (e.g. getTasks)', () => {
+        const wrapped = wrapApiError(scopeError(), 'getTasks') as CliError
         expect(wrapped.code).toBe('MISSING_SCOPE')
         expect(wrapped.hints?.[0]).not.toContain('--app-management')
+        expect(wrapped.hints?.[0]).not.toContain('--backups')
         expect(wrapped.hints?.[0]).toContain('td auth login')
     })
 

--- a/src/__tests__/auth-flags.test.ts
+++ b/src/__tests__/auth-flags.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { buildReloginCommand } from '../lib/auth-flags.js'
+import type { AuthMetadata } from '../lib/auth.js'
+
+function metadata(overrides: Partial<AuthMetadata> = {}): AuthMetadata {
+    return {
+        authMode: 'read-write',
+        source: 'config-file',
+        ...overrides,
+    }
+}
+
+describe('buildReloginCommand', () => {
+    it('returns a bare re-login command when authFlags is undefined', () => {
+        expect(buildReloginCommand(metadata(), 'backups')).toBe('td auth login --backups')
+    })
+
+    it('returns a bare re-login command when authFlags is an empty array', () => {
+        expect(buildReloginCommand(metadata({ authFlags: [] }), 'backups')).toBe(
+            'td auth login --backups',
+        )
+    })
+
+    it('preserves a prior --read-only flag', () => {
+        expect(buildReloginCommand(metadata({ authFlags: ['read-only'] }), 'backups')).toBe(
+            'td auth login --read-only --backups',
+        )
+    })
+
+    it('does not duplicate the required flag if it is already present', () => {
+        expect(buildReloginCommand(metadata({ authFlags: ['backups'] }), 'backups')).toBe(
+            'td auth login --backups',
+        )
+    })
+
+    it('emits flags in a canonical order regardless of the stored order', () => {
+        expect(
+            buildReloginCommand(
+                metadata({ authFlags: ['app-management', 'read-only'] }),
+                'backups',
+            ),
+        ).toBe('td auth login --read-only --app-management --backups')
+    })
+})

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -252,6 +252,7 @@ describe('auth command', () => {
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-write',
                 authScope: 'data:read_write,data:delete,project:delete',
+                authFlags: [],
             })
             expect(consoleSpy).toHaveBeenCalledWith('✓', 'Successfully logged in!')
             expect(consoleSpy).toHaveBeenCalledWith(
@@ -283,6 +284,7 @@ describe('auth command', () => {
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-only',
                 authScope: 'data:read',
+                authFlags: ['read-only'],
             })
         })
 
@@ -310,6 +312,7 @@ describe('auth command', () => {
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-write',
                 authScope: 'data:read_write,data:delete,project:delete,dev:app_console',
+                authFlags: ['app-management'],
             })
         })
 
@@ -344,6 +347,7 @@ describe('auth command', () => {
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-only',
                 authScope: 'data:read,dev:app_console',
+                authFlags: ['read-only', 'app-management'],
             })
         })
 
@@ -371,6 +375,7 @@ describe('auth command', () => {
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-write',
                 authScope: 'data:read_write,data:delete,project:delete,backups:read',
+                authFlags: ['backups'],
             })
         })
 
@@ -393,6 +398,7 @@ describe('auth command', () => {
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-only',
                 authScope: 'data:read,backups:read',
+                authFlags: ['read-only', 'backups'],
             })
         })
 
@@ -423,6 +429,7 @@ describe('auth command', () => {
                 authMode: 'read-write',
                 authScope:
                     'data:read_write,data:delete,project:delete,dev:app_console,backups:read',
+                authFlags: ['app-management', 'backups'],
             })
         })
 

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -251,7 +251,7 @@ describe('auth command', () => {
             )
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-write',
-                authScope: 'data:read_write,data:delete,project:delete,backups:read',
+                authScope: 'data:read_write,data:delete,project:delete',
             })
             expect(consoleSpy).toHaveBeenCalledWith('✓', 'Successfully logged in!')
             expect(consoleSpy).toHaveBeenCalledWith(
@@ -282,7 +282,7 @@ describe('auth command', () => {
             )
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-only',
-                authScope: 'data:read,backups:read',
+                authScope: 'data:read',
             })
         })
 
@@ -305,12 +305,11 @@ describe('auth command', () => {
             expect(mockBuildAuthorizationUrl).toHaveBeenCalledWith(
                 'test_code_challenge',
                 'test_state',
-                { readOnly: undefined, appManagement: true, port: 8765 },
+                { readOnly: undefined, appManagement: true, backups: undefined, port: 8765 },
             )
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-write',
-                authScope:
-                    'data:read_write,data:delete,project:delete,backups:read,dev:app_console',
+                authScope: 'data:read_write,data:delete,project:delete,dev:app_console',
             })
         })
 
@@ -340,11 +339,90 @@ describe('auth command', () => {
             expect(mockBuildAuthorizationUrl).toHaveBeenCalledWith(
                 'test_code_challenge',
                 'test_state',
-                { readOnly: true, appManagement: true, port: 8765 },
+                { readOnly: true, appManagement: true, backups: undefined, port: 8765 },
             )
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-only',
-                authScope: 'data:read,backups:read,dev:app_console',
+                authScope: 'data:read,dev:app_console',
+            })
+        })
+
+        it('appends backups:read scope when --backups is set', async () => {
+            const program = createProgram()
+            const authCode = 'oauth_auth_code_backups'
+            const accessToken = 'oauth_access_token_backups'
+
+            mockStartCallbackServer.mockResolvedValue({
+                promise: Promise.resolve(authCode),
+                port: 8765,
+                cleanup: vi.fn(),
+            })
+            mockExchangeCodeForToken.mockResolvedValue(accessToken)
+            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
+            mockOpen.mockResolvedValue({} as Awaited<ReturnType<typeof open>>)
+
+            await program.parseAsync(['node', 'td', 'auth', 'login', '--backups'])
+
+            expect(mockBuildAuthorizationUrl).toHaveBeenCalledWith(
+                'test_code_challenge',
+                'test_state',
+                { readOnly: undefined, appManagement: undefined, backups: true, port: 8765 },
+            )
+            expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
+                authMode: 'read-write',
+                authScope: 'data:read_write,data:delete,project:delete,backups:read',
+            })
+        })
+
+        it('combines --backups with --read-only', async () => {
+            const program = createProgram()
+            const authCode = 'oauth_auth_code_backups_ro'
+            const accessToken = 'oauth_access_token_backups_ro'
+
+            mockStartCallbackServer.mockResolvedValue({
+                promise: Promise.resolve(authCode),
+                port: 8765,
+                cleanup: vi.fn(),
+            })
+            mockExchangeCodeForToken.mockResolvedValue(accessToken)
+            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
+            mockOpen.mockResolvedValue({} as Awaited<ReturnType<typeof open>>)
+
+            await program.parseAsync(['node', 'td', 'auth', 'login', '--backups', '--read-only'])
+
+            expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
+                authMode: 'read-only',
+                authScope: 'data:read,backups:read',
+            })
+        })
+
+        it('combines --backups with --app-management', async () => {
+            const program = createProgram()
+            const authCode = 'oauth_auth_code_backups_app'
+            const accessToken = 'oauth_access_token_backups_app'
+
+            mockStartCallbackServer.mockResolvedValue({
+                promise: Promise.resolve(authCode),
+                port: 8765,
+                cleanup: vi.fn(),
+            })
+            mockExchangeCodeForToken.mockResolvedValue(accessToken)
+            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
+            mockOpen.mockResolvedValue({} as Awaited<ReturnType<typeof open>>)
+
+            await program.parseAsync([
+                'node',
+                'td',
+                'auth',
+                'login',
+                '--backups',
+                '--app-management',
+            ])
+
+            expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
+                authMode: 'read-write',
+                authScope:
+                    'data:read_write,data:delete,project:delete,dev:app_console,backups:read',
             })
         })
 

--- a/src/__tests__/backup.test.ts
+++ b/src/__tests__/backup.test.ts
@@ -117,6 +117,52 @@ describe('backup list', () => {
             'missing the backups:read scope',
         )
     })
+
+    it('suggests `td auth login --backups` when no prior flags were recorded', async () => {
+        const program = createProgram()
+
+        mockGetAuthMetadata.mockResolvedValue({
+            authMode: 'read-write',
+            authScope: 'data:read_write,data:delete,project:delete',
+            source: 'secure-store',
+        })
+
+        await expect(program.parseAsync(['node', 'td', 'backup', 'list'])).rejects.toMatchObject({
+            hints: ['Re-authenticate to grant backup access: td auth login --backups'],
+        })
+    })
+
+    it('preserves prior --read-only flag in the suggested re-login command', async () => {
+        const program = createProgram()
+
+        mockGetAuthMetadata.mockResolvedValue({
+            authMode: 'read-only',
+            authScope: 'data:read',
+            authFlags: ['read-only'],
+            source: 'secure-store',
+        })
+
+        await expect(program.parseAsync(['node', 'td', 'backup', 'list'])).rejects.toMatchObject({
+            hints: ['Re-authenticate to grant backup access: td auth login --read-only --backups'],
+        })
+    })
+
+    it('preserves prior --app-management flag in the suggested re-login command', async () => {
+        const program = createProgram()
+
+        mockGetAuthMetadata.mockResolvedValue({
+            authMode: 'read-write',
+            authScope: 'data:read_write,data:delete,project:delete,dev:app_console',
+            authFlags: ['app-management'],
+            source: 'secure-store',
+        })
+
+        await expect(program.parseAsync(['node', 'td', 'backup', 'list'])).rejects.toMatchObject({
+            hints: [
+                'Re-authenticate to grant backup access: td auth login --app-management --backups',
+            ],
+        })
+    })
 })
 
 describe('backup download', () => {

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -230,6 +230,7 @@ describe('doctor command', () => {
             JSON.stringify({
                 pendingSecureStoreClear: 'yes',
                 auth_mode: 'admin',
+                auth_flags: ['read-only', 'not-a-flag'],
                 update_channel: 'beta',
                 extra_setting: true,
             }),
@@ -252,6 +253,9 @@ describe('doctor command', () => {
         expect(configWarning).toContain('contains unrecognized key "extra_setting"')
         expect(configWarning).toContain('pendingSecureStoreClear must be a boolean')
         expect(configWarning).toContain('auth_mode must be one of: read-only, read-write, unknown')
+        expect(configWarning).toContain(
+            'auth_flags must be an array of: read-only, app-management, backups',
+        )
         expect(configWarning).toContain('update_channel must be one of: stable, pre-release')
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('PASS Authenticated as person@example.com via secure-store'),

--- a/src/__tests__/oauth.test.ts
+++ b/src/__tests__/oauth.test.ts
@@ -6,21 +6,47 @@ describe('buildAuthorizationUrl', () => {
         const url = buildAuthorizationUrl('challenge', 'state')
         const params = new URL(url).searchParams
 
-        expect(params.get('scope')).toBe('data:read_write,data:delete,project:delete,backups:read')
+        expect(params.get('scope')).toBe('data:read_write,data:delete,project:delete')
     })
 
     it('uses read-only scope when requested', () => {
         const url = buildAuthorizationUrl('challenge', 'state', { readOnly: true })
         const params = new URL(url).searchParams
 
-        expect(params.get('scope')).toBe('data:read,backups:read')
+        expect(params.get('scope')).toBe('data:read')
     })
 
     it('uses read-write scope when readOnly is false', () => {
         const url = buildAuthorizationUrl('challenge', 'state', { readOnly: false })
         const params = new URL(url).searchParams
 
+        expect(params.get('scope')).toBe('data:read_write,data:delete,project:delete')
+    })
+
+    it('appends backups:read when --backups is set', () => {
+        const url = buildAuthorizationUrl('challenge', 'state', { backups: true })
+        const params = new URL(url).searchParams
+
         expect(params.get('scope')).toBe('data:read_write,data:delete,project:delete,backups:read')
+    })
+
+    it('appends backups:read to read-only scope when combined', () => {
+        const url = buildAuthorizationUrl('challenge', 'state', { readOnly: true, backups: true })
+        const params = new URL(url).searchParams
+
+        expect(params.get('scope')).toBe('data:read,backups:read')
+    })
+
+    it('combines --backups with --app-management', () => {
+        const url = buildAuthorizationUrl('challenge', 'state', {
+            appManagement: true,
+            backups: true,
+        })
+        const params = new URL(url).searchParams
+
+        expect(params.get('scope')).toBe(
+            'data:read_write,data:delete,project:delete,dev:app_console,backups:read',
+        )
     })
 
     it('uses the specified port in redirect_uri', () => {

--- a/src/__tests__/permissions.test.ts
+++ b/src/__tests__/permissions.test.ts
@@ -34,7 +34,7 @@ describe('permissions', () => {
     it('allows writes in read-write mode', async () => {
         mockGetAuthMetadata.mockResolvedValue({
             authMode: 'read-write',
-            authScope: 'data:read_write,data:delete,project:delete,backups:read',
+            authScope: 'data:read_write,data:delete,project:delete',
             source: 'secure-store',
         })
 

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -9,10 +9,14 @@ export function registerAuthCommand(program: Command): void {
 
     auth.command('login')
         .description('Authenticate with Todoist via OAuth')
-        .option('--read-only', 'Authenticate with read-only scope (data:read,backups:read)')
+        .option('--read-only', 'Authenticate with read-only scope (data:read)')
         .option(
             '--app-management',
             'Also request the dev:app_console scope (manage your Todoist apps). Combine with --read-only if desired.',
+        )
+        .option(
+            '--backups',
+            'Also request the backups:read scope (list/download Todoist backups). Combine with --read-only if desired.',
         )
         .action(loginWithOAuth)
 

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import open from 'open'
-import { saveApiToken } from '../../lib/auth.js'
+import { saveApiToken, type AuthFlag } from '../../lib/auth.js'
 import { startCallbackServer } from '../../lib/oauth-server.js'
 import { buildAuthorizationUrl, exchangeCodeForToken, resolveAuthScope } from '../../lib/oauth.js'
 import { generateCodeChallenge, generateCodeVerifier, generateState } from '../../lib/pkce.js'
@@ -31,9 +31,14 @@ export async function loginWithOAuth(
         console.log(chalk.dim('Exchanging code for token...'))
 
         const accessToken = await exchangeCodeForToken(code, codeVerifier, port)
+        const authFlags: AuthFlag[] = []
+        if (options.readOnly) authFlags.push('read-only')
+        if (options.appManagement) authFlags.push('app-management')
+        if (options.backups) authFlags.push('backups')
         const result = await saveApiToken(accessToken, {
             authMode: options.readOnly ? 'read-only' : 'read-write',
             authScope: resolveAuthScope(options),
+            authFlags,
         })
 
         console.log(chalk.green('✓'), 'Successfully logged in!')

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -7,7 +7,7 @@ import { generateCodeChallenge, generateCodeVerifier, generateState } from '../.
 import { logTokenStorageResult } from './helpers.js'
 
 export async function loginWithOAuth(
-    options: { readOnly?: boolean; appManagement?: boolean } = {},
+    options: { readOnly?: boolean; appManagement?: boolean; backups?: boolean } = {},
 ): Promise<void> {
     const codeVerifier = generateCodeVerifier()
     const codeChallenge = generateCodeChallenge(codeVerifier)
@@ -19,6 +19,7 @@ export async function loginWithOAuth(
     const authUrl = buildAuthorizationUrl(codeChallenge, state, {
         readOnly: options.readOnly,
         appManagement: options.appManagement,
+        backups: options.backups,
         port,
     })
 

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -27,6 +27,7 @@ export async function showStatus(options: { json?: boolean }): Promise<void> {
                     fullName: user.fullName,
                     authMode: metadata.authMode,
                     authScope: metadata.authScope,
+                    authFlags: metadata.authFlags,
                 },
                 null,
                 2,

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -4,7 +4,7 @@ import { type AuthMode, getAuthMetadata } from '../../lib/auth.js'
 
 function formatAuthMode(authMode: AuthMode, authScope?: string): string {
     if (authMode === 'read-only') {
-        return `read-only (OAuth scope ${authScope ?? 'data:read,backups:read'})`
+        return `read-only (OAuth scope ${authScope ?? 'data:read'})`
     }
     if (authMode === 'read-write') {
         return 'read-write'

--- a/src/commands/backup/helpers.ts
+++ b/src/commands/backup/helpers.ts
@@ -1,12 +1,14 @@
 import type { Backup, TodoistApi } from '@doist/todoist-sdk'
+import { buildReloginCommand } from '../../lib/auth-flags.js'
 import { getAuthMetadata } from '../../lib/auth.js'
 import { CliError } from '../../lib/errors.js'
 
 export async function fetchBackups(api: TodoistApi): Promise<Backup[]> {
     const metadata = await getAuthMetadata()
     if (metadata.authScope && !metadata.authScope.includes('backups:read')) {
+        const command = buildReloginCommand(metadata, 'backups')
         throw new CliError('AUTH_ERROR', 'Your current token is missing the backups:read scope', [
-            'Re-authenticate to grant backup access: td auth login --backups',
+            `Re-authenticate to grant backup access: ${command}`,
         ])
     }
 

--- a/src/commands/backup/helpers.ts
+++ b/src/commands/backup/helpers.ts
@@ -6,7 +6,7 @@ export async function fetchBackups(api: TodoistApi): Promise<Backup[]> {
     const metadata = await getAuthMetadata()
     if (metadata.authScope && !metadata.authScope.includes('backups:read')) {
         throw new CliError('AUTH_ERROR', 'Your current token is missing the backups:read scope', [
-            'Re-authenticate to grant backup access: td auth login',
+            'Re-authenticate to grant backup access: td auth login --backups',
         ])
     }
 

--- a/src/commands/backup/index.ts
+++ b/src/commands/backup/index.ts
@@ -12,7 +12,10 @@ export function registerBackupCommand(program: Command): void {
 Examples:
   td backup list
   td backup list --json
-  td backup download "2024-01-15_12:00" --output-file backup.zip`,
+  td backup download "2024-01-15_12:00" --output-file backup.zip
+
+Requires authenticating with the backups:read scope:
+  td auth login --backups`,
         )
 
     backup

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -177,21 +177,26 @@ function isInsufficientScopeError(error: TodoistRequestError): boolean {
  * hint instead of a generic "re-auth" line. Add new methods here as scope-
  * gated SDK surface lands.
  *
- * Methods not listed fall back to the `standard` group — that's the safe
- * default for endpoints gated by scopes that are already part of the standard
- * grant (e.g. `backups:read` for `td backup …`), where the right fix is just
- * `td auth login` rather than any specific opt-in flag.
+ * Methods not listed fall back to the `standard` group — appropriate for
+ * endpoints gated by scopes that are part of the standard grant.
+ * Opt-in scopes (e.g. `dev:app_console` via `--app-management`,
+ * `backups:read` via `--backups`) get their own group with flag-specific
+ * remediation strings.
  */
-type ScopeGroup = 'app-management' | 'standard'
+type ScopeGroup = 'app-management' | 'backups' | 'standard'
 
 const METHOD_SCOPE_GROUP: Record<string, ScopeGroup> = {
     getApps: 'app-management',
     getApp: 'app-management',
+    getBackups: 'backups',
+    downloadBackup: 'backups',
 }
 
 const SCOPE_REMEDIATION: Record<ScopeGroup, string> = {
     'app-management':
         'This command requires the dev:app_console scope. Re-run `td auth login --app-management` (combine with --read-only if desired).',
+    backups:
+        'This command requires the backups:read scope. Re-run `td auth login --backups` (combine with --read-only if desired).',
     standard:
         'Re-authenticate with `td auth login` (or `td auth login --read-only`) to refresh your token with the standard scopes.',
 }

--- a/src/lib/auth-flags.ts
+++ b/src/lib/auth-flags.ts
@@ -1,12 +1,14 @@
-import type { AuthFlag, AuthMetadata } from './auth.js'
-
-// Canonical order so the suggested command reads the same way every time,
-// regardless of the order flags were originally passed.
-const FLAG_ORDER: readonly AuthFlag[] = ['read-only', 'app-management', 'backups']
+import type { AuthMetadata } from './auth.js'
+import { AUTH_FLAG_ORDER, type AuthFlag } from './config.js'
 
 /**
  * Build a `td auth login …` command string that preserves the user's prior
  * flag choices and adds whichever extra scope flag is now required.
+ *
+ * Flags render in the canonical order defined by `AUTH_FLAG_ORDER` — that
+ * same list is the type/validator source of truth in `config.ts`, so a
+ * newly added flag automatically flows into the ordering here without a
+ * separate update.
  *
  * When `metadata.authFlags` is missing (older configs, env-var tokens,
  * manual `td auth token` logins) we treat it as "no flags" — the base login.
@@ -14,6 +16,6 @@ const FLAG_ORDER: readonly AuthFlag[] = ['read-only', 'app-management', 'backups
 export function buildReloginCommand(metadata: AuthMetadata, requiredFlag: AuthFlag): string {
     const existing = metadata.authFlags ?? []
     const merged = new Set<AuthFlag>([...existing, requiredFlag])
-    const orderedFlags = FLAG_ORDER.filter((flag) => merged.has(flag))
+    const orderedFlags = AUTH_FLAG_ORDER.filter((flag) => merged.has(flag))
     return `td auth login ${orderedFlags.map((flag) => `--${flag}`).join(' ')}`
 }

--- a/src/lib/auth-flags.ts
+++ b/src/lib/auth-flags.ts
@@ -1,0 +1,19 @@
+import type { AuthFlag, AuthMetadata } from './auth.js'
+
+// Canonical order so the suggested command reads the same way every time,
+// regardless of the order flags were originally passed.
+const FLAG_ORDER: readonly AuthFlag[] = ['read-only', 'app-management', 'backups']
+
+/**
+ * Build a `td auth login …` command string that preserves the user's prior
+ * flag choices and adds whichever extra scope flag is now required.
+ *
+ * When `metadata.authFlags` is missing (older configs, env-var tokens,
+ * manual `td auth token` logins) we treat it as "no flags" — the base login.
+ */
+export function buildReloginCommand(metadata: AuthMetadata, requiredFlag: AuthFlag): string {
+    const existing = metadata.authFlags ?? []
+    const merged = new Set<AuthFlag>([...existing, requiredFlag])
+    const orderedFlags = FLAG_ORDER.filter((flag) => merged.has(flag))
+    return `td auth login ${orderedFlags.map((flag) => `--${flag}`).join(' ')}`
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,7 @@ import {
     SECURE_STORE_DESCRIPTION,
 } from './secure-store.js'
 export {
+    AUTH_FLAG_ORDER,
     CONFIG_PATH,
     readConfig,
     writeConfig,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,12 +7,20 @@ export {
     CONFIG_PATH,
     readConfig,
     writeConfig,
+    type AuthFlag,
     type AuthMode,
     type Config,
     type UpdateChannel,
 } from './config.js'
 
-import { CONFIG_PATH, readConfig, writeConfig, type AuthMode, type Config } from './config.js'
+import {
+    CONFIG_PATH,
+    readConfig,
+    writeConfig,
+    type AuthFlag,
+    type AuthMode,
+    type Config,
+} from './config.js'
 import { CliError } from './errors.js'
 
 export const TOKEN_ENV_VAR = 'TODOIST_API_TOKEN'
@@ -20,12 +28,14 @@ export const TOKEN_ENV_VAR = 'TODOIST_API_TOKEN'
 export interface AuthMetadata {
     authMode: AuthMode
     authScope?: string
+    authFlags?: AuthFlag[]
     source: 'env' | 'secure-store' | 'config-file'
 }
 
 export interface SaveApiTokenOptions {
     authMode?: AuthMode
     authScope?: string
+    authFlags?: AuthFlag[]
 }
 
 export interface AuthProbeResult {
@@ -133,6 +143,7 @@ export async function probeApiToken(): Promise<AuthProbeResult> {
             metadata: {
                 authMode: config.auth_mode ?? 'unknown',
                 authScope: config.auth_scope,
+                authFlags: config.auth_flags,
                 source: 'config-file',
             },
         }
@@ -151,6 +162,7 @@ export async function probeApiToken(): Promise<AuthProbeResult> {
                 metadata: {
                     authMode: config.auth_mode ?? 'unknown',
                     authScope: config.auth_scope,
+                    authFlags: config.auth_flags,
                     source: 'secure-store',
                 },
             }
@@ -194,6 +206,7 @@ export async function saveApiToken(
     delete config.pendingSecureStoreClear
     config.auth_mode = options.authMode
     config.auth_scope = options.authScope
+    config.auth_flags = options.authFlags
     await writeConfig(config)
     return {
         storage: 'config-file',
@@ -233,6 +246,7 @@ export async function getAuthMetadata(): Promise<AuthMetadata> {
         return {
             authMode: config.auth_mode,
             authScope: config.auth_scope,
+            authFlags: config.auth_flags,
             source: getConfigToken(config) ? 'config-file' : 'secure-store',
         }
     }
@@ -275,11 +289,12 @@ function withAuthMetadata(config: Config, options: SaveApiTokenOptions): Config 
         ...config,
         auth_mode: options.authMode,
         auth_scope: options.authScope,
+        auth_flags: options.authFlags,
     }
 }
 
 function withoutAuthMetadata(config: Config): Config {
-    const { auth_mode: _mode, auth_scope: _scope, ...rest } = config
+    const { auth_mode: _mode, auth_scope: _scope, auth_flags: _flags, ...rest } = config
     return rest
 }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,7 +6,16 @@ export const CONFIG_PATH = join(homedir(), '.config', 'todoist-cli', 'config.jso
 
 export type AuthMode = 'read-only' | 'read-write' | 'unknown'
 export type UpdateChannel = 'stable' | 'pre-release'
-export type AuthFlag = 'read-only' | 'app-management' | 'backups'
+
+/**
+ * Canonical ordered list of login flags. Acts as the single source of truth —
+ * `AuthFlag`, `AUTH_FLAGS` (validation), and the display order of re-login
+ * suggestions in `buildReloginCommand` all derive from this one list. Adding
+ * a new flag only requires appending it here and wiring it into the login
+ * command; everything downstream stays consistent.
+ */
+export const AUTH_FLAG_ORDER = ['read-only', 'app-management', 'backups'] as const
+export type AuthFlag = (typeof AUTH_FLAG_ORDER)[number]
 
 export interface Config extends Record<string, unknown> {
     api_token?: string
@@ -27,7 +36,7 @@ const KNOWN_CONFIG_KEYS: ReadonlySet<string> = new Set([
 ])
 
 const AUTH_MODES: ReadonlySet<AuthMode> = new Set(['read-only', 'read-write', 'unknown'])
-export const AUTH_FLAGS: ReadonlySet<AuthFlag> = new Set(['read-only', 'app-management', 'backups'])
+export const AUTH_FLAGS: ReadonlySet<AuthFlag> = new Set(AUTH_FLAG_ORDER)
 const UPDATE_CHANNELS: ReadonlySet<UpdateChannel> = new Set(['stable', 'pre-release'])
 
 export async function readConfig(): Promise<Config> {
@@ -103,7 +112,7 @@ export function validateConfigForDoctor(config: Record<string, unknown>): string
                 (flag) => typeof flag === 'string' && AUTH_FLAGS.has(flag as AuthFlag),
             )
         ) {
-            issues.push('auth_flags must be an array of: read-only, app-management, backups')
+            issues.push(`auth_flags must be an array of: ${AUTH_FLAG_ORDER.join(', ')}`)
         }
     }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,12 +6,14 @@ export const CONFIG_PATH = join(homedir(), '.config', 'todoist-cli', 'config.jso
 
 export type AuthMode = 'read-only' | 'read-write' | 'unknown'
 export type UpdateChannel = 'stable' | 'pre-release'
+export type AuthFlag = 'read-only' | 'app-management' | 'backups'
 
 export interface Config extends Record<string, unknown> {
     api_token?: string
     pendingSecureStoreClear?: boolean
     auth_mode?: AuthMode
     auth_scope?: string
+    auth_flags?: AuthFlag[]
     update_channel?: UpdateChannel
 }
 
@@ -20,10 +22,12 @@ const KNOWN_CONFIG_KEYS: ReadonlySet<string> = new Set([
     'pendingSecureStoreClear',
     'auth_mode',
     'auth_scope',
+    'auth_flags',
     'update_channel',
 ])
 
 const AUTH_MODES: ReadonlySet<AuthMode> = new Set(['read-only', 'read-write', 'unknown'])
+export const AUTH_FLAGS: ReadonlySet<AuthFlag> = new Set(['read-only', 'app-management', 'backups'])
 const UPDATE_CHANNELS: ReadonlySet<UpdateChannel> = new Set(['stable', 'pre-release'])
 
 export async function readConfig(): Promise<Config> {
@@ -90,6 +94,17 @@ export function validateConfigForDoctor(config: Record<string, unknown>): string
 
     if (config.auth_scope !== undefined && typeof config.auth_scope !== 'string') {
         issues.push('auth_scope must be a string')
+    }
+
+    if (config.auth_flags !== undefined) {
+        if (
+            !Array.isArray(config.auth_flags) ||
+            !config.auth_flags.every(
+                (flag) => typeof flag === 'string' && AUTH_FLAGS.has(flag as AuthFlag),
+            )
+        ) {
+            issues.push('auth_flags must be an array of: read-only, app-management, backups')
+        }
     }
 
     if (

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -4,19 +4,31 @@ import { DEFAULT_PORT, getRedirectUri } from './oauth-server.js'
 const TODOIST_CLIENT_ID = '04863cc1e3584830a578622f50224d5b'
 const OAUTH_AUTHORIZE_URL = 'https://todoist.com/oauth/authorize'
 const OAUTH_TOKEN_URL = 'https://todoist.com/oauth/access_token'
-export const READ_WRITE_SCOPES = 'data:read_write,data:delete,project:delete,backups:read'
-export const READ_ONLY_SCOPES = 'data:read,backups:read'
+export const READ_WRITE_SCOPES = 'data:read_write,data:delete,project:delete'
+export const READ_ONLY_SCOPES = 'data:read'
 export const APP_MANAGEMENT_SCOPE = 'dev:app_console'
+export const BACKUPS_SCOPE = 'backups:read'
 
-export function resolveAuthScope(options: { readOnly?: boolean; appManagement?: boolean }): string {
-    const baseScope = options.readOnly ? READ_ONLY_SCOPES : READ_WRITE_SCOPES
-    return options.appManagement ? `${baseScope},${APP_MANAGEMENT_SCOPE}` : baseScope
+export function resolveAuthScope(options: {
+    readOnly?: boolean
+    appManagement?: boolean
+    backups?: boolean
+}): string {
+    const parts = [options.readOnly ? READ_ONLY_SCOPES : READ_WRITE_SCOPES]
+    if (options.appManagement) parts.push(APP_MANAGEMENT_SCOPE)
+    if (options.backups) parts.push(BACKUPS_SCOPE)
+    return parts.join(',')
 }
 
 export function buildAuthorizationUrl(
     codeChallenge: string,
     state: string,
-    options: { readOnly?: boolean; appManagement?: boolean; port?: number } = {},
+    options: {
+        readOnly?: boolean
+        appManagement?: boolean
+        backups?: boolean
+        port?: number
+    } = {},
 ): string {
     const scope = resolveAuthScope(options)
     const redirectUri = getRedirectUri(options.port ?? DEFAULT_PORT)

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -32,12 +32,16 @@ td auth login
 td auth login --read-only
 td auth login --app-management
 td auth login --app-management --read-only
+td auth login --backups
+td auth login --read-only --backups
 td auth token
 td auth status
 td auth logout
 \`\`\`
 
 \`--app-management\` adds the \`dev:app_console\` OAuth scope to the requested grant. Combine with \`--read-only\` to keep data access read-only while still gaining app-management access. Granting this scope is opt-in because it allows the token to manage your registered Todoist apps (rotate secrets, edit webhooks, etc.).
+
+\`--backups\` adds the \`backups:read\` OAuth scope, required by \`td backup list\` and \`td backup download\`. It is opt-in for the same reason as \`--app-management\`: users who never pull backups should not grant access to them. Flags combine freely (e.g. \`td auth login --read-only --backups\`). When a backup command fails for lack of the scope, the error suggests a re-login command that preserves whichever flags were originally used.
 
 Tokens are stored in the OS credential manager when available, with fallback to \`~/.config/todoist-cli/config.json\`. \`TODOIST_API_TOKEN\` takes precedence over stored credentials.
 
@@ -52,6 +56,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Templates and files: \`td template ...\`, \`td attachment view <file-url>\`, \`td backup ...\`
 - Account and tooling: \`td stats\`, \`td settings ...\`, \`td completion ...\`, \`td view <todoist-url>\`, \`td doctor\`, \`td update\`, \`td changelog\`
 - Developer apps: \`td apps list/view\` (requires \`td auth login --app-management\`)
+- Backups: \`td backup list/download\` (requires \`td auth login --backups\`)
 
 ## References
 
@@ -214,6 +219,8 @@ td template import-id "Roadmap" --template-id product-launch --locale fr
 td backup list
 td backup download "2024-01-15_12:00" --output-file backup.zip
 \`\`\`
+
+The \`backup\` command surface requires the \`backups:read\` OAuth scope — re-run \`td auth login --backups\` to grant it. Without the scope, calls fail with an \`AUTH_ERROR\` whose hint preserves any previously used flags (e.g. a read-only user sees \`td auth login --read-only --backups\`).
 
 ### Developer Apps
 \`\`\`bash


### PR DESCRIPTION
## Summary

- Splits `backups:read` out of the default OAuth scopes into a new opt-in `--backups` flag, mirroring the existing `--app-management` / `dev:app_console` pattern. Users who never run `td backup …` no longer grant backup access by default.
- Persists login-time flags (`read-only`, `app-management`, `backups`) in the config as `auth_flags`. Scope-gap errors now suggest a re-login command that preserves prior flag choices — e.g. a read-only user who tries `td backup list` sees `td auth login --read-only --backups` rather than a generic `td auth login --backups` that would silently promote them to read-write.
- New `buildReloginCommand` helper with deterministic flag ordering. Missing `auth_flags` (older installs, env-var tokens, manual `td auth token`) is treated as "base login" — no flags.

## Test plan

- [x] `npm run check` — clean
- [x] `npm test` — 1387/1387 passing (+8 new tests across `auth-flags.test.ts`, `backup.test.ts`, `auth.test.ts`, `doctor.test.ts`)
- [ ] Manual smoke: `td auth login --read-only --backups`, then `td auth status --json` shows `authFlags: ["read-only", "backups"]`
- [ ] Manual smoke: on a token that lacks `backups:read`, `td backup list` errors with the correct flag-preserving suggestion
- [ ] Manual smoke: existing tokens (pre-upgrade) without `auth_flags` still work and get a bare `td auth login --backups` suggestion

## Notes

- The reactive 403 path in `wrapApiError` (`src/lib/api/core.ts`) still uses static remediation strings. Upgrading it to use stored `auth_flags` was deferred so `wrapApiError` can stay synchronous; the static strings still name the correct `--backups` / `--app-management` flag for their scope group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)