### PR TITLE
feat: Add Help Center CLI commands

### DIFF
--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -62,6 +62,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Organization: `td label ...`, `td filter ...`, `td section ...`, `td workspace ...`
 - Collaboration: `td comment ...`, `td notification ...`, `td reminder ...`
 - Templates and files: `td template ...`, `td attachment view <file-url>`, `td backup ...`
+- Help Center: `td hc locales/search/view`
 - Account and tooling: `td stats`, `td settings ...`, `td completion ...`, `td view <todoist-url>`, `td doctor`, `td update`, `td changelog`
 - Developer apps: `td apps list/view` (requires `td auth login --additional-scopes=app-management`)
 - Backups: `td backup list/download` (requires `td auth login --additional-scopes=backups`)
@@ -212,6 +213,14 @@ td reminder location get id:456
 ```
 
 `td attachment view` prints text attachments directly and encodes binary content as base64. Use `--json` for metadata plus content.
+
+### Help Center
+```bash
+td hc
+td hc --help
+```
+
+`td hc` queries the Todoist online Help Center. Run `td hc --help` for locale discovery, article search, and article viewing details.
 
 ### Templates
 ```bash

--- a/src/commands/hc/hc.test.ts
+++ b/src/commands/hc/hc.test.ts
@@ -1,0 +1,309 @@
+import { Command } from 'commander'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../lib/browser.js', () => ({
+    openInBrowser: vi.fn(),
+}))
+
+import { openInBrowser } from '../../lib/browser.js'
+import { registerHelpCenterCommand } from './index.js'
+
+function createProgram() {
+    const program = new Command()
+    program.exitOverride()
+    registerHelpCenterCommand(program)
+    return program
+}
+
+function createJsonResponse(body: unknown, status = 200, statusText = 'OK'): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        statusText,
+        headers: { 'content-type': 'application/json' },
+    })
+}
+
+describe('hc command', () => {
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+    let fetchSpy: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        fetchSpy = vi.fn()
+        vi.stubGlobal('fetch', fetchSpy)
+    })
+
+    afterEach(() => {
+        consoleSpy.mockRestore()
+        vi.unstubAllGlobals()
+    })
+
+    it('searches the Help Center and prints article ids alongside results', async () => {
+        fetchSpy.mockResolvedValue(
+            createJsonResponse({
+                count: 1,
+                results: [
+                    {
+                        id: 360000269065,
+                        title: 'Manage your notifications in Todoist',
+                        html_url:
+                            'https://get.todoist.help/hc/en-us/articles/360000269065-manage-your-notifications',
+                        snippet: '...and web <em>notifications</em> are enabled by default...',
+                        body: '<p>Full HTML body should stay out of search output</p>',
+                    },
+                ],
+            }),
+        )
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'td', 'hc', 'search', 'notifications'])
+
+        const output = consoleSpy.mock.calls.map((call: [string]) => call[0]).join('\n')
+        expect(output).toContain('Manage your notifications in Todoist')
+        expect(output).toContain('id:360000269065')
+        expect(output).toContain(
+            'https://get.todoist.help/hc/en-us/articles/360000269065-manage-your-notifications',
+        )
+        expect(output).toContain('...and web notifications are enabled by default...')
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1)
+        expect(String(fetchSpy.mock.calls[0][0])).toContain(
+            '/api/v2/help_center/articles/search?query=notifications&locale=en-us&per_page=10',
+        )
+    })
+
+    it('returns bounded JSON search results without article bodies', async () => {
+        fetchSpy.mockResolvedValue(
+            createJsonResponse({
+                results: [
+                    {
+                        id: 205348301,
+                        title: 'Set reminders for your tasks',
+                        html_url:
+                            'https://get.todoist.help/hc/en-us/articles/205348301-set-reminders',
+                        snippet: '...send a push notification...',
+                        body: '<p>Full article body</p>',
+                    },
+                ],
+            }),
+        )
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'td', 'hc', 'search', 'reminders', '--json'])
+
+        const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string)
+        expect(parsed).toEqual([
+            {
+                id: '205348301',
+                title: 'Set reminders for your tasks',
+                htmlUrl: 'https://get.todoist.help/hc/en-us/articles/205348301-set-reminders',
+                snippet: '...send a push notification...',
+                locale: 'en-us',
+            },
+        ])
+    })
+
+    it('lists supported locales with names and the default marker', async () => {
+        fetchSpy
+            .mockResolvedValueOnce(
+                createJsonResponse({
+                    locales: ['en-us', 'es', 'pt-br'],
+                    default_locale: 'en-us',
+                }),
+            )
+            .mockResolvedValueOnce(
+                createJsonResponse({
+                    locales: [
+                        {
+                            locale: 'en-US',
+                            name: 'English',
+                            native_name: 'English (United States)',
+                            presentation_name: 'English (United States)',
+                            rtl: false,
+                        },
+                        {
+                            locale: 'es',
+                            name: 'Español',
+                            native_name: 'español',
+                            presentation_name: 'Spanish - español',
+                            rtl: false,
+                        },
+                        {
+                            locale: 'pt-BR',
+                            name: 'Português (Brasil)',
+                            native_name: 'português (Brasil)',
+                            presentation_name: 'Portuguese (Brazil) - português (Brasil)',
+                            rtl: false,
+                        },
+                    ],
+                }),
+            )
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'td', 'hc', 'locales'])
+
+        const output = consoleSpy.mock.calls.map((call: [string]) => call[0]).join('\n')
+        expect(output).toContain('Default locale: en-us')
+        expect(output).toContain('Supported locales:')
+        expect(output).toContain('en-us  English [default]')
+        expect(output).toContain('es  Español')
+        expect(output).toContain('pt-br  Português (Brasil)')
+    })
+
+    it('returns structured locale metadata with --json', async () => {
+        fetchSpy
+            .mockResolvedValueOnce(
+                createJsonResponse({
+                    locales: ['en-us', 'ja'],
+                    default_locale: 'en-us',
+                }),
+            )
+            .mockResolvedValueOnce(
+                createJsonResponse({
+                    locales: [
+                        {
+                            locale: 'en-US',
+                            name: 'English',
+                            native_name: 'English (United States)',
+                            presentation_name: 'English (United States)',
+                            rtl: false,
+                        },
+                        {
+                            locale: 'ja',
+                            name: '日本語 (Japanese)',
+                            native_name: '日本語',
+                            presentation_name: 'Japanese - 日本語',
+                            rtl: false,
+                        },
+                    ],
+                }),
+            )
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'td', 'hc', 'locales', '--json'])
+
+        expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toEqual({
+            defaultLocale: 'en-us',
+            locales: [
+                {
+                    locale: 'en-us',
+                    name: 'English',
+                    nativeName: 'English (United States)',
+                    presentationName: 'English (United States)',
+                    rtl: false,
+                    isDefault: true,
+                },
+                {
+                    locale: 'ja',
+                    name: '日本語 (Japanese)',
+                    nativeName: '日本語',
+                    presentationName: 'Japanese - 日本語',
+                    rtl: false,
+                    isDefault: false,
+                },
+            ],
+        })
+    })
+
+    it('views a raw article id and renders markdown output', async () => {
+        fetchSpy.mockResolvedValue(
+            createJsonResponse({
+                article: {
+                    id: 360000269065,
+                    title: 'Manage your notifications in Todoist',
+                    html_url:
+                        'https://get.todoist.help/hc/en-us/articles/360000269065-manage-your-notifications',
+                    body: '<p>Turn on <strong>web</strong> notifications.</p>',
+                },
+            }),
+        )
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'td', 'hc', 'view', '360000269065'])
+
+        expect(fetchSpy).toHaveBeenCalledWith(
+            'https://todoist.zendesk.com/api/v2/help_center/en-us/articles/360000269065',
+        )
+
+        const output = consoleSpy.mock.calls[0][0] as string
+        expect(output).toContain('# Manage your notifications in Todoist')
+        expect(output).toContain('Source: https://get.todoist.help/hc/en-us/articles/360000269065')
+        expect(output).toContain('Turn on **web** notifications.')
+    })
+
+    it('uses the provided URL directly for browser mode', async () => {
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'td',
+            'hc',
+            'view',
+            'https://get.todoist.help/hc/en-us/articles/360000269065-manage-your-notifications',
+            '--browser',
+        ])
+
+        expect(openInBrowser).toHaveBeenCalledWith(
+            'https://get.todoist.help/hc/en-us/articles/360000269065-manage-your-notifications',
+        )
+        expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('outputs the raw HTML body with --html', async () => {
+        const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+        fetchSpy.mockResolvedValue(
+            createJsonResponse({
+                article: {
+                    id: 205348301,
+                    title: 'Set reminders for your tasks',
+                    html_url: 'https://get.todoist.help/hc/en-us/articles/205348301-set-reminders',
+                    body: '<p>Full <strong>HTML</strong> body.</p>',
+                },
+            }),
+        )
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'td', 'hc', 'view', 'id:205348301', '--html'])
+
+        expect(stdoutSpy).toHaveBeenCalledWith('<p>Full <strong>HTML</strong> body.</p>')
+        stdoutSpy.mockRestore()
+    })
+
+    it('returns normalized article JSON with --json', async () => {
+        fetchSpy.mockResolvedValue(
+            createJsonResponse({
+                article: {
+                    id: 205348301,
+                    title: 'Set reminders for your tasks',
+                    html_url: 'https://get.todoist.help/hc/en-us/articles/205348301-set-reminders',
+                    body: '<p>Full article body</p>',
+                    updated_at: '2025-11-28T00:27:28Z',
+                    label_names: ['notification', 'reminders'],
+                },
+            }),
+        )
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'td', 'hc', 'view', '205348301', '--json'])
+
+        expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toEqual({
+            id: '205348301',
+            title: 'Set reminders for your tasks',
+            htmlUrl: 'https://get.todoist.help/hc/en-us/articles/205348301-set-reminders',
+            bodyHtml: '<p>Full article body</p>',
+            updatedAt: '2025-11-28T00:27:28Z',
+            labelNames: ['notification', 'reminders'],
+            locale: 'en-us',
+        })
+    })
+
+    it('errors on conflicting output modes', async () => {
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'td', 'hc', 'view', '205348301', '--json', '--browser']),
+        ).rejects.toMatchObject({
+            code: 'CONFLICTING_OPTIONS',
+        })
+    })
+})

--- a/src/commands/hc/index.ts
+++ b/src/commands/hc/index.ts
@@ -1,0 +1,62 @@
+import { Command } from 'commander'
+import { listHelpCenterLocales } from './locales.js'
+import { searchHelpCenterArticles } from './search.js'
+import { viewHelpCenterArticle } from './view.js'
+
+const LOCALE_OPTION_DESCRIPTION = 'Help Center locale (default: en-us)'
+
+export function registerHelpCenterCommand(program: Command): void {
+    const hc = program
+        .command('hc')
+        .description('Search Todoist Help Center articles')
+        .addHelpText(
+            'after',
+            `
+Examples:
+  td hc locales
+  td hc locales --json
+  td hc search "notifications"
+  td hc search "reminders" --locale pt-br --json
+  td hc view id:360000269065
+  td hc view 360000269065
+  td hc view https://get.todoist.help/hc/en-us/articles/360000269065
+
+Notes:
+  search prints real Help Center article IDs
+  view accepts id:N, raw article IDs, and Help Center URLs`,
+        )
+
+    hc.command('locales')
+        .description('List supported Help Center locales')
+        .option('--json', 'Output as JSON')
+        .action(listHelpCenterLocales)
+
+    const searchCmd = hc
+        .command('search [query]')
+        .description('Search Todoist Help Center articles')
+        .option('--locale <locale>', LOCALE_OPTION_DESCRIPTION)
+        .option('--limit <n>', 'Number of results to return (default: 10, max: 25)')
+        .option('--json', 'Output as JSON')
+        .action((query, options) => {
+            if (!query) {
+                searchCmd.help()
+                return
+            }
+            return searchHelpCenterArticles(query, options)
+        })
+
+    const viewCmd = hc
+        .command('view [ref]', { isDefault: true })
+        .description('View a Help Center article by id:N, raw article ID, or URL')
+        .option('--locale <locale>', LOCALE_OPTION_DESCRIPTION)
+        .option('--browser', 'Open the article in your browser')
+        .option('--json', 'Output as JSON')
+        .option('--html', 'Output the raw HTML article body')
+        .action((ref, options) => {
+            if (!ref) {
+                viewCmd.help()
+                return
+            }
+            return viewHelpCenterArticle(ref, options)
+        })
+}

--- a/src/commands/hc/locales.ts
+++ b/src/commands/hc/locales.ts
@@ -1,0 +1,30 @@
+import chalk from 'chalk'
+import { getHelpCenterLocales } from '../../lib/help-center.js'
+import { withSpinner } from '../../lib/spinner.js'
+
+export interface ListHelpCenterLocalesOptions {
+    json?: boolean
+}
+
+export async function listHelpCenterLocales(
+    options: ListHelpCenterLocalesOptions = {},
+): Promise<void> {
+    const result = await withSpinner(
+        { text: 'Loading Help Center locales...', color: 'blue' },
+        () => getHelpCenterLocales(),
+    )
+
+    if (options.json) {
+        console.log(JSON.stringify(result, null, 2))
+        return
+    }
+
+    console.log(`Default locale: ${result.defaultLocale}`)
+    console.log('')
+    console.log('Supported locales:')
+
+    for (const locale of result.locales) {
+        const defaultTag = locale.isDefault ? ` ${chalk.dim('[default]')}` : ''
+        console.log(`  ${locale.locale}  ${locale.name}${defaultTag}`)
+    }
+}

--- a/src/commands/hc/search.ts
+++ b/src/commands/hc/search.ts
@@ -1,0 +1,42 @@
+import chalk from 'chalk'
+import { normalizeHelpCenterLocale, searchHelpCenter } from '../../lib/help-center.js'
+import { withSpinner } from '../../lib/spinner.js'
+
+export interface SearchHelpCenterOptions {
+    json?: boolean
+    limit?: string
+    locale?: string
+}
+
+export async function searchHelpCenterArticles(
+    query: string,
+    options: SearchHelpCenterOptions = {},
+): Promise<void> {
+    const trimmedQuery = query.trim()
+    const locale = normalizeHelpCenterLocale(options.locale)
+    const results = await withSpinner({ text: 'Searching Help Center...', color: 'blue' }, () =>
+        searchHelpCenter(trimmedQuery, { locale, limit: options.limit }),
+    )
+
+    if (options.json) {
+        console.log(JSON.stringify(results, null, 2))
+        return
+    }
+
+    if (results.length === 0) {
+        console.log(`No Help Center articles found for "${trimmedQuery}".`)
+        return
+    }
+
+    for (const [index, result] of results.entries()) {
+        console.log(result.title)
+        console.log(`   ${chalk.dim(`id:${result.id}`)}`)
+        console.log(`   ${chalk.dim(result.htmlUrl)}`)
+        if (result.snippet) {
+            console.log(`   ${result.snippet}`)
+        }
+        if (index < results.length - 1) {
+            console.log('')
+        }
+    }
+}

--- a/src/commands/hc/view.ts
+++ b/src/commands/hc/view.ts
@@ -1,0 +1,59 @@
+import { openInBrowser } from '../../lib/browser.js'
+import { CliError } from '../../lib/errors.js'
+import {
+    formatHelpCenterArticleMarkdown,
+    getHelpCenterArticle,
+    resolveHelpCenterRef,
+} from '../../lib/help-center.js'
+import { renderMarkdown } from '../../lib/markdown.js'
+import { withSpinner } from '../../lib/spinner.js'
+
+export interface ViewHelpCenterOptions {
+    browser?: boolean
+    html?: boolean
+    json?: boolean
+    locale?: string
+}
+
+export async function viewHelpCenterArticle(
+    ref: string,
+    options: ViewHelpCenterOptions = {},
+): Promise<void> {
+    const selectedModes = [options.browser, options.html, options.json].filter(Boolean)
+    if (selectedModes.length > 1) {
+        throw new CliError(
+            'CONFLICTING_OPTIONS',
+            'Options --browser, --html, and --json are mutually exclusive.',
+            ['Choose one output mode, e.g. `td hc view id:360000269065 --json`.'],
+        )
+    }
+
+    const resolved = resolveHelpCenterRef(ref, { locale: options.locale })
+
+    if (options.browser && resolved.htmlUrl && !options.locale) {
+        await openInBrowser(resolved.htmlUrl)
+        return
+    }
+
+    const article = await withSpinner(
+        { text: 'Loading Help Center article...', color: 'blue' },
+        () => getHelpCenterArticle(resolved.articleId, { locale: resolved.locale }),
+    )
+
+    if (options.browser) {
+        await openInBrowser(article.htmlUrl)
+        return
+    }
+
+    if (options.json) {
+        console.log(JSON.stringify(article, null, 2))
+        return
+    }
+
+    if (options.html) {
+        process.stdout.write(article.bodyHtml)
+        return
+    }
+
+    console.log(await renderMarkdown(formatHelpCenterArticleMarkdown(article)))
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,10 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
         'Diagnose common CLI setup and environment issues',
         async () => (await import('./commands/doctor.js')).registerDoctorCommand,
     ],
+    hc: [
+        'Search Todoist Help Center articles',
+        async () => (await import('./commands/hc/index.js')).registerHelpCenterCommand,
+    ],
     today: [
         'Show tasks due today and overdue',
         async () => (await import('./commands/today.js')).registerTodayCommand,

--- a/src/lib/help-center.test.ts
+++ b/src/lib/help-center.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { htmlToMarkdown, resolveHelpCenterRef, sanitizeHelpCenterSnippet } from './help-center.js'
+
+describe('help center helpers', () => {
+    it('sanitizes snippets by stripping tags and decoding entities', () => {
+        expect(
+            sanitizeHelpCenterSnippet(
+                'Manage <em>notifications</em> &amp; reminders&nbsp;across <strong>devices</strong>.',
+            ),
+        ).toBe('Manage notifications & reminders across devices.')
+    })
+
+    it('converts article HTML into readable markdown', () => {
+        const markdown = htmlToMarkdown(`
+            <h1>Notifications &amp; reminders</h1>
+            <p>Turn on <strong>desktop</strong> alerts and visit <a href="https://example.com/settings">settings</a>.</p>
+            <ul>
+              <li>Review <em>web</em> notifications</li>
+              <li>Use <code>td hc view id:360000269065</code></li>
+            </ul>
+            <pre><code>td hc search "notifications"</code></pre>
+        `)
+
+        expect(markdown).toContain('# Notifications & reminders')
+        expect(markdown).toContain(
+            'Turn on **desktop** alerts and visit [settings](https://example.com/settings).',
+        )
+        expect(markdown).toContain('- Review *web* notifications')
+        expect(markdown).toContain('- Use `td hc view id:360000269065`')
+        expect(markdown).toContain('```')
+        expect(markdown).toContain('td hc search "notifications"')
+    })
+
+    it('resolves an explicit id: ref', () => {
+        expect(resolveHelpCenterRef('id:360000269065')).toEqual({
+            articleId: '360000269065',
+            locale: 'en-us',
+            source: 'id',
+        })
+    })
+
+    it('resolves a raw numeric article id', () => {
+        expect(resolveHelpCenterRef('205348301')).toEqual({
+            articleId: '205348301',
+            locale: 'en-us',
+            source: 'id',
+        })
+    })
+
+    it('resolves a Help Center URL', () => {
+        expect(
+            resolveHelpCenterRef(
+                'https://get.todoist.help/hc/en-us/articles/360000269065-manage-your-notifications',
+            ),
+        ).toEqual({
+            articleId: '360000269065',
+            htmlUrl:
+                'https://get.todoist.help/hc/en-us/articles/360000269065-manage-your-notifications',
+            locale: 'en-us',
+            source: 'url',
+        })
+    })
+
+    it('errors for non-id, non-url refs', () => {
+        expect(() => resolveHelpCenterRef('notifications')).toThrow(
+            'Invalid Help Center reference "notifications".',
+        )
+    })
+})

--- a/src/lib/help-center.ts
+++ b/src/lib/help-center.ts
@@ -1,0 +1,631 @@
+import { CliError } from './errors.js'
+
+const HELP_CENTER_SEARCH_URL = 'https://todoist.zendesk.com/api/v2/help_center/articles/search'
+const HELP_CENTER_ARTICLE_URL_BASE = 'https://todoist.zendesk.com/api/v2/help_center'
+const HELP_CENTER_LOCALES_URL = 'https://todoist.zendesk.com/api/v2/help_center/locales'
+const ACCOUNT_LOCALES_URL = 'https://todoist.zendesk.com/api/v2/locales.json'
+const HELP_CENTER_LOCALE_PATTERN = /^[a-z]{2}(?:-[a-z]{2})?$/
+
+export const DEFAULT_HELP_CENTER_LOCALE = 'en-us'
+export const DEFAULT_HELP_CENTER_LIMIT = 10
+export const MAX_HELP_CENTER_LIMIT = 25
+
+interface RawHelpCenterArticle {
+    id?: number | string
+    title?: string
+    html_url?: string
+    snippet?: string
+    body?: string
+    updated_at?: string
+    label_names?: unknown[]
+    locale?: string
+}
+
+interface RawHelpCenterSearchResponse {
+    results?: RawHelpCenterArticle[]
+}
+
+interface RawHelpCenterArticleResponse {
+    article?: RawHelpCenterArticle
+}
+
+interface RawHelpCenterLocalesResponse {
+    locales?: string[]
+    default_locale?: string
+}
+
+interface RawLocaleDefinition {
+    locale?: string
+    name?: string
+    native_name?: string
+    presentation_name?: string
+    rtl?: boolean
+}
+
+interface RawLocalesResponse {
+    locales?: RawLocaleDefinition[]
+}
+
+export interface HelpCenterSearchResult {
+    id: string
+    title: string
+    htmlUrl: string
+    snippet: string
+    locale: string
+}
+
+export interface HelpCenterArticle {
+    id: string
+    title: string
+    htmlUrl: string
+    bodyHtml: string
+    updatedAt?: string
+    labelNames: string[]
+    locale: string
+}
+
+export interface HelpCenterLocale {
+    locale: string
+    name: string
+    nativeName?: string
+    presentationName?: string
+    rtl: boolean
+    isDefault: boolean
+}
+
+export interface HelpCenterLocales {
+    defaultLocale: string
+    locales: HelpCenterLocale[]
+}
+
+export interface ResolveHelpCenterRefOptions {
+    locale?: string
+}
+
+export interface ResolvedHelpCenterRef {
+    articleId: string
+    locale: string
+    htmlUrl?: string
+    source: 'id' | 'url'
+}
+
+const NAMED_HTML_ENTITIES: Record<string, string> = {
+    amp: '&',
+    apos: "'",
+    copy: '©',
+    gt: '>',
+    hellip: '...',
+    ldquo: '"',
+    lsquo: "'",
+    lt: '<',
+    mdash: '--',
+    nbsp: ' ',
+    ndash: '-',
+    quot: '"',
+    rdquo: '"',
+    rsquo: "'",
+}
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error)
+}
+
+function collapseWhitespace(value: string): string {
+    return value.replace(/\s+/g, ' ').trim()
+}
+
+function tightenPunctuationSpacing(value: string): string {
+    return value.replace(/\s+([,.;:!?])/g, '$1')
+}
+
+function normalizeMarkdownWhitespace(value: string): string {
+    return tightenPunctuationSpacing(
+        value
+            .replace(/\r/g, '')
+            .replace(/[ \t]+\n/g, '\n')
+            .replace(/\n[ \t]+/g, '\n')
+            .replace(/[ \t]{2,}/g, ' ')
+            .replace(/\n{3,}/g, '\n\n')
+            .trim(),
+    )
+}
+
+function removeHtmlTags(value: string): string {
+    return value.replace(/<[^>]+>/g, ' ')
+}
+
+function getArticleFallbackUrl(locale: string, articleId: string): string {
+    return `https://get.todoist.help/hc/${locale}/articles/${articleId}`
+}
+
+function normalizeArticleId(value: string): string {
+    const trimmed = value.trim()
+    if (!/^\d+$/.test(trimmed)) {
+        throw new CliError('INVALID_REF', `Invalid Help Center reference "${value}".`, [
+            'Use `id:360000269065`, a raw numeric article ID, or a Help Center URL.',
+        ])
+    }
+    return trimmed
+}
+
+async function fetchHelpCenterJson<T>(url: string): Promise<{ response: Response; data: T }> {
+    let response: Response
+    try {
+        response = await fetch(url)
+    } catch (error) {
+        throw new CliError('FETCH_FAILED', `Help Center request failed: ${errorMessage(error)}`)
+    }
+
+    let data: T
+    try {
+        data = (await response.json()) as T
+    } catch (error) {
+        throw new CliError(
+            'FETCH_FAILED',
+            `Help Center request returned invalid JSON: ${errorMessage(error)}`,
+        )
+    }
+
+    return { response, data }
+}
+
+function renderInlineHtml(fragment: string): string {
+    let rendered = fragment
+        .replace(/<!--[\s\S]*?-->/g, '')
+        .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, '')
+        .replace(/<br\s*\/?>/gi, '\n')
+
+    rendered = rendered.replace(
+        /<a\b[^>]*href=(['"])(.*?)\1[^>]*>([\s\S]*?)<\/a>/gi,
+        (_match, _quote: string, href: string, inner: string) => {
+            const label = renderInlineHtml(inner).replace(/\n+/g, ' ').trim()
+            const cleanHref = decodeHtmlEntities(href)
+            return label ? `[${label}](${cleanHref})` : cleanHref
+        },
+    )
+
+    rendered = rendered.replace(
+        /<(strong|b)[^>]*>([\s\S]*?)<\/\1>/gi,
+        (_match, _tag: string, inner: string) => {
+            const value = renderInlineHtml(inner).replace(/\n+/g, ' ').trim()
+            return value ? `**${value}**` : ''
+        },
+    )
+
+    rendered = rendered.replace(
+        /<(em|i)[^>]*>([\s\S]*?)<\/\1>/gi,
+        (_match, _tag: string, inner: string) => {
+            const value = renderInlineHtml(inner).replace(/\n+/g, ' ').trim()
+            return value ? `*${value}*` : ''
+        },
+    )
+
+    rendered = rendered.replace(/<code[^>]*>([\s\S]*?)<\/code>/gi, (_match, inner: string) => {
+        const value = collapseWhitespace(decodeHtmlEntities(removeHtmlTags(inner)))
+        return value ? `\`${value}\`` : ''
+    })
+
+    rendered = rendered.replace(/<[^>]+>/g, '')
+    rendered = decodeHtmlEntities(rendered)
+    rendered = rendered.replace(/\u00a0/g, ' ')
+    rendered = rendered.replace(/[ \t]+\n/g, '\n').replace(/\n[ \t]+/g, '\n')
+    return tightenPunctuationSpacing(rendered.replace(/[ \t]{2,}/g, ' '))
+}
+
+function renderList(kind: 'ol' | 'ul', inner: string): string {
+    let index = 0
+    const items = Array.from(inner.matchAll(/<li[^>]*>([\s\S]*?)<\/li>/gi))
+    if (items.length === 0) {
+        return htmlToMarkdown(inner)
+    }
+
+    return items
+        .map((match) => {
+            index += 1
+            const itemHtml = match[1]
+            const body =
+                /<(p|div|section|article|header|footer|aside|ul|ol|blockquote|pre|h[1-6])\b/i.test(
+                    itemHtml,
+                )
+                    ? htmlToMarkdown(itemHtml).trim()
+                    : renderInlineHtml(itemHtml).trim()
+            if (!body) return ''
+
+            const lines = body.split('\n')
+            const marker = kind === 'ol' ? `${index}.` : '-'
+            return [marker + ' ' + lines[0], ...lines.slice(1).map((line) => `  ${line}`)].join(
+                '\n',
+            )
+        })
+        .filter(Boolean)
+        .join('\n')
+}
+
+function normalizeRawLocale(rawLocale: string | undefined, fallbackLocale: string): string {
+    if (!rawLocale) return fallbackLocale
+    try {
+        return normalizeHelpCenterLocale(rawLocale)
+    } catch {
+        return fallbackLocale
+    }
+}
+
+function normalizeSearchResult(
+    rawResult: RawHelpCenterArticle,
+    fallbackLocale: string,
+): HelpCenterSearchResult | null {
+    if (rawResult.id === undefined || rawResult.id === null || !rawResult.title) {
+        return null
+    }
+
+    const articleId = String(rawResult.id)
+    const locale = normalizeRawLocale(rawResult.locale, fallbackLocale)
+    return {
+        id: articleId,
+        title: rawResult.title,
+        htmlUrl: rawResult.html_url || getArticleFallbackUrl(locale, articleId),
+        snippet: sanitizeHelpCenterSnippet(rawResult.snippet ?? ''),
+        locale,
+    }
+}
+
+function normalizeLocaleDefinition(rawLocale: RawLocaleDefinition): HelpCenterLocale | null {
+    if (!rawLocale.locale) {
+        return null
+    }
+
+    return {
+        locale: String(rawLocale.locale).toLowerCase(),
+        name: rawLocale.name || String(rawLocale.locale),
+        nativeName: rawLocale.native_name,
+        presentationName: rawLocale.presentation_name,
+        rtl: rawLocale.rtl ?? false,
+        isDefault: false,
+    }
+}
+
+function normalizeArticle(
+    rawArticle: RawHelpCenterArticle,
+    fallbackLocale: string,
+    requestedArticleId: string,
+): HelpCenterArticle {
+    const locale = normalizeRawLocale(rawArticle.locale, fallbackLocale)
+    const articleId =
+        rawArticle.id !== undefined && rawArticle.id !== null
+            ? String(rawArticle.id)
+            : requestedArticleId
+
+    return {
+        id: articleId,
+        title: rawArticle.title || `Article ${articleId}`,
+        htmlUrl: rawArticle.html_url || getArticleFallbackUrl(locale, articleId),
+        bodyHtml: rawArticle.body ?? '',
+        updatedAt: rawArticle.updated_at,
+        labelNames: Array.isArray(rawArticle.label_names)
+            ? rawArticle.label_names
+                  .map((value) => (typeof value === 'string' ? value : null))
+                  .filter((value): value is string => Boolean(value))
+            : [],
+        locale,
+    }
+}
+
+export function normalizeHelpCenterLocale(locale = DEFAULT_HELP_CENTER_LOCALE): string {
+    const normalized = locale.trim().toLowerCase()
+    if (!HELP_CENTER_LOCALE_PATTERN.test(normalized)) {
+        throw new CliError('INVALID_OPTIONS', `Invalid Help Center locale "${locale}".`, [
+            'Use values like `en-us`, `es`, `de`, `fr`, `ja`, or `pt-br`.',
+        ])
+    }
+    return normalized
+}
+
+export function parseHelpCenterLimit(limit: number | string | undefined): number {
+    if (limit === undefined) return DEFAULT_HELP_CENTER_LIMIT
+
+    const parsed = typeof limit === 'number' ? limit : Number.parseInt(String(limit).trim(), 10)
+
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_HELP_CENTER_LIMIT) {
+        throw new CliError(
+            'INVALID_OPTIONS',
+            `Option --limit must be an integer between 1 and ${MAX_HELP_CENTER_LIMIT}.`,
+            ['Example: `td hc search "notifications" --limit 5`'],
+        )
+    }
+
+    return parsed
+}
+
+export function decodeHtmlEntities(value: string): string {
+    return value.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (entity, raw) => {
+        const token = String(raw)
+        if (token.startsWith('#x') || token.startsWith('#X')) {
+            const codePoint = Number.parseInt(token.slice(2), 16)
+            return Number.isNaN(codePoint) ? entity : String.fromCodePoint(codePoint)
+        }
+        if (token.startsWith('#')) {
+            const codePoint = Number.parseInt(token.slice(1), 10)
+            return Number.isNaN(codePoint) ? entity : String.fromCodePoint(codePoint)
+        }
+
+        const decoded = NAMED_HTML_ENTITIES[token.toLowerCase()]
+        return decoded ?? entity
+    })
+}
+
+export function sanitizeHelpCenterSnippet(snippet: string): string {
+    return tightenPunctuationSpacing(
+        collapseWhitespace(decodeHtmlEntities(removeHtmlTags(snippet))),
+    )
+}
+
+export function htmlToMarkdown(html: string): string {
+    let rendered = html
+        .replace(/\r/g, '')
+        .replace(/<!--[\s\S]*?-->/g, '')
+        .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, '')
+
+    rendered = rendered.replace(
+        /<pre[^>]*>\s*<code[^>]*>([\s\S]*?)<\/code>\s*<\/pre>/gi,
+        (_match, inner: string) => {
+            const code = decodeHtmlEntities(removeHtmlTags(inner)).trim()
+            return code ? `\n\n\`\`\`\n${code}\n\`\`\`\n\n` : '\n\n'
+        },
+    )
+
+    rendered = rendered.replace(/<pre[^>]*>([\s\S]*?)<\/pre>/gi, (_match, inner: string) => {
+        const code = decodeHtmlEntities(removeHtmlTags(inner)).trim()
+        return code ? `\n\n\`\`\`\n${code}\n\`\`\`\n\n` : '\n\n'
+    })
+
+    rendered = rendered.replace(
+        /<blockquote[^>]*>([\s\S]*?)<\/blockquote>/gi,
+        (_match, inner: string) => {
+            const body = htmlToMarkdown(inner)
+            if (!body) return '\n\n'
+            return (
+                '\n\n' +
+                body
+                    .split('\n')
+                    .map((line) => (line ? `> ${line}` : '>'))
+                    .join('\n') +
+                '\n\n'
+            )
+        },
+    )
+
+    rendered = rendered.replace(
+        /<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi,
+        (_match, level: string, inner: string) => {
+            const heading = renderInlineHtml(inner).replace(/\n+/g, ' ').trim()
+            return heading ? `\n\n${'#'.repeat(Number(level))} ${heading}\n\n` : '\n\n'
+        },
+    )
+
+    rendered = rendered.replace(
+        /<(ul|ol)[^>]*>([\s\S]*?)<\/\1>/gi,
+        (_match, kind: string, inner: string) => {
+            const list = renderList(kind.toLowerCase() as 'ol' | 'ul', inner)
+            return list ? `\n\n${list}\n\n` : '\n\n'
+        },
+    )
+
+    rendered = rendered.replace(
+        /<(p|div|section|article|header|footer|aside)[^>]*>([\s\S]*?)<\/\1>/gi,
+        (_match, _tag: string, inner: string) => {
+            const body = renderInlineHtml(inner).trim()
+            return body ? `\n\n${body}\n\n` : '\n\n'
+        },
+    )
+
+    rendered = rendered.replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, (_match, inner: string) => {
+        const body = renderInlineHtml(inner).trim()
+        return body ? `\n- ${body}\n` : '\n'
+    })
+
+    rendered = rendered.replace(/<br\s*\/?>/gi, '\n')
+    rendered = rendered.replace(/<[^>]+>/g, '')
+    rendered = decodeHtmlEntities(rendered).replace(/\u00a0/g, ' ')
+
+    return normalizeMarkdownWhitespace(rendered)
+}
+
+export function formatHelpCenterArticleMarkdown(article: HelpCenterArticle): string {
+    const lines = [`# ${article.title}`, '', `Source: ${article.htmlUrl}`]
+    const body = htmlToMarkdown(article.bodyHtml)
+
+    if (body) {
+        lines.push('', body)
+    }
+
+    return lines.join('\n').trim()
+}
+
+export function parseHelpCenterArticleUrl(
+    ref: string,
+): { articleId: string; locale?: string; htmlUrl: string } | null {
+    let url: URL
+    try {
+        url = new URL(ref)
+    } catch {
+        return null
+    }
+
+    const hostname = url.hostname.toLowerCase()
+    if (hostname !== 'get.todoist.help' && hostname !== 'todoist.zendesk.com') {
+        return null
+    }
+
+    const htmlMatch = url.pathname.match(/\/hc\/([^/]+)\/articles\/(\d+)/i)
+    if (htmlMatch) {
+        return {
+            articleId: htmlMatch[2],
+            locale: htmlMatch[1].toLowerCase(),
+            htmlUrl: url.toString(),
+        }
+    }
+
+    const apiMatch = url.pathname.match(/\/api\/v2\/help_center\/([^/]+)\/articles\/(\d+)/i)
+    if (apiMatch) {
+        return {
+            articleId: apiMatch[2],
+            locale: apiMatch[1].toLowerCase(),
+            htmlUrl: getArticleFallbackUrl(apiMatch[1].toLowerCase(), apiMatch[2]),
+        }
+    }
+
+    return null
+}
+
+export async function searchHelpCenter(
+    query: string,
+    options: { locale?: string; limit?: number | string } = {},
+): Promise<HelpCenterSearchResult[]> {
+    const trimmedQuery = query.trim()
+    if (!trimmedQuery) {
+        throw new CliError('MISSING_NAME', 'Help Center search query is required.', [
+            'Example: `td hc search "notifications"`',
+        ])
+    }
+
+    const locale = normalizeHelpCenterLocale(options.locale)
+    const limit = parseHelpCenterLimit(options.limit)
+    const url = new URL(HELP_CENTER_SEARCH_URL)
+    url.searchParams.set('query', trimmedQuery)
+    url.searchParams.set('locale', locale)
+    url.searchParams.set('per_page', String(limit))
+
+    const { response, data } = await fetchHelpCenterJson<RawHelpCenterSearchResponse>(
+        url.toString(),
+    )
+    if (!response.ok) {
+        throw new CliError(
+            'FETCH_FAILED',
+            `Failed to search the Help Center: ${response.status} ${response.statusText}`,
+        )
+    }
+
+    return (data.results ?? [])
+        .map((result) => normalizeSearchResult(result, locale))
+        .filter((result): result is HelpCenterSearchResult => Boolean(result))
+}
+
+export async function getHelpCenterArticle(
+    articleId: string,
+    options: { locale?: string } = {},
+): Promise<HelpCenterArticle> {
+    const normalizedArticleId = normalizeArticleId(articleId)
+    const locale = normalizeHelpCenterLocale(options.locale)
+    const url = `${HELP_CENTER_ARTICLE_URL_BASE}/${locale}/articles/${normalizedArticleId}`
+
+    const { response, data } = await fetchHelpCenterJson<RawHelpCenterArticleResponse>(url)
+    if (response.status === 404) {
+        throw new CliError('NOT_FOUND', `Help Center article ${normalizedArticleId} not found.`)
+    }
+    if (!response.ok) {
+        throw new CliError(
+            'FETCH_FAILED',
+            `Failed to fetch Help Center article ${normalizedArticleId}: ${response.status} ${response.statusText}`,
+        )
+    }
+    if (!data.article) {
+        throw new CliError(
+            'FETCH_FAILED',
+            `Help Center article ${normalizedArticleId} returned an invalid response.`,
+        )
+    }
+
+    return normalizeArticle(data.article, locale, normalizedArticleId)
+}
+
+export async function getHelpCenterLocales(): Promise<HelpCenterLocales> {
+    const { response, data } =
+        await fetchHelpCenterJson<RawHelpCenterLocalesResponse>(HELP_CENTER_LOCALES_URL)
+    if (!response.ok) {
+        throw new CliError(
+            'FETCH_FAILED',
+            `Failed to fetch Help Center locales: ${response.status} ${response.statusText}`,
+        )
+    }
+
+    const defaultLocale = normalizeHelpCenterLocale(
+        data.default_locale ?? DEFAULT_HELP_CENTER_LOCALE,
+    )
+    const supportedLocales = Array.isArray(data.locales)
+        ? data.locales.map((locale) => normalizeHelpCenterLocale(locale))
+        : []
+
+    let localeDetails = new Map<string, HelpCenterLocale>()
+    try {
+        const detailResult = await fetchHelpCenterJson<RawLocalesResponse>(ACCOUNT_LOCALES_URL)
+        if (detailResult.response.ok && Array.isArray(detailResult.data.locales)) {
+            localeDetails = new Map(
+                detailResult.data.locales
+                    .map((locale) => normalizeLocaleDefinition(locale))
+                    .filter((locale): locale is HelpCenterLocale => Boolean(locale))
+                    .map((locale) => [locale.locale, locale]),
+            )
+        }
+    } catch {
+        // Fallback to bare locale codes when the enrichment endpoint is unavailable.
+    }
+
+    return {
+        defaultLocale,
+        locales: supportedLocales.map((locale) => {
+            const detail = localeDetails.get(locale)
+            return {
+                locale,
+                name: detail?.name ?? locale,
+                nativeName: detail?.nativeName,
+                presentationName: detail?.presentationName,
+                rtl: detail?.rtl ?? false,
+                isDefault: locale === defaultLocale,
+            }
+        }),
+    }
+}
+
+export function resolveHelpCenterRef(
+    ref: string,
+    options: ResolveHelpCenterRefOptions = {},
+): ResolvedHelpCenterRef {
+    const trimmed = ref.trim()
+    if (!trimmed) {
+        throw new CliError('INVALID_REF', 'Help Center article reference is required.', [
+            'Use an article ID or a Help Center URL.',
+        ])
+    }
+
+    const explicitLocale = options.locale ? normalizeHelpCenterLocale(options.locale) : undefined
+    const urlRef = parseHelpCenterArticleUrl(trimmed)
+    if (urlRef) {
+        return {
+            articleId: urlRef.articleId,
+            locale: explicitLocale ?? urlRef.locale ?? DEFAULT_HELP_CENTER_LOCALE,
+            htmlUrl: urlRef.htmlUrl,
+            source: 'url',
+        }
+    }
+
+    if (trimmed.startsWith('id:')) {
+        const articleId = normalizeArticleId(trimmed.slice(3))
+        return {
+            articleId,
+            locale: explicitLocale ?? DEFAULT_HELP_CENTER_LOCALE,
+            source: 'id',
+        }
+    }
+
+    if (/^[1-9]\d*$/.test(trimmed)) {
+        return {
+            articleId: trimmed,
+            locale: explicitLocale ?? DEFAULT_HELP_CENTER_LOCALE,
+            source: 'id',
+        }
+    }
+
+    throw new CliError('INVALID_REF', `Invalid Help Center reference "${ref}".`, [
+        'Use `id:360000269065`, a raw numeric article ID, or a Help Center URL.',
+    ])
+}

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -58,6 +58,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Organization: \`td label ...\`, \`td filter ...\`, \`td section ...\`, \`td workspace ...\`
 - Collaboration: \`td comment ...\`, \`td notification ...\`, \`td reminder ...\`
 - Templates and files: \`td template ...\`, \`td attachment view <file-url>\`, \`td backup ...\`
+- Help Center: \`td hc locales/search/view\`
 - Account and tooling: \`td stats\`, \`td settings ...\`, \`td completion ...\`, \`td view <todoist-url>\`, \`td doctor\`, \`td update\`, \`td changelog\`
 - Developer apps: \`td apps list/view\` (requires \`td auth login --additional-scopes=app-management\`)
 - Backups: \`td backup list/download\` (requires \`td auth login --additional-scopes=backups\`)
@@ -208,6 +209,14 @@ td reminder location get id:456
 \`\`\`
 
 \`td attachment view\` prints text attachments directly and encodes binary content as base64. Use \`--json\` for metadata plus content.
+
+### Help Center
+\`\`\`bash
+td hc
+td hc --help
+\`\`\`
+
+\`td hc\` queries the Todoist online Help Center. Run \`td hc --help\` for locale discovery, article search, and article viewing details.
 
 ### Templates
 \`\`\`bash


### PR DESCRIPTION
## Summary

- add a new `td hc` top-level command with `locales`, `search`, and default `view` subcommands for Todoist Help Center articles
- keep article lookup stateless by resolving `view` refs from `id:N`, raw numeric article IDs, or Help Center URLs, and expose supported locales via `td hc locales --json`
- add Help Center fetch/formatting helpers, test coverage, and the corresponding skill/help documentation updates

## Demo

Opening the content of https://www.todoist.com/help/articles/use-task-quick-add-in-todoist-va4Lhpzz

<img width="868" height="738" alt="CleanShot 2026-04-20 at 08 48 29" src="https://github.com/user-attachments/assets/d678b169-7827-4b2b-ac42-c30047e0984b" />
