### PR TITLE
ci(skill): validate skill against agentskills.io spec on PRs

### DIFF
--- a/.github/workflows/check-skill-sync.yml
+++ b/.github/workflows/check-skill-sync.yml
@@ -34,8 +34,8 @@ jobs:
               env:
                   GH_TOKEN: ${{ github.token }}
               run: |
-                  if ! gh skill --help >/dev/null 2>&1; then
-                      echo "::notice::gh skill subcommand not available on this runner (preview feature, gh >= 2.90.0); skipping validation."
+                  if ! gh skill publish --help >/dev/null 2>&1; then
+                      echo "::notice::gh skill publish not available on this runner (preview feature, gh >= 2.90.0); skipping validation."
                       exit 0
                   fi
                   gh skill publish --dry-run

--- a/.github/workflows/check-skill-sync.yml
+++ b/.github/workflows/check-skill-sync.yml
@@ -29,3 +29,13 @@ jobs:
 
             - name: Check SKILL.md is in sync
               run: npm run check:skill-sync
+
+            - name: Validate skill against agentskills.io spec
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  if ! gh skill --help >/dev/null 2>&1; then
+                      echo "::notice::gh skill subcommand not available on this runner (preview feature, gh >= 2.90.0); skipping validation."
+                      exit 0
+                  fi
+                  gh skill publish --dry-run


### PR DESCRIPTION
## Summary
- Adds a `gh skill publish --dry-run` step to the existing **Skill Sync Check** workflow so broken frontmatter, naming violations, or stripped install metadata are caught on PRs rather than surfacing at release time.
- Guards the step with a `gh skill --help` probe: if the subcommand isn't present on the runner (it is a preview feature in `gh >= 2.90.0`), the step emits a GitHub Actions notice and exits 0 instead of failing. Once ubuntu-latest catches up, the validation starts running automatically with no config change.

## Why this (and not a release-pipeline hook)?
`gh skill install` resolves to the latest tagged release in the repo, and our semantic-release flow already produces those tags plus the matching GitHub release. The `agent-skills` topic is already set. So no separate skill-publish step is needed — every CLI release is already the skill release.

## Test plan
- [ ] On this PR: confirm the **Skill Sync Check** job runs the new step and either validates cleanly or prints the "skipping validation" notice depending on the runner's `gh` version
- [ ] Optional local sanity check: `gh skill publish --dry-run` from the repo root reports `Dry run complete.` (already verified locally on gh 2.90.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)