### PR TITLE
fix(goal): include description in JSON output

### DIFF
--- a/src/__tests__/goal.test.ts
+++ b/src/__tests__/goal.test.ts
@@ -96,6 +96,28 @@ describe('goal view', () => {
         consoleSpy.mockRestore()
     })
 
+    it('includes description in JSON output', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getGoal.mockResolvedValue(fixtures.goals.shipV2)
+        mockApi.getTasks.mockResolvedValue({ results: [], nextCursor: null })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'goal',
+            'view',
+            `id:${fixtures.goals.shipV2.id}`,
+            '--json',
+        ])
+
+        const output = consoleSpy.mock.calls[0][0]
+        const parsed = JSON.parse(output)
+        expect(parsed.goal.description).toBe('Launch the new version')
+        consoleSpy.mockRestore()
+    })
+
     it('is the default subcommand', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -218,6 +218,7 @@ const LOCATION_REMINDER_ESSENTIAL_FIELDS = [
 const GOAL_ESSENTIAL_FIELDS = [
     'id',
     'name',
+    'description',
     'ownerType',
     'ownerId',
     'deadline',


### PR DESCRIPTION
## Overview

- Adds `description` to `GOAL_ESSENTIAL_FIELDS` so `td goal view --json` and `td goal list --json` include the goal description.
- The plain-text view already prints `Desc: ...`, but JSON omitted the field entirely — meaning programmatic consumers had no way to read a goal's description short of parsing the text output. Consistent with how tasks and comments already surface `description`/`content` in JSON.
- Added a regression test on `goal view --json` that asserts `parsed.goal.description` is present.

> [!NOTE]
> Based off `next`, not `main` — the `td goal` command lives on the `next` branch until the SDK bump lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)