### PR TITLE
feat(skill): add author/version metadata and keep in sync on release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@semantic-release/changelog": "6.0.3",
+        "@semantic-release/exec": "7.1.0",
         "@semantic-release/git": "10.0.1",
         "@types/node": "25.6.0",
         "conventional-changelog-conventionalcommits": "9.3.1",
@@ -2201,6 +2202,191 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/@semantic-release/exec": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-7.1.0.tgz",
+      "integrity": "sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^9.0.0",
+        "lodash-es": "^4.17.21",
+        "parse-json": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.8.1"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=24.1.0"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/@semantic-release/error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/git": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@semantic-release/changelog": "6.0.3",
+    "@semantic-release/exec": "7.1.0",
     "@semantic-release/git": "10.0.1",
     "@types/node": "25.6.0",
     "conventional-changelog-conventionalcommits": "9.3.1",

--- a/release.config.js
+++ b/release.config.js
@@ -14,13 +14,21 @@ export default {
         // Only update CHANGELOG.md and commit back on stable releases
         ...(isPrerelease ? [] : ['@semantic-release/changelog']),
         '@semantic-release/npm',
+        // Regenerate the committed SKILL.md so its version metadata matches the
+        // just-bumped package.json before @semantic-release/git commits it back.
+        ...(isPrerelease ? [] : [['@semantic-release/exec', { prepareCmd: 'npm run sync:skill' }]]),
         ...(isPrerelease
             ? []
             : [
                   [
                       '@semantic-release/git',
                       {
-                          assets: ['CHANGELOG.md', 'package.json', 'package-lock.json'],
+                          assets: [
+                              'CHANGELOG.md',
+                              'package.json',
+                              'package-lock.json',
+                              'skills/todoist-cli/SKILL.md',
+                          ],
                           message:
                               'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
                       },

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: todoist-cli
-description: "Manage Todoist tasks, projects, labels, comments, and more via the td CLI"
+description: "Manage Todoist tasks, projects, labels, filters, sections, comments, reminders, and workspaces via the `td` CLI. Use when the user wants to view, create, update, complete, or organize Todoist items, or mentions tasks, inbox, today, upcoming, projects, labels, or filters."
+compatibility: "Requires the td CLI (@doist/todoist-cli) to be installed and authenticated via 'td auth login'."
 license: MIT
 metadata:
   author: Doist
@@ -8,8 +9,6 @@ metadata:
 ---
 
 # Todoist CLI (td)
-
-Use this skill when the user wants to interact with their Todoist tasks.
 
 ## Core Patterns
 

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: todoist-cli
 description: "Manage Todoist tasks, projects, labels, comments, and more via the td CLI"
+license: MIT
+metadata:
+  author: Doist
+  version: "1.48.0"
 ---
 
 # Todoist CLI (td)

--- a/src/__tests__/skill.test.ts
+++ b/src/__tests__/skill.test.ts
@@ -223,9 +223,11 @@ describe('installer paths', () => {
         const content = skillInstallers['claude-code'].generateContent()
         expect(content).toContain('---')
         expect(content).toContain('name: todoist-cli')
-        expect(content).toContain(
-            'description: "Manage Todoist tasks, projects, labels, comments, and more via the td CLI"',
-        )
+        expect(content).toContain('description: "Manage Todoist tasks, projects, labels')
+        expect(content).toContain('Use when the user wants to view, create, update')
+        expect(content).toContain('compatibility: ')
+        expect(content).toContain('license: MIT')
+        expect(content).toContain('author: Doist')
         expect(content).toContain('# Todoist CLI (td)')
         expect(content).toContain('td today')
         expect(content).toContain('td task add')

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -1,10 +1,10 @@
 export const SKILL_NAME = 'todoist-cli'
 export const SKILL_DESCRIPTION =
-    'Manage Todoist tasks, projects, labels, comments, and more via the td CLI'
+    'Manage Todoist tasks, projects, labels, filters, sections, comments, reminders, and workspaces via the `td` CLI. Use when the user wants to view, create, update, complete, or organize Todoist items, or mentions tasks, inbox, today, upcoming, projects, labels, or filters.'
+export const SKILL_COMPATIBILITY =
+    "Requires the td CLI (@doist/todoist-cli) to be installed and authenticated via 'td auth login'."
 
 export const SKILL_CONTENT = `# Todoist CLI (td)
-
-Use this skill when the user wants to interact with their Todoist tasks.
 
 ## Core Patterns
 

--- a/src/lib/skills/create-installer.ts
+++ b/src/lib/skills/create-installer.ts
@@ -1,6 +1,7 @@
 import { access, mkdir, readdir, rmdir, unlink, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
+import packageJson from '../../../package.json' with { type: 'json' }
 import { CliError } from '../errors.js'
 import { SKILL_CONTENT, SKILL_DESCRIPTION, SKILL_NAME } from './content.js'
 import type { SkillInstaller } from './types.js'
@@ -15,6 +16,10 @@ export function generateSkillFile(): string {
     const frontmatter = `---
 name: ${SKILL_NAME}
 description: ${JSON.stringify(SKILL_DESCRIPTION)}
+license: MIT
+metadata:
+  author: Doist
+  version: ${JSON.stringify(packageJson.version)}
 ---
 
 `

--- a/src/lib/skills/create-installer.ts
+++ b/src/lib/skills/create-installer.ts
@@ -17,7 +17,7 @@ export function generateSkillFile(): string {
 name: ${SKILL_NAME}
 description: ${JSON.stringify(SKILL_DESCRIPTION)}
 compatibility: ${JSON.stringify(SKILL_COMPATIBILITY)}
-license: MIT
+license: ${packageJson.license}
 metadata:
   author: Doist
   version: ${JSON.stringify(packageJson.version)}

--- a/src/lib/skills/create-installer.ts
+++ b/src/lib/skills/create-installer.ts
@@ -3,7 +3,7 @@ import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import packageJson from '../../../package.json' with { type: 'json' }
 import { CliError } from '../errors.js'
-import { SKILL_CONTENT, SKILL_DESCRIPTION, SKILL_NAME } from './content.js'
+import { SKILL_COMPATIBILITY, SKILL_CONTENT, SKILL_DESCRIPTION, SKILL_NAME } from './content.js'
 import type { SkillInstaller } from './types.js'
 
 interface InstallerConfig {
@@ -16,6 +16,7 @@ export function generateSkillFile(): string {
     const frontmatter = `---
 name: ${SKILL_NAME}
 description: ${JSON.stringify(SKILL_DESCRIPTION)}
+compatibility: ${JSON.stringify(SKILL_COMPATIBILITY)}
 license: MIT
 metadata:
   author: Doist


### PR DESCRIPTION
## Summary
- Adds spec-compliant frontmatter metadata to the generated SKILL.md: `license: MIT` and a `metadata` block with `author: Doist` and a `version` sourced dynamically from `package.json`.
- Wires `@semantic-release/exec` into the release pipeline to run `npm run sync:skill` after `@semantic-release/npm` bumps the version, and includes `skills/todoist-cli/SKILL.md` in the `@semantic-release/git` assets — so the committed skill file never lags the package version and `check:skill-sync` stays green post-release.

## Test plan
- [x] `npm run check`
- [x] `npm test` (1411 tests pass)
- [x] `npm run sync:skill` regenerates `skills/todoist-cli/SKILL.md` cleanly
- [ ] Verify on the next stable release that the `chore(release)` commit includes the regenerated SKILL.md with the bumped version

🤖 Generated with [Claude Code](https://claude.com/claude-code)