### PR TITLE
feat(auth): replace per-scope flags with --additional-scopes

### DIFF
--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -31,18 +31,22 @@ Use this skill when the user wants to interact with their Todoist tasks.
 ```bash
 td auth login
 td auth login --read-only
-td auth login --app-management
-td auth login --app-management --read-only
-td auth login --backups
-td auth login --read-only --backups
+td auth login --additional-scopes=app-management
+td auth login --read-only --additional-scopes=app-management
+td auth login --additional-scopes=backups
+td auth login --read-only --additional-scopes=backups
+td auth login --additional-scopes=app-management,backups
 td auth token
 td auth status
 td auth logout
 ```
 
-`--app-management` adds the `dev:app_console` OAuth scope to the requested grant. Combine with `--read-only` to keep data access read-only while still gaining app-management access. Granting this scope is opt-in because it allows the token to manage your registered Todoist apps (rotate secrets, edit webhooks, etc.).
+Opt-in OAuth scopes are requested via `--additional-scopes=<list>` (comma-separated). Run `td auth login --help` for the full list. Currently supported:
 
-`--backups` adds the `backups:read` OAuth scope, required by `td backup list` and `td backup download`. It is opt-in for the same reason as `--app-management`: users who never pull backups should not grant access to them. Flags combine freely (e.g. `td auth login --read-only --backups`). When a backup command fails for lack of the scope, the error suggests a re-login command that preserves whichever flags were originally used.
+- `app-management` — adds the `dev:app_console` scope (manage your registered Todoist apps — rotate secrets, edit webhooks, etc.). Required by `td apps list` and `td apps view`.
+- `backups` — adds the `backups:read` scope (list and download Todoist backups). Required by `td backup list` and `td backup download`.
+
+Combine freely with `--read-only` to keep data access read-only while still granting an opt-in scope (e.g. `td auth login --read-only --additional-scopes=backups`). When a command fails for lack of a scope, the error suggests a re-login command that preserves whichever flags were originally used.
 
 Tokens are stored in the OS credential manager when available, with fallback to `~/.config/todoist-cli/config.json`. `TODOIST_API_TOKEN` takes precedence over stored credentials.
 
@@ -56,8 +60,8 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Collaboration: `td comment ...`, `td notification ...`, `td reminder ...`
 - Templates and files: `td template ...`, `td attachment view <file-url>`, `td backup ...`
 - Account and tooling: `td stats`, `td settings ...`, `td completion ...`, `td view <todoist-url>`, `td doctor`, `td update`, `td changelog`
-- Developer apps: `td apps list/view` (requires `td auth login --app-management`)
-- Backups: `td backup list/download` (requires `td auth login --backups`)
+- Developer apps: `td apps list/view` (requires `td auth login --additional-scopes=app-management`)
+- Backups: `td backup list/download` (requires `td auth login --additional-scopes=backups`)
 
 ## References
 
@@ -221,7 +225,7 @@ td backup list
 td backup download "2024-01-15_12:00" --output-file backup.zip
 ```
 
-The `backup` command surface requires the `backups:read` OAuth scope — re-run `td auth login --backups` to grant it. Without the scope, calls fail with an `AUTH_ERROR` whose hint preserves any previously used flags (e.g. a read-only user sees `td auth login --read-only --backups`).
+The `backup` command surface requires the `backups:read` OAuth scope — re-run `td auth login --additional-scopes=backups` to grant it. Without the scope, calls fail with an `AUTH_ERROR` whose hint preserves any previously used flags (e.g. a read-only user sees `td auth login --read-only --additional-scopes=backups`).
 
 ### Developer Apps
 ```bash
@@ -233,7 +237,7 @@ td apps view 9909
 td apps view id:9909 --json
 ```
 
-The `apps` command surface manages the user's registered Todoist developer apps (integrations). All `apps` subcommands require the `dev:app_console` OAuth scope — re-run `td auth login --app-management` to grant it. Without the scope, calls fail with a `MISSING_SCOPE` error pointing at the same hint.
+The `apps` command surface manages the user's registered Todoist developer apps (integrations). All `apps` subcommands require the `dev:app_console` OAuth scope — re-run `td auth login --additional-scopes=app-management` to grant it. Without the scope, calls fail with a `MISSING_SCOPE` error pointing at the same hint.
 
 `td apps list` plain output leads with the display name and follows it with `(id:N)` (self-describing in `--accessible` mode). `--json` / `--ndjson` dump the full app payload (id, displayName, status, userId, createdAt, serviceUrl, oauthRedirectUri, description, icons, appTokenScopes).
 

--- a/src/__tests__/apps.test.ts
+++ b/src/__tests__/apps.test.ts
@@ -365,20 +365,20 @@ describe('wrapApiError → MISSING_SCOPE detection', () => {
         })
     }
 
-    it('emits the --app-management hint for app-management methods (getApps, getApp)', () => {
+    it('emits the app-management hint for app-management methods (getApps, getApp)', () => {
         for (const method of ['getApps', 'getApp']) {
             const wrapped = wrapApiError(scopeError(), method) as CliError
             expect(wrapped.code).toBe('MISSING_SCOPE')
-            expect(wrapped.hints?.[0]).toContain('--app-management')
+            expect(wrapped.hints?.[0]).toContain('--additional-scopes=app-management')
             expect(wrapped.hints?.[0]).toContain('dev:app_console')
         }
     })
 
-    it('emits the --backups hint for backup methods (getBackups, downloadBackup)', () => {
+    it('emits the backups hint for backup methods (getBackups, downloadBackup)', () => {
         for (const method of ['getBackups', 'downloadBackup']) {
             const wrapped = wrapApiError(scopeError(), method) as CliError
             expect(wrapped.code).toBe('MISSING_SCOPE')
-            expect(wrapped.hints?.[0]).toContain('--backups')
+            expect(wrapped.hints?.[0]).toContain('--additional-scopes=backups')
             expect(wrapped.hints?.[0]).toContain('backups:read')
         }
     })
@@ -386,15 +386,14 @@ describe('wrapApiError → MISSING_SCOPE detection', () => {
     it('emits the generic re-auth hint for methods without a scope group (e.g. getTasks)', () => {
         const wrapped = wrapApiError(scopeError(), 'getTasks') as CliError
         expect(wrapped.code).toBe('MISSING_SCOPE')
-        expect(wrapped.hints?.[0]).not.toContain('--app-management')
-        expect(wrapped.hints?.[0]).not.toContain('--backups')
+        expect(wrapped.hints?.[0]).not.toContain('--additional-scopes')
         expect(wrapped.hints?.[0]).toContain('td auth login')
     })
 
     it('falls back to the standard hint when no method name is supplied', () => {
         const wrapped = wrapApiError(scopeError()) as CliError
         expect(wrapped.code).toBe('MISSING_SCOPE')
-        expect(wrapped.hints?.[0]).not.toContain('--app-management')
+        expect(wrapped.hints?.[0]).not.toContain('--additional-scopes')
     })
 
     it('falls through to AUTH_ERROR for a generic 403 without the scope tag', () => {

--- a/src/__tests__/apps.test.ts
+++ b/src/__tests__/apps.test.ts
@@ -10,12 +10,22 @@ vi.mock('../lib/api/core.js', async (importOriginal) => {
     }
 })
 
+vi.mock('../lib/auth.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../lib/auth.js')>()
+    return {
+        ...actual,
+        getAuthMetadata: vi.fn(),
+    }
+})
+
 import { registerAppsCommand } from '../commands/apps/index.js'
 import { getApi, wrapApiError } from '../lib/api/core.js'
+import { getAuthMetadata } from '../lib/auth.js'
 import { CliError } from '../lib/errors.js'
 import { createMockApi, type MockApi } from './helpers/mock-api.js'
 
 const mockGetApi = vi.mocked(getApi)
+const mockGetAuthMetadata = vi.mocked(getAuthMetadata)
 
 function createProgram() {
     const program = new Command()
@@ -365,60 +375,88 @@ describe('wrapApiError → MISSING_SCOPE detection', () => {
         })
     }
 
-    it('emits the app-management hint for app-management methods (getApps, getApp)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockGetAuthMetadata.mockResolvedValue({
+            authMode: 'read-write',
+            source: 'secure-store',
+        })
+    })
+
+    it('emits the app-management hint for app-management methods (getApps, getApp)', async () => {
         for (const method of ['getApps', 'getApp']) {
-            const wrapped = wrapApiError(scopeError(), method) as CliError
+            const wrapped = (await wrapApiError(scopeError(), method)) as CliError
             expect(wrapped.code).toBe('MISSING_SCOPE')
             expect(wrapped.hints?.[0]).toContain('--additional-scopes=app-management')
             expect(wrapped.hints?.[0]).toContain('dev:app_console')
         }
     })
 
-    it('emits the backups hint for backup methods (getBackups, downloadBackup)', () => {
+    it('emits the backups hint for backup methods (getBackups, downloadBackup)', async () => {
         for (const method of ['getBackups', 'downloadBackup']) {
-            const wrapped = wrapApiError(scopeError(), method) as CliError
+            const wrapped = (await wrapApiError(scopeError(), method)) as CliError
             expect(wrapped.code).toBe('MISSING_SCOPE')
             expect(wrapped.hints?.[0]).toContain('--additional-scopes=backups')
             expect(wrapped.hints?.[0]).toContain('backups:read')
         }
     })
 
-    it('emits the generic re-auth hint for methods without a scope group (e.g. getTasks)', () => {
-        const wrapped = wrapApiError(scopeError(), 'getTasks') as CliError
+    it('preserves prior --read-only flag in the personalised re-login hint', async () => {
+        mockGetAuthMetadata.mockResolvedValue({
+            authMode: 'read-only',
+            authFlags: ['read-only'],
+            source: 'secure-store',
+        })
+        const wrapped = (await wrapApiError(scopeError(), 'getApps')) as CliError
+        expect(wrapped.hints?.[0]).toContain('--read-only --additional-scopes=app-management')
+    })
+
+    it('preserves prior opt-in scopes alongside the newly required one', async () => {
+        mockGetAuthMetadata.mockResolvedValue({
+            authMode: 'read-write',
+            authFlags: ['app-management'],
+            source: 'secure-store',
+        })
+        const wrapped = (await wrapApiError(scopeError(), 'getBackups')) as CliError
+        expect(wrapped.hints?.[0]).toContain('--additional-scopes=app-management,backups')
+    })
+
+    it('emits the generic re-auth hint for methods without a scope group (e.g. getTasks)', async () => {
+        const wrapped = (await wrapApiError(scopeError(), 'getTasks')) as CliError
         expect(wrapped.code).toBe('MISSING_SCOPE')
         expect(wrapped.hints?.[0]).not.toContain('--additional-scopes')
         expect(wrapped.hints?.[0]).toContain('td auth login')
     })
 
-    it('falls back to the standard hint when no method name is supplied', () => {
-        const wrapped = wrapApiError(scopeError()) as CliError
+    it('falls back to the standard hint when no method name is supplied', async () => {
+        const wrapped = (await wrapApiError(scopeError())) as CliError
         expect(wrapped.code).toBe('MISSING_SCOPE')
         expect(wrapped.hints?.[0]).not.toContain('--additional-scopes')
     })
 
-    it('falls through to AUTH_ERROR for a generic 403 without the scope tag', () => {
+    it('falls through to AUTH_ERROR for a generic 403 without the scope tag', async () => {
         const error = new TodoistRequestError('HTTP 403: Forbidden', 403, { error: 'Forbidden' })
 
-        const wrapped = wrapApiError(error, 'getApps')
+        const wrapped = await wrapApiError(error, 'getApps')
 
         expect(wrapped).toBeInstanceOf(CliError)
         expect((wrapped as CliError).code).toBe('AUTH_ERROR')
     })
 
-    it('falls through to AUTH_ERROR for 403 with non-object responseData', () => {
+    it('falls through to AUTH_ERROR for 403 with non-object responseData', async () => {
         const error = new TodoistRequestError('HTTP 403: Forbidden', 403, 'Forbidden')
 
-        const wrapped = wrapApiError(error, 'getApps')
+        const wrapped = await wrapApiError(error, 'getApps')
 
         expect((wrapped as CliError).code).toBe('AUTH_ERROR')
     })
 
-    it('does not match on non-403 statuses even with the scope tag in body', () => {
+    it('does not match on non-403 statuses even with the scope tag in body', async () => {
         const error = new TodoistRequestError('HTTP 500: Internal Server Error', 500, {
             error_tag: 'AUTH_INSUFFICIENT_TOKEN_SCOPE',
         })
 
-        const wrapped = wrapApiError(error, 'getApps')
+        const wrapped = await wrapApiError(error, 'getApps')
 
         expect((wrapped as CliError).code).toBe('API_ERROR')
     })

--- a/src/__tests__/auth-flags.test.ts
+++ b/src/__tests__/auth-flags.test.ts
@@ -12,24 +12,26 @@ function metadata(overrides: Partial<AuthMetadata> = {}): AuthMetadata {
 
 describe('buildReloginCommand', () => {
     it('returns a bare re-login command when authFlags is undefined', () => {
-        expect(buildReloginCommand(metadata(), 'backups')).toBe('td auth login --backups')
+        expect(buildReloginCommand(metadata(), 'backups')).toBe(
+            'td auth login --additional-scopes=backups',
+        )
     })
 
     it('returns a bare re-login command when authFlags is an empty array', () => {
         expect(buildReloginCommand(metadata({ authFlags: [] }), 'backups')).toBe(
-            'td auth login --backups',
+            'td auth login --additional-scopes=backups',
         )
     })
 
     it('preserves a prior --read-only flag', () => {
         expect(buildReloginCommand(metadata({ authFlags: ['read-only'] }), 'backups')).toBe(
-            'td auth login --read-only --backups',
+            'td auth login --read-only --additional-scopes=backups',
         )
     })
 
     it('does not duplicate the required flag if it is already present', () => {
         expect(buildReloginCommand(metadata({ authFlags: ['backups'] }), 'backups')).toBe(
-            'td auth login --backups',
+            'td auth login --additional-scopes=backups',
         )
     })
 
@@ -39,6 +41,6 @@ describe('buildReloginCommand', () => {
                 metadata({ authFlags: ['app-management', 'read-only'] }),
                 'backups',
             ),
-        ).toBe('td auth login --read-only --app-management --backups')
+        ).toBe('td auth login --read-only --additional-scopes=app-management,backups')
     })
 })

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -279,7 +279,7 @@ describe('auth command', () => {
             expect(mockBuildAuthorizationUrl).toHaveBeenCalledWith(
                 'test_code_challenge',
                 'test_state',
-                { readOnly: true, port: 8765 },
+                { readOnly: true, additionalScopes: [], port: 8765 },
             )
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-only',
@@ -288,7 +288,7 @@ describe('auth command', () => {
             })
         })
 
-        it('appends dev:app_console scope when --app-management is set', async () => {
+        it('appends dev:app_console scope when --additional-scopes=app-management is set', async () => {
             const program = createProgram()
             const authCode = 'oauth_auth_code_app'
             const accessToken = 'oauth_access_token_app'
@@ -302,12 +302,18 @@ describe('auth command', () => {
             mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
             mockOpen.mockResolvedValue({} as Awaited<ReturnType<typeof open>>)
 
-            await program.parseAsync(['node', 'td', 'auth', 'login', '--app-management'])
+            await program.parseAsync([
+                'node',
+                'td',
+                'auth',
+                'login',
+                '--additional-scopes=app-management',
+            ])
 
             expect(mockBuildAuthorizationUrl).toHaveBeenCalledWith(
                 'test_code_challenge',
                 'test_state',
-                { readOnly: undefined, appManagement: true, backups: undefined, port: 8765 },
+                { readOnly: undefined, additionalScopes: ['app-management'], port: 8765 },
             )
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-write',
@@ -316,7 +322,7 @@ describe('auth command', () => {
             })
         })
 
-        it('combines --app-management with --read-only', async () => {
+        it('combines --additional-scopes=app-management with --read-only', async () => {
             const program = createProgram()
             const authCode = 'oauth_auth_code_app_ro'
             const accessToken = 'oauth_access_token_app_ro'
@@ -335,14 +341,14 @@ describe('auth command', () => {
                 'td',
                 'auth',
                 'login',
-                '--app-management',
+                '--additional-scopes=app-management',
                 '--read-only',
             ])
 
             expect(mockBuildAuthorizationUrl).toHaveBeenCalledWith(
                 'test_code_challenge',
                 'test_state',
-                { readOnly: true, appManagement: true, backups: undefined, port: 8765 },
+                { readOnly: true, additionalScopes: ['app-management'], port: 8765 },
             )
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-only',
@@ -351,7 +357,7 @@ describe('auth command', () => {
             })
         })
 
-        it('appends backups:read scope when --backups is set', async () => {
+        it('appends backups:read scope when --additional-scopes=backups is set', async () => {
             const program = createProgram()
             const authCode = 'oauth_auth_code_backups'
             const accessToken = 'oauth_access_token_backups'
@@ -365,12 +371,12 @@ describe('auth command', () => {
             mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
             mockOpen.mockResolvedValue({} as Awaited<ReturnType<typeof open>>)
 
-            await program.parseAsync(['node', 'td', 'auth', 'login', '--backups'])
+            await program.parseAsync(['node', 'td', 'auth', 'login', '--additional-scopes=backups'])
 
             expect(mockBuildAuthorizationUrl).toHaveBeenCalledWith(
                 'test_code_challenge',
                 'test_state',
-                { readOnly: undefined, appManagement: undefined, backups: true, port: 8765 },
+                { readOnly: undefined, additionalScopes: ['backups'], port: 8765 },
             )
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-write',
@@ -379,7 +385,7 @@ describe('auth command', () => {
             })
         })
 
-        it('combines --backups with --read-only', async () => {
+        it('combines --additional-scopes=backups with --read-only', async () => {
             const program = createProgram()
             const authCode = 'oauth_auth_code_backups_ro'
             const accessToken = 'oauth_access_token_backups_ro'
@@ -393,7 +399,14 @@ describe('auth command', () => {
             mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
             mockOpen.mockResolvedValue({} as Awaited<ReturnType<typeof open>>)
 
-            await program.parseAsync(['node', 'td', 'auth', 'login', '--backups', '--read-only'])
+            await program.parseAsync([
+                'node',
+                'td',
+                'auth',
+                'login',
+                '--additional-scopes=backups',
+                '--read-only',
+            ])
 
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
                 authMode: 'read-only',
@@ -402,7 +415,7 @@ describe('auth command', () => {
             })
         })
 
-        it('combines --backups with --app-management', async () => {
+        it('accepts multiple scopes in one --additional-scopes flag', async () => {
             const program = createProgram()
             const authCode = 'oauth_auth_code_backups_app'
             const accessToken = 'oauth_access_token_backups_app'
@@ -421,8 +434,7 @@ describe('auth command', () => {
                 'td',
                 'auth',
                 'login',
-                '--backups',
-                '--app-management',
+                '--additional-scopes=backups,app-management',
             ])
 
             expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
@@ -431,6 +443,22 @@ describe('auth command', () => {
                     'data:read_write,data:delete,project:delete,dev:app_console,backups:read',
                 authFlags: ['app-management', 'backups'],
             })
+        })
+
+        it('rejects an unknown scope with a friendly error', async () => {
+            const program = createProgram()
+
+            mockStartCallbackServer.mockResolvedValue({
+                promise: new Promise(() => {}),
+                port: 8765,
+                cleanup: vi.fn(),
+            })
+
+            await expect(
+                program.parseAsync(['node', 'td', 'auth', 'login', '--additional-scopes=nonsense']),
+            ).rejects.toThrow(/Unknown scope/)
+            expect(mockOpen).not.toHaveBeenCalled()
+            expect(mockSaveApiToken).not.toHaveBeenCalled()
         })
 
         it('handles OAuth callback server error', async () => {

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -415,6 +415,37 @@ describe('auth command', () => {
             })
         })
 
+        it('merges repeated --additional-scopes occurrences rather than overwriting', async () => {
+            const program = createProgram()
+            const authCode = 'oauth_auth_code_repeated'
+            const accessToken = 'oauth_access_token_repeated'
+
+            mockStartCallbackServer.mockResolvedValue({
+                promise: Promise.resolve(authCode),
+                port: 8765,
+                cleanup: vi.fn(),
+            })
+            mockExchangeCodeForToken.mockResolvedValue(accessToken)
+            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
+            mockOpen.mockResolvedValue({} as Awaited<ReturnType<typeof open>>)
+
+            await program.parseAsync([
+                'node',
+                'td',
+                'auth',
+                'login',
+                '--additional-scopes=app-management',
+                '--additional-scopes=backups',
+            ])
+
+            expect(mockSaveApiToken).toHaveBeenCalledWith(accessToken, {
+                authMode: 'read-write',
+                authScope:
+                    'data:read_write,data:delete,project:delete,dev:app_console,backups:read',
+                authFlags: ['app-management', 'backups'],
+            })
+        })
+
         it('accepts multiple scopes in one --additional-scopes flag', async () => {
             const program = createProgram()
             const authCode = 'oauth_auth_code_backups_app'

--- a/src/__tests__/backup.test.ts
+++ b/src/__tests__/backup.test.ts
@@ -118,7 +118,7 @@ describe('backup list', () => {
         )
     })
 
-    it('suggests `td auth login --backups` when no prior flags were recorded', async () => {
+    it('suggests `td auth login --additional-scopes=backups` when no prior flags were recorded', async () => {
         const program = createProgram()
 
         mockGetAuthMetadata.mockResolvedValue({
@@ -128,7 +128,9 @@ describe('backup list', () => {
         })
 
         await expect(program.parseAsync(['node', 'td', 'backup', 'list'])).rejects.toMatchObject({
-            hints: ['Re-authenticate to grant backup access: td auth login --backups'],
+            hints: [
+                'Re-authenticate to grant backup access: td auth login --additional-scopes=backups',
+            ],
         })
     })
 
@@ -143,11 +145,13 @@ describe('backup list', () => {
         })
 
         await expect(program.parseAsync(['node', 'td', 'backup', 'list'])).rejects.toMatchObject({
-            hints: ['Re-authenticate to grant backup access: td auth login --read-only --backups'],
+            hints: [
+                'Re-authenticate to grant backup access: td auth login --read-only --additional-scopes=backups',
+            ],
         })
     })
 
-    it('preserves prior --app-management flag in the suggested re-login command', async () => {
+    it('preserves prior app-management scope in the suggested re-login command', async () => {
         const program = createProgram()
 
         mockGetAuthMetadata.mockResolvedValue({
@@ -159,7 +163,7 @@ describe('backup list', () => {
 
         await expect(program.parseAsync(['node', 'td', 'backup', 'list'])).rejects.toMatchObject({
             hints: [
-                'Re-authenticate to grant backup access: td auth login --app-management --backups',
+                'Re-authenticate to grant backup access: td auth login --additional-scopes=app-management,backups',
             ],
         })
     })

--- a/src/__tests__/oauth-scopes.test.ts
+++ b/src/__tests__/oauth-scopes.test.ts
@@ -47,7 +47,20 @@ describe('parseScopesOption', () => {
     it('throws CliError when given an empty string', () => {
         expect(() => parseScopesOption('')).toThrow(CliError)
         expect(() => parseScopesOption('   ')).toThrow(CliError)
-        expect(() => parseScopesOption(',,,')).toThrow(CliError)
+    })
+
+    it('rejects trailing or stray empty segments rather than silently filtering them', () => {
+        // `app-management,` and `a,,b` are almost always typos — we surface them
+        // as an error instead of quietly accepting them.
+        for (const raw of ['app-management,', ',app-management', 'app-management,,backups', ',,']) {
+            try {
+                parseScopesOption(raw)
+                throw new Error(`expected parseScopesOption(${JSON.stringify(raw)}) to throw`)
+            } catch (error) {
+                expect(error).toBeInstanceOf(CliError)
+                expect((error as CliError).message).toContain('empty entry')
+            }
+        }
     })
 
     it('pluralizes the error message when multiple entries are unknown', () => {

--- a/src/__tests__/oauth-scopes.test.ts
+++ b/src/__tests__/oauth-scopes.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { CliError } from '../lib/errors.js'
+import { formatScopesHelp, parseScopesOption } from '../lib/oauth-scopes.js'
+
+describe('parseScopesOption', () => {
+    it('parses a single scope', () => {
+        expect(parseScopesOption('app-management')).toEqual(['app-management'])
+    })
+
+    it('parses multiple comma-separated scopes', () => {
+        expect(parseScopesOption('app-management,backups')).toEqual(['app-management', 'backups'])
+    })
+
+    it('trims whitespace around entries', () => {
+        expect(parseScopesOption(' app-management ,  backups  ')).toEqual([
+            'app-management',
+            'backups',
+        ])
+    })
+
+    it('returns scopes in canonical AUTH_FLAG_ORDER regardless of input order', () => {
+        expect(parseScopesOption('backups,app-management')).toEqual(['app-management', 'backups'])
+    })
+
+    it('deduplicates repeated entries', () => {
+        expect(parseScopesOption('backups,backups,app-management')).toEqual([
+            'app-management',
+            'backups',
+        ])
+    })
+
+    it('throws CliError listing valid scopes when an entry is unknown', () => {
+        try {
+            parseScopesOption('nonsense')
+            throw new Error('expected parseScopesOption to throw')
+        } catch (error) {
+            expect(error).toBeInstanceOf(CliError)
+            const cliError = error as CliError
+            expect(cliError.code).toBe('INVALID_OPTIONS')
+            expect(cliError.message).toContain('Unknown scope')
+            expect(cliError.message).toContain('nonsense')
+            expect(cliError.hints?.[0]).toContain('app-management')
+            expect(cliError.hints?.[0]).toContain('backups')
+        }
+    })
+
+    it('throws CliError when given an empty string', () => {
+        expect(() => parseScopesOption('')).toThrow(CliError)
+        expect(() => parseScopesOption('   ')).toThrow(CliError)
+        expect(() => parseScopesOption(',,,')).toThrow(CliError)
+    })
+
+    it('pluralizes the error message when multiple entries are unknown', () => {
+        try {
+            parseScopesOption('foo,bar')
+            throw new Error('expected parseScopesOption to throw')
+        } catch (error) {
+            expect((error as CliError).message).toContain('Unknown scopes')
+            expect((error as CliError).message).toContain('foo, bar')
+        }
+    })
+})
+
+describe('formatScopesHelp', () => {
+    it('lists every registered scope with its summary', () => {
+        const help = formatScopesHelp()
+        expect(help).toContain('app-management')
+        expect(help).toContain('backups')
+        expect(help).toContain('rotate secrets')
+        expect(help).toContain('List and download your Todoist backups.')
+    })
+
+    it('demonstrates the =<value> form in its examples', () => {
+        const help = formatScopesHelp()
+        expect(help).toContain('--additional-scopes=app-management')
+        expect(help).toContain('--additional-scopes=backups')
+        expect(help).toContain('--additional-scopes=app-management,backups')
+    })
+})

--- a/src/__tests__/oauth.test.ts
+++ b/src/__tests__/oauth.test.ts
@@ -23,24 +23,28 @@ describe('buildAuthorizationUrl', () => {
         expect(params.get('scope')).toBe('data:read_write,data:delete,project:delete')
     })
 
-    it('appends backups:read when --backups is set', () => {
-        const url = buildAuthorizationUrl('challenge', 'state', { backups: true })
+    it('appends backups:read when the backups scope is requested', () => {
+        const url = buildAuthorizationUrl('challenge', 'state', {
+            additionalScopes: ['backups'],
+        })
         const params = new URL(url).searchParams
 
         expect(params.get('scope')).toBe('data:read_write,data:delete,project:delete,backups:read')
     })
 
     it('appends backups:read to read-only scope when combined', () => {
-        const url = buildAuthorizationUrl('challenge', 'state', { readOnly: true, backups: true })
+        const url = buildAuthorizationUrl('challenge', 'state', {
+            readOnly: true,
+            additionalScopes: ['backups'],
+        })
         const params = new URL(url).searchParams
 
         expect(params.get('scope')).toBe('data:read,backups:read')
     })
 
-    it('combines --backups with --app-management', () => {
+    it('combines multiple additional scopes', () => {
         const url = buildAuthorizationUrl('challenge', 'state', {
-            appManagement: true,
-            backups: true,
+            additionalScopes: ['app-management', 'backups'],
         })
         const params = new URL(url).searchParams
 

--- a/src/commands/apps/index.ts
+++ b/src/commands/apps/index.ts
@@ -17,7 +17,7 @@ Examples:
   td apps view 9909
 
 Requires authenticating with the dev:app_console scope:
-  td auth login --app-management`,
+  td auth login --additional-scopes=app-management`,
         )
 
     apps.command('list')

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -13,7 +13,12 @@ export function registerAuthCommand(program: Command): void {
         .option('--read-only', 'Authenticate with read-only scope (data:read)')
         .option(
             '--additional-scopes <list>',
-            'Comma-separated opt-in OAuth scopes (see list below)',
+            'Comma-separated opt-in OAuth scopes (see list below). The flag may be repeated; every occurrence is merged.',
+            // Commander treats this as a scalar by default, so repeated uses
+            // (`--additional-scopes=a --additional-scopes=b`) would silently
+            // drop earlier values. Concatenate into one comma-separated string
+            // and let parseScopesOption split/dedupe/validate as usual.
+            (value: string, prev: string | undefined) => (prev ? `${prev},${value}` : value),
         )
         .addHelpText('after', formatScopesHelp())
         .action(loginWithOAuth)

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander'
+import { formatScopesHelp } from '../../lib/oauth-scopes.js'
 import { loginWithOAuth } from './login.js'
 import { logout } from './logout.js'
 import { showStatus } from './status.js'
@@ -11,13 +12,10 @@ export function registerAuthCommand(program: Command): void {
         .description('Authenticate with Todoist via OAuth')
         .option('--read-only', 'Authenticate with read-only scope (data:read)')
         .option(
-            '--app-management',
-            'Also request the dev:app_console scope (manage your Todoist apps). Combine with --read-only if desired.',
+            '--additional-scopes <list>',
+            'Comma-separated opt-in OAuth scopes (see list below)',
         )
-        .option(
-            '--backups',
-            'Also request the backups:read scope (list/download Todoist backups). Combine with --read-only if desired.',
-        )
+        .addHelpText('after', formatScopesHelp())
         .action(loginWithOAuth)
 
     auth.command('token [token]')

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,14 +1,19 @@
 import chalk from 'chalk'
 import open from 'open'
 import { saveApiToken, type AuthFlag } from '../../lib/auth.js'
+import { type AdditionalScopeFlag, parseScopesOption } from '../../lib/oauth-scopes.js'
 import { startCallbackServer } from '../../lib/oauth-server.js'
 import { buildAuthorizationUrl, exchangeCodeForToken, resolveAuthScope } from '../../lib/oauth.js'
 import { generateCodeChallenge, generateCodeVerifier, generateState } from '../../lib/pkce.js'
 import { logTokenStorageResult } from './helpers.js'
 
 export async function loginWithOAuth(
-    options: { readOnly?: boolean; appManagement?: boolean; backups?: boolean } = {},
+    options: { readOnly?: boolean; additionalScopes?: string } = {},
 ): Promise<void> {
+    const additionalScopes: AdditionalScopeFlag[] = options.additionalScopes
+        ? parseScopesOption(options.additionalScopes)
+        : []
+
     const codeVerifier = generateCodeVerifier()
     const codeChallenge = generateCodeChallenge(codeVerifier)
     const state = generateState()
@@ -18,8 +23,7 @@ export async function loginWithOAuth(
     const { promise: callbackPromise, port, cleanup } = await startCallbackServer(state)
     const authUrl = buildAuthorizationUrl(codeChallenge, state, {
         readOnly: options.readOnly,
-        appManagement: options.appManagement,
-        backups: options.backups,
+        additionalScopes,
         port,
     })
 
@@ -33,11 +37,10 @@ export async function loginWithOAuth(
         const accessToken = await exchangeCodeForToken(code, codeVerifier, port)
         const authFlags: AuthFlag[] = []
         if (options.readOnly) authFlags.push('read-only')
-        if (options.appManagement) authFlags.push('app-management')
-        if (options.backups) authFlags.push('backups')
+        authFlags.push(...additionalScopes)
         const result = await saveApiToken(accessToken, {
             authMode: options.readOnly ? 'read-only' : 'read-write',
-            authScope: resolveAuthScope(options),
+            authScope: resolveAuthScope({ readOnly: options.readOnly, additionalScopes }),
             authFlags,
         })
 

--- a/src/commands/backup/index.ts
+++ b/src/commands/backup/index.ts
@@ -15,7 +15,7 @@ Examples:
   td backup download "2024-01-15_12:00" --output-file backup.zip
 
 Requires authenticating with the backups:read scope:
-  td auth login --backups`,
+  td auth login --additional-scopes=backups`,
         )
 
     backup

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -9,7 +9,9 @@ import {
     WorkspaceProject,
     type DueDate,
 } from '@doist/todoist-sdk'
-import { getApiToken } from '../auth.js'
+import { buildReloginCommand } from '../auth-flags.js'
+import { getApiToken, getAuthMetadata } from '../auth.js'
+import type { AuthFlag } from '../config.js'
 import { CliError } from '../errors.js'
 import { ensureWriteAllowed, isMutatingApiMethod, isMutatingSyncPayload } from '../permissions.js'
 import { getProgressTracker } from '../progress.js'
@@ -157,7 +159,7 @@ function createSpinnerWrappedApi(api: TodoistApi): TodoistApi {
                             (error as Error).message,
                         )
                     }
-                    throw wrapApiError(error, property)
+                    throw await wrapApiError(error, property)
                 }
             }
         },
@@ -178,34 +180,39 @@ function isInsufficientScopeError(error: TodoistRequestError): boolean {
  * gated SDK surface lands.
  *
  * Methods not listed fall back to the `standard` group — appropriate for
- * endpoints gated by scopes that are part of the standard grant.
- * Opt-in scopes (e.g. `dev:app_console`, `backups:read`) get their own group
- * with flag-specific remediation strings.
+ * endpoints gated by scopes that are part of the standard grant. Opt-in
+ * scopes map to an `AuthFlag` that `buildReloginCommand` splices into a
+ * personalised re-login command that preserves whichever flags the user
+ * already has recorded in `auth_flags`.
  */
-type ScopeGroup = 'app-management' | 'backups' | 'standard'
-
-const METHOD_SCOPE_GROUP: Record<string, ScopeGroup> = {
+const METHOD_REQUIRED_FLAG: Record<string, AuthFlag> = {
     getApps: 'app-management',
     getApp: 'app-management',
     getBackups: 'backups',
     downloadBackup: 'backups',
 }
 
-const SCOPE_REMEDIATION: Record<ScopeGroup, string> = {
-    'app-management':
-        'This command requires the dev:app_console scope. Re-run `td auth login --additional-scopes=app-management` (combine with --read-only if desired).',
-    backups:
-        'This command requires the backups:read scope. Re-run `td auth login --additional-scopes=backups` (combine with --read-only if desired).',
-    standard:
-        'Re-authenticate with `td auth login` (or `td auth login --read-only`) to refresh your token with the standard scopes.',
+const SCOPE_DESCRIPTIONS: Record<AuthFlag, string> = {
+    'read-only': '',
+    'app-management': 'dev:app_console',
+    backups: 'backups:read',
 }
 
-function getScopeRemediation(methodName: string | undefined): string {
-    const group: ScopeGroup = (methodName && METHOD_SCOPE_GROUP[methodName]) || 'standard'
-    return SCOPE_REMEDIATION[group]
+const STANDARD_REMEDIATION =
+    'Re-authenticate with `td auth login` (or `td auth login --read-only`) to refresh your token with the standard scopes.'
+
+async function getScopeRemediation(methodName: string | undefined): Promise<string> {
+    const requiredFlag = methodName ? METHOD_REQUIRED_FLAG[methodName] : undefined
+    if (!requiredFlag) {
+        return STANDARD_REMEDIATION
+    }
+    const metadata = await getAuthMetadata()
+    const command = buildReloginCommand(metadata, requiredFlag)
+    const scopeString = SCOPE_DESCRIPTIONS[requiredFlag]
+    return `This command requires the ${scopeString} scope. Re-run \`${command}\` to grant it.`
 }
 
-export function wrapApiError(error: unknown, methodName?: string): Error {
+export async function wrapApiError(error: unknown, methodName?: string): Promise<Error> {
     if (error instanceof CliError) return error
     if (error instanceof TodoistRequestError) {
         const status = error.httpStatusCode
@@ -213,7 +220,7 @@ export function wrapApiError(error: unknown, methodName?: string): Error {
             return new CliError(
                 'MISSING_SCOPE',
                 'Your token is missing the OAuth scope required for this command.',
-                [getScopeRemediation(methodName)],
+                [await getScopeRemediation(methodName)],
             )
         }
         if (status === 401 || status === 403) {

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -179,9 +179,8 @@ function isInsufficientScopeError(error: TodoistRequestError): boolean {
  *
  * Methods not listed fall back to the `standard` group — appropriate for
  * endpoints gated by scopes that are part of the standard grant.
- * Opt-in scopes (e.g. `dev:app_console` via `--app-management`,
- * `backups:read` via `--backups`) get their own group with flag-specific
- * remediation strings.
+ * Opt-in scopes (e.g. `dev:app_console`, `backups:read`) get their own group
+ * with flag-specific remediation strings.
  */
 type ScopeGroup = 'app-management' | 'backups' | 'standard'
 
@@ -194,9 +193,9 @@ const METHOD_SCOPE_GROUP: Record<string, ScopeGroup> = {
 
 const SCOPE_REMEDIATION: Record<ScopeGroup, string> = {
     'app-management':
-        'This command requires the dev:app_console scope. Re-run `td auth login --app-management` (combine with --read-only if desired).',
+        'This command requires the dev:app_console scope. Re-run `td auth login --additional-scopes=app-management` (combine with --read-only if desired).',
     backups:
-        'This command requires the backups:read scope. Re-run `td auth login --backups` (combine with --read-only if desired).',
+        'This command requires the backups:read scope. Re-run `td auth login --additional-scopes=backups` (combine with --read-only if desired).',
     standard:
         'Re-authenticate with `td auth login` (or `td auth login --read-only`) to refresh your token with the standard scopes.',
 }

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -11,8 +11,8 @@ import {
 } from '@doist/todoist-sdk'
 import { buildReloginCommand } from '../auth-flags.js'
 import { getApiToken, getAuthMetadata } from '../auth.js'
-import type { AuthFlag } from '../config.js'
 import { CliError } from '../errors.js'
+import { type AdditionalScopeFlag, oauthScopeFor } from '../oauth-scopes.js'
 import { ensureWriteAllowed, isMutatingApiMethod, isMutatingSyncPayload } from '../permissions.js'
 import { getProgressTracker } from '../progress.js'
 import { withSpinner } from '../spinner.js'
@@ -174,28 +174,22 @@ function isInsufficientScopeError(error: TodoistRequestError): boolean {
 }
 
 /**
- * Group SDK methods by the OAuth scope they require, so a 403
+ * Group SDK methods by the opt-in OAuth scope they require, so a 403
  * `AUTH_INSUFFICIENT_TOKEN_SCOPE` can surface a *command-specific* remediation
  * hint instead of a generic "re-auth" line. Add new methods here as scope-
  * gated SDK surface lands.
  *
- * Methods not listed fall back to the `standard` group — appropriate for
- * endpoints gated by scopes that are part of the standard grant. Opt-in
- * scopes map to an `AuthFlag` that `buildReloginCommand` splices into a
- * personalised re-login command that preserves whichever flags the user
- * already has recorded in `auth_flags`.
+ * Methods not listed fall back to the standard remediation — appropriate for
+ * endpoints gated by scopes that are part of the standard grant. The raw
+ * OAuth scope string and user-facing flag name both come from the
+ * `ADDITIONAL_SCOPES` registry via `oauthScopeFor`, so this table is the
+ * single place that needs changes when wiring a new scope-gated method.
  */
-const METHOD_REQUIRED_FLAG: Record<string, AuthFlag> = {
+const METHOD_REQUIRED_FLAG: Record<string, AdditionalScopeFlag> = {
     getApps: 'app-management',
     getApp: 'app-management',
     getBackups: 'backups',
     downloadBackup: 'backups',
-}
-
-const SCOPE_DESCRIPTIONS: Record<AuthFlag, string> = {
-    'read-only': '',
-    'app-management': 'dev:app_console',
-    backups: 'backups:read',
 }
 
 const STANDARD_REMEDIATION =
@@ -208,8 +202,7 @@ async function getScopeRemediation(methodName: string | undefined): Promise<stri
     }
     const metadata = await getAuthMetadata()
     const command = buildReloginCommand(metadata, requiredFlag)
-    const scopeString = SCOPE_DESCRIPTIONS[requiredFlag]
-    return `This command requires the ${scopeString} scope. Re-run \`${command}\` to grant it.`
+    return `This command requires the ${oauthScopeFor(requiredFlag)} scope. Re-run \`${command}\` to grant it.`
 }
 
 export async function wrapApiError(error: unknown, methodName?: string): Promise<Error> {

--- a/src/lib/auth-flags.ts
+++ b/src/lib/auth-flags.ts
@@ -17,5 +17,13 @@ export function buildReloginCommand(metadata: AuthMetadata, requiredFlag: AuthFl
     const existing = metadata.authFlags ?? []
     const merged = new Set<AuthFlag>([...existing, requiredFlag])
     const orderedFlags = AUTH_FLAG_ORDER.filter((flag) => merged.has(flag))
-    return `td auth login ${orderedFlags.map((flag) => `--${flag}`).join(' ')}`
+    const parts = ['td auth login']
+    if (orderedFlags.includes('read-only')) {
+        parts.push('--read-only')
+    }
+    const additional = orderedFlags.filter((flag) => flag !== 'read-only')
+    if (additional.length > 0) {
+        parts.push(`--additional-scopes=${additional.join(',')}`)
+    }
+    return parts.join(' ')
 }

--- a/src/lib/oauth-scopes.ts
+++ b/src/lib/oauth-scopes.ts
@@ -1,0 +1,112 @@
+import { AUTH_FLAG_ORDER, type AuthFlag } from './config.js'
+import { CliError } from './errors.js'
+
+/**
+ * Additional OAuth scopes that can be requested on top of the base data grant
+ * via `td auth login --additional-scopes=...`. `read-only` is intentionally
+ * excluded — it swaps the base grant rather than adding to it.
+ */
+export type AdditionalScopeFlag = Exclude<AuthFlag, 'read-only'>
+
+export interface ScopeDefinition {
+    /** User-facing identifier used in --additional-scopes and in persisted auth_flags. */
+    readonly flag: AdditionalScopeFlag
+    /** Raw OAuth scope string sent to the Todoist authorize endpoint. */
+    readonly oauthScope: string
+    /** One-line summary shown in `td auth login --help`. */
+    readonly summary: string
+}
+
+/**
+ * Registry of opt-in OAuth scopes. Adding a new scope here is the only edit
+ * needed to expose it via `--additional-scopes`, help output, and the
+ * re-login remediation hints. Adding the same identifier to `AUTH_FLAG_ORDER`
+ * in `config.ts` is the only other step.
+ */
+export const ADDITIONAL_SCOPES: readonly ScopeDefinition[] = [
+    {
+        flag: 'app-management',
+        oauthScope: 'dev:app_console',
+        summary: 'Manage your registered Todoist developer apps (rotate secrets, edit webhooks).',
+    },
+    {
+        flag: 'backups',
+        oauthScope: 'backups:read',
+        summary: 'List and download your Todoist backups.',
+    },
+]
+
+const ADDITIONAL_SCOPE_FLAGS: ReadonlySet<AdditionalScopeFlag> = new Set(
+    ADDITIONAL_SCOPES.map((s) => s.flag),
+)
+
+export function isAdditionalScopeFlag(value: string): value is AdditionalScopeFlag {
+    return ADDITIONAL_SCOPE_FLAGS.has(value as AdditionalScopeFlag)
+}
+
+export function oauthScopeFor(flag: AdditionalScopeFlag): string {
+    const def = ADDITIONAL_SCOPES.find((s) => s.flag === flag)
+    if (!def) {
+        // Unreachable — the AdditionalScopeFlag type is derived from ADDITIONAL_SCOPES.
+        throw new Error(`Unknown additional scope: ${flag}`)
+    }
+    return def.oauthScope
+}
+
+/**
+ * Parse a comma-separated `--additional-scopes` value into an ordered,
+ * de-duplicated list of scope flags. Emits a canonical order matching
+ * `AUTH_FLAG_ORDER` (so persisted `auth_flags` stays stable regardless of
+ * user input order). Throws `CliError('INVALID_OPTIONS')` on empty entries
+ * or unknown scope names.
+ */
+export function parseScopesOption(raw: string): AdditionalScopeFlag[] {
+    const parts = raw
+        .split(',')
+        .map((p) => p.trim())
+        .filter((p) => p.length > 0)
+
+    if (parts.length === 0) {
+        throw new CliError(
+            'INVALID_OPTIONS',
+            '--additional-scopes requires at least one scope name.',
+            [`Valid scopes: ${ADDITIONAL_SCOPES.map((s) => s.flag).join(', ')}`],
+        )
+    }
+
+    const unknown = parts.filter((p) => !isAdditionalScopeFlag(p))
+    if (unknown.length > 0) {
+        throw new CliError(
+            'INVALID_OPTIONS',
+            `Unknown scope${unknown.length === 1 ? '' : 's'}: ${unknown.join(', ')}`,
+            [`Valid scopes: ${ADDITIONAL_SCOPES.map((s) => s.flag).join(', ')}`],
+        )
+    }
+
+    const seen = new Set<AdditionalScopeFlag>(parts as AdditionalScopeFlag[])
+    return AUTH_FLAG_ORDER.filter(
+        (f): f is AdditionalScopeFlag => f !== 'read-only' && seen.has(f as AdditionalScopeFlag),
+    )
+}
+
+/**
+ * Render the `Available scopes / Examples` block appended to
+ * `td auth login --help` via `.addHelpText('after', ...)`.
+ */
+export function formatScopesHelp(): string {
+    const maxFlagLength = Math.max(...ADDITIONAL_SCOPES.map((s) => s.flag.length))
+    const scopeLines = ADDITIONAL_SCOPES.map(
+        (s) => `  ${s.flag.padEnd(maxFlagLength)}  ${s.summary}`,
+    ).join('\n')
+
+    return `
+Available scopes (comma-separated for --additional-scopes):
+${scopeLines}
+
+Examples:
+  td auth login
+  td auth login --read-only
+  td auth login --additional-scopes=app-management
+  td auth login --read-only --additional-scopes=backups
+  td auth login --additional-scopes=app-management,backups`
+}

--- a/src/lib/oauth-scopes.ts
+++ b/src/lib/oauth-scopes.ts
@@ -61,15 +61,23 @@ export function oauthScopeFor(flag: AdditionalScopeFlag): string {
  * or unknown scope names.
  */
 export function parseScopesOption(raw: string): AdditionalScopeFlag[] {
-    const parts = raw
-        .split(',')
-        .map((p) => p.trim())
-        .filter((p) => p.length > 0)
-
-    if (parts.length === 0) {
+    const trimmed = raw.trim()
+    if (trimmed.length === 0) {
         throw new CliError(
             'INVALID_OPTIONS',
             '--additional-scopes requires at least one scope name.',
+            [`Valid scopes: ${ADDITIONAL_SCOPES.map((s) => s.flag).join(', ')}`],
+        )
+    }
+
+    // Reject empty segments (`app-management,` or `a,,b`) explicitly rather
+    // than filtering them out — a stray comma is almost always a typo and
+    // silently ignoring it would mask mistakes.
+    const parts = trimmed.split(',').map((p) => p.trim())
+    if (parts.some((p) => p.length === 0)) {
+        throw new CliError(
+            'INVALID_OPTIONS',
+            '--additional-scopes contains an empty entry (stray or trailing comma).',
             [`Valid scopes: ${ADDITIONAL_SCOPES.map((s) => s.flag).join(', ')}`],
         )
     }

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -1,4 +1,5 @@
 import { CliError } from './errors.js'
+import { type AdditionalScopeFlag, oauthScopeFor } from './oauth-scopes.js'
 import { DEFAULT_PORT, getRedirectUri } from './oauth-server.js'
 
 const TODOIST_CLIENT_ID = '04863cc1e3584830a578622f50224d5b'
@@ -6,29 +7,24 @@ const OAUTH_AUTHORIZE_URL = 'https://todoist.com/oauth/authorize'
 const OAUTH_TOKEN_URL = 'https://todoist.com/oauth/access_token'
 export const READ_WRITE_SCOPES = 'data:read_write,data:delete,project:delete'
 export const READ_ONLY_SCOPES = 'data:read'
-export const APP_MANAGEMENT_SCOPE = 'dev:app_console'
-export const BACKUPS_SCOPE = 'backups:read'
 
-export function resolveAuthScope(options: {
+export interface AuthScopeOptions {
     readOnly?: boolean
-    appManagement?: boolean
-    backups?: boolean
-}): string {
+    additionalScopes?: readonly AdditionalScopeFlag[]
+}
+
+export function resolveAuthScope(options: AuthScopeOptions): string {
     const parts = [options.readOnly ? READ_ONLY_SCOPES : READ_WRITE_SCOPES]
-    if (options.appManagement) parts.push(APP_MANAGEMENT_SCOPE)
-    if (options.backups) parts.push(BACKUPS_SCOPE)
+    for (const scope of options.additionalScopes ?? []) {
+        parts.push(oauthScopeFor(scope))
+    }
     return parts.join(',')
 }
 
 export function buildAuthorizationUrl(
     codeChallenge: string,
     state: string,
-    options: {
-        readOnly?: boolean
-        appManagement?: boolean
-        backups?: boolean
-        port?: number
-    } = {},
+    options: AuthScopeOptions & { port?: number } = {},
 ): string {
     const scope = resolveAuthScope(options)
     const redirectUri = getRedirectUri(options.port ?? DEFAULT_PORT)

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -30,18 +30,22 @@ Use this skill when the user wants to interact with their Todoist tasks.
 \`\`\`bash
 td auth login
 td auth login --read-only
-td auth login --app-management
-td auth login --app-management --read-only
-td auth login --backups
-td auth login --read-only --backups
+td auth login --additional-scopes=app-management
+td auth login --read-only --additional-scopes=app-management
+td auth login --additional-scopes=backups
+td auth login --read-only --additional-scopes=backups
+td auth login --additional-scopes=app-management,backups
 td auth token
 td auth status
 td auth logout
 \`\`\`
 
-\`--app-management\` adds the \`dev:app_console\` OAuth scope to the requested grant. Combine with \`--read-only\` to keep data access read-only while still gaining app-management access. Granting this scope is opt-in because it allows the token to manage your registered Todoist apps (rotate secrets, edit webhooks, etc.).
+Opt-in OAuth scopes are requested via \`--additional-scopes=<list>\` (comma-separated). Run \`td auth login --help\` for the full list. Currently supported:
 
-\`--backups\` adds the \`backups:read\` OAuth scope, required by \`td backup list\` and \`td backup download\`. It is opt-in for the same reason as \`--app-management\`: users who never pull backups should not grant access to them. Flags combine freely (e.g. \`td auth login --read-only --backups\`). When a backup command fails for lack of the scope, the error suggests a re-login command that preserves whichever flags were originally used.
+- \`app-management\` — adds the \`dev:app_console\` scope (manage your registered Todoist apps — rotate secrets, edit webhooks, etc.). Required by \`td apps list\` and \`td apps view\`.
+- \`backups\` — adds the \`backups:read\` scope (list and download Todoist backups). Required by \`td backup list\` and \`td backup download\`.
+
+Combine freely with \`--read-only\` to keep data access read-only while still granting an opt-in scope (e.g. \`td auth login --read-only --additional-scopes=backups\`). When a command fails for lack of a scope, the error suggests a re-login command that preserves whichever flags were originally used.
 
 Tokens are stored in the OS credential manager when available, with fallback to \`~/.config/todoist-cli/config.json\`. \`TODOIST_API_TOKEN\` takes precedence over stored credentials.
 
@@ -55,8 +59,8 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Collaboration: \`td comment ...\`, \`td notification ...\`, \`td reminder ...\`
 - Templates and files: \`td template ...\`, \`td attachment view <file-url>\`, \`td backup ...\`
 - Account and tooling: \`td stats\`, \`td settings ...\`, \`td completion ...\`, \`td view <todoist-url>\`, \`td doctor\`, \`td update\`, \`td changelog\`
-- Developer apps: \`td apps list/view\` (requires \`td auth login --app-management\`)
-- Backups: \`td backup list/download\` (requires \`td auth login --backups\`)
+- Developer apps: \`td apps list/view\` (requires \`td auth login --additional-scopes=app-management\`)
+- Backups: \`td backup list/download\` (requires \`td auth login --additional-scopes=backups\`)
 
 ## References
 
@@ -220,7 +224,7 @@ td backup list
 td backup download "2024-01-15_12:00" --output-file backup.zip
 \`\`\`
 
-The \`backup\` command surface requires the \`backups:read\` OAuth scope — re-run \`td auth login --backups\` to grant it. Without the scope, calls fail with an \`AUTH_ERROR\` whose hint preserves any previously used flags (e.g. a read-only user sees \`td auth login --read-only --backups\`).
+The \`backup\` command surface requires the \`backups:read\` OAuth scope — re-run \`td auth login --additional-scopes=backups\` to grant it. Without the scope, calls fail with an \`AUTH_ERROR\` whose hint preserves any previously used flags (e.g. a read-only user sees \`td auth login --read-only --additional-scopes=backups\`).
 
 ### Developer Apps
 \`\`\`bash
@@ -232,7 +236,7 @@ td apps view 9909
 td apps view id:9909 --json
 \`\`\`
 
-The \`apps\` command surface manages the user's registered Todoist developer apps (integrations). All \`apps\` subcommands require the \`dev:app_console\` OAuth scope — re-run \`td auth login --app-management\` to grant it. Without the scope, calls fail with a \`MISSING_SCOPE\` error pointing at the same hint.
+The \`apps\` command surface manages the user's registered Todoist developer apps (integrations). All \`apps\` subcommands require the \`dev:app_console\` OAuth scope — re-run \`td auth login --additional-scopes=app-management\` to grant it. Without the scope, calls fail with a \`MISSING_SCOPE\` error pointing at the same hint.
 
 \`td apps list\` plain output leads with the display name and follows it with \`(id:N)\` (self-describing in \`--accessible\` mode). \`--json\` / \`--ndjson\` dump the full app payload (id, displayName, status, userId, createdAt, serviceUrl, oauthRedirectUri, description, icons, appTokenScopes).
 


### PR DESCRIPTION
## Summary

Addresses [@henningmu's review feedback on #264](https://github.com/Doist/todoist-cli/pull/264#discussion_r3077573810): each new opt-in OAuth scope was getting its own top-level login flag (`--app-management`, `--backups`). That pattern doesn't scale. This PR replaces the two flags with one `--additional-scopes=<list>` (comma-separated), backed by a small registry so future scopes are additive — no new command surface when a new scope lands.

Two commits:

1. **feat(auth): replace per-scope flags with --additional-scopes** (`80b0099`)
   - New `src/lib/oauth-scopes.ts` registry with `ADDITIONAL_SCOPES`, `parseScopesOption`, and `formatScopesHelp` — one place to add future scopes.
   - `td auth login --help` now enumerates every supported scope with a one-line summary.
   - Unknown scopes fail fast with a friendly error listing valid options, *before* any browser opens.
   - `buildReloginCommand` emits the new syntax (preserves `--read-only` separately, bundles opt-ins into one `--additional-scopes=` arg).
   - SKILL.md, command help text (`td apps`, `td backup`), and the `MISSING_SCOPE` remediation strings all speak the new language.
   - `--read-only` stays separate — it swaps the base grant (`data:read_write` → `data:read`), it's not an additional scope.
   - Breaking change: `--app-management` and `--backups` are removed. Persisted `auth_flags` identifiers are unchanged, so existing configs keep working.

2. **feat(auth): personalise MISSING_SCOPE hint from stored auth flags** (`11af719`)
   - When a 403 `AUTH_INSUFFICIENT_TOKEN_SCOPE` fires, `wrapApiError` now reads `auth_flags` via `getAuthMetadata` and threads the required flag through `buildReloginCommand` — the same helper `fetchBackups` already uses for its proactive pre-flight check. Both paths now produce identical advice that preserves whichever scopes the user already holds.
   - Previously the hint was a static string: a read-only user hitting `td backup list` saw `td auth login --additional-scopes=backups`, silently dropping `--read-only`. Now they see `td auth login --read-only --additional-scopes=backups`.

## Examples

```
$ td auth login --help
...
  --read-only                   Authenticate with read-only scope (data:read)
  --additional-scopes <list>    Comma-separated opt-in OAuth scopes (see list below)

Available scopes (comma-separated for --additional-scopes):
  app-management  Manage your registered Todoist developer apps (rotate secrets, edit webhooks).
  backups         List and download your Todoist backups.

Examples:
  td auth login
  td auth login --read-only
  td auth login --additional-scopes=app-management
  td auth login --read-only --additional-scopes=backups
  td auth login --additional-scopes=app-management,backups
```

## Test plan

- [x] \`npm test\` — 1400 tests pass (up from 1368; new \`src/__tests__/oauth-scopes.test.ts\` covers \`parseScopesOption\` edge cases; existing tests updated for the new signatures)
- [x] \`npm run check\` — lint / format / type-check clean
- [x] \`npm run check:skill-sync\` — \`skills/todoist-cli/SKILL.md\` regenerated from \`content.ts\`
- [ ] Live smoke against a real account:
  - [ ] \`td auth login --help\` shows the scopes block
  - [ ] \`td auth login --additional-scopes=app-management\` → authorize URL contains \`dev:app_console\`; persisted \`auth_flags: ['app-management']\`
  - [ ] \`td auth login --read-only --additional-scopes=backups\` → combined scope \`data:read,backups:read\`
  - [ ] \`td auth login --additional-scopes=nonsense\` → friendly error, browser not opened
  - [ ] Space form also accepted: \`td auth login --additional-scopes app-management\` works
  - [ ] On a token missing the scope: \`td apps list\` surfaces a \`MISSING_SCOPE\` hint that preserves any prior flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)