### PR TITLE
feat(config): add `td config view` to inspect the CLI config file

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -46,7 +46,7 @@ src/
 │  ├─ task/, project/, label/, comment/, section/, filter/,
 │  │  reminder/, workspace/, folder/, notification/, template/,
 │  │  backup/, apps/, stats/, completed/, auth/, settings/,
-│  │  skill/, hc/, completion/, update/
+│  │  config/, skill/, hc/, completion/, update/
 │  └─ *.test.ts           # Co-located tests
 ├─ lib/                   # Shared utilities. See catalog — don't reimplement.
 │  ├─ api/                # SDK wrapper + typed helpers (core, filters, workspaces,

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -63,7 +63,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Collaboration: `td comment ...`, `td notification ...`, `td reminder ...`
 - Templates and files: `td template ...`, `td attachment view <file-url>`, `td backup ...`
 - Help Center: `td hc locales/search/view`
-- Account and tooling: `td stats`, `td settings ...`, `td completion ...`, `td view <todoist-url>`, `td doctor`, `td update`, `td changelog`
+- Account and tooling: `td stats`, `td settings ...`, `td config view`, `td completion ...`, `td view <todoist-url>`, `td doctor`, `td update`, `td changelog`
 - Developer apps: `td apps list/view` (requires `td auth login --additional-scopes=app-management`)
 - Backups: `td backup list/download` (requires `td auth login --additional-scopes=backups`)
 
@@ -280,6 +280,10 @@ td stats vacation --on
 td settings view
 td settings update --timezone "America/New_York" --time-format 24 --date-format intl
 td settings themes
+
+td config view
+td config view --json
+td config view --show-token
 
 td completion install zsh
 td completion uninstall

--- a/src/commands/config/config.test.ts
+++ b/src/commands/config/config.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/config.js', () => ({
     CONFIG_PATH: '/tmp/fake-todoist-cli/config.json',
-    readConfig: vi.fn(),
+    readConfigStrict: vi.fn(),
 }))
 
 vi.mock('../../lib/auth.js', async () => {
@@ -17,10 +17,12 @@ vi.mock('../../lib/auth.js', async () => {
 vi.mock('chalk')
 
 import { NoTokenError, probeApiToken } from '../../lib/auth.js'
-import { type Config, readConfig } from '../../lib/config.js'
+import { type Config, readConfigStrict } from '../../lib/config.js'
+import { CliError } from '../../lib/errors.js'
+import { SecureStoreUnavailableError } from '../../lib/secure-store.js'
 import { registerConfigCommand } from './index.js'
 
-const mockReadConfig = vi.mocked(readConfig)
+const mockReadConfigStrict = vi.mocked(readConfigStrict)
 const mockProbeApiToken = vi.mocked(probeApiToken)
 
 function createProgram() {
@@ -39,10 +41,31 @@ const fullConfig: Config = {
     hc: { defaultLocale: 'en-us' },
 }
 
-function mockToken(source: 'env' | 'secure-store' | 'config-file', token = fullConfig.api_token!) {
+function presentConfig(config: Config = fullConfig) {
+    mockReadConfigStrict.mockResolvedValue({ state: 'present', config })
+}
+
+function missingConfig() {
+    mockReadConfigStrict.mockResolvedValue({ state: 'missing' })
+}
+
+function mockToken(
+    source: 'env' | 'secure-store' | 'config-file',
+    overrides: Partial<{
+        token: string
+        authMode: 'read-only' | 'read-write' | 'unknown'
+        authScope?: string
+        authFlags?: ('read-only' | 'app-management' | 'backups')[]
+    }> = {},
+) {
     mockProbeApiToken.mockResolvedValue({
-        token,
-        metadata: { authMode: 'read-write', source },
+        token: overrides.token ?? fullConfig.api_token!,
+        metadata: {
+            authMode: overrides.authMode ?? 'read-write',
+            authScope: overrides.authScope,
+            authFlags: overrides.authFlags,
+            source,
+        },
     })
 }
 
@@ -52,8 +75,11 @@ describe('config view', () => {
     })
 
     it('prints a pretty layout with the token masked by default', async () => {
-        mockReadConfig.mockResolvedValue(fullConfig)
-        mockToken('config-file')
+        presentConfig()
+        mockToken('config-file', {
+            authScope: 'data:read,data:delete',
+            authFlags: ['app-management'],
+        })
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view'])
@@ -73,8 +99,8 @@ describe('config view', () => {
     })
 
     it('labels tokens stored in the system credential manager', async () => {
-        mockReadConfig.mockResolvedValue({ auth_mode: 'read-write' })
-        mockToken('secure-store', 'tdo_keychainXXXXXXXX1234')
+        presentConfig({ auth_mode: 'read-write' })
+        mockToken('secure-store', { token: 'tdo_keychainXXXXXXXX1234' })
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view'])
@@ -87,9 +113,15 @@ describe('config view', () => {
         consoleSpy.mockRestore()
     })
 
-    it('labels tokens coming from the environment variable', async () => {
-        mockReadConfig.mockResolvedValue({})
-        mockToken('env', 'tdo_envXXXXXXXX5678')
+    it('labels env-sourced tokens and shows active mode, not stale config values', async () => {
+        // Config has a stale read-only entry from a previous `td auth login`,
+        // but TODOIST_API_TOKEN is now driving auth with an unknown scope.
+        presentConfig({
+            auth_mode: 'read-only',
+            auth_scope: 'data:read',
+            auth_flags: ['read-only'],
+        })
+        mockToken('env', { token: 'tdo_envXXXXXXXX5678', authMode: 'unknown' })
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view'])
@@ -97,13 +129,31 @@ describe('config view', () => {
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('****…5678')
         expect(output).toContain('TODOIST_API_TOKEN')
+        // Active mode is unknown (env scope isn't introspectable), not read-only.
+        expect(output).toContain('Mode:          unknown')
+        expect(output).not.toContain('data:read')
+        expect(output).not.toMatch(/Flags:\s+read-only/)
+
+        consoleSpy.mockRestore()
+    })
+
+    it('degrades gracefully when the credential manager is unavailable', async () => {
+        presentConfig({ auth_mode: 'read-write', update_channel: 'stable' })
+        mockProbeApiToken.mockRejectedValue(new SecureStoreUnavailableError('macOS Keychain error'))
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'td', 'config', 'view'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('unknown')
+        expect(output).toContain('system credential manager unavailable')
+        expect(output).toContain('stable')
 
         consoleSpy.mockRestore()
     })
 
     it('--json emits the raw config with api_token masked', async () => {
-        mockReadConfig.mockResolvedValue(fullConfig)
-        mockToken('config-file')
+        presentConfig()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view', '--json'])
@@ -117,7 +167,7 @@ describe('config view', () => {
     })
 
     it('--show-token reveals the full token in both views', async () => {
-        mockReadConfig.mockResolvedValue(fullConfig)
+        presentConfig()
         mockToken('config-file')
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
@@ -133,8 +183,8 @@ describe('config view', () => {
         consoleSpy.mockRestore()
     })
 
-    it('handles a missing / empty config gracefully', async () => {
-        mockReadConfig.mockResolvedValue({})
+    it('handles a missing config file gracefully', async () => {
+        missingConfig()
         mockProbeApiToken.mockRejectedValue(new NoTokenError())
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
@@ -148,8 +198,23 @@ describe('config view', () => {
         consoleSpy.mockRestore()
     })
 
+    it('surfaces malformed-config errors instead of silently pretending it is empty', async () => {
+        mockReadConfigStrict.mockRejectedValue(
+            new CliError(
+                'CONFIG_INVALID_JSON',
+                'Config file at /tmp/fake-todoist-cli/config.json is not valid JSON: Unexpected token',
+                ['Fix the JSON'],
+            ),
+        )
+        mockProbeApiToken.mockRejectedValue(new NoTokenError())
+
+        await expect(
+            createProgram().parseAsync(['node', 'td', 'config', 'view']),
+        ).rejects.toMatchObject({ code: 'CONFIG_INVALID_JSON' })
+    })
+
     it('shows "not set" when no token can be found anywhere', async () => {
-        mockReadConfig.mockResolvedValue({ update_channel: 'stable' })
+        presentConfig({ update_channel: 'stable' })
         mockProbeApiToken.mockRejectedValue(new NoTokenError())
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
@@ -162,7 +227,7 @@ describe('config view', () => {
     })
 
     it('masks very short tokens without exposing characters', async () => {
-        mockReadConfig.mockResolvedValue({ api_token: 'abcd' })
+        presentConfig({ api_token: 'abcd' })
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view', '--json'])

--- a/src/commands/config/config.test.ts
+++ b/src/commands/config/config.test.ts
@@ -1,0 +1,175 @@
+import { Command } from 'commander'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../lib/config.js', () => ({
+    CONFIG_PATH: '/tmp/fake-todoist-cli/config.json',
+    readConfig: vi.fn(),
+}))
+
+vi.mock('../../lib/auth.js', async () => {
+    const actual = await vi.importActual<typeof import('../../lib/auth.js')>('../../lib/auth.js')
+    return {
+        ...actual,
+        probeApiToken: vi.fn(),
+    }
+})
+
+vi.mock('chalk')
+
+import { NoTokenError, probeApiToken } from '../../lib/auth.js'
+import { type Config, readConfig } from '../../lib/config.js'
+import { registerConfigCommand } from './index.js'
+
+const mockReadConfig = vi.mocked(readConfig)
+const mockProbeApiToken = vi.mocked(probeApiToken)
+
+function createProgram() {
+    const program = new Command()
+    program.exitOverride()
+    registerConfigCommand(program)
+    return program
+}
+
+const fullConfig: Config = {
+    api_token: 'tdo_abcdefghij1234567890',
+    auth_mode: 'read-write',
+    auth_scope: 'data:read,data:delete',
+    auth_flags: ['app-management'],
+    update_channel: 'stable',
+    hc: { defaultLocale: 'en-us' },
+}
+
+function mockToken(source: 'env' | 'secure-store' | 'config-file', token = fullConfig.api_token!) {
+    mockProbeApiToken.mockResolvedValue({
+        token,
+        metadata: { authMode: 'read-write', source },
+    })
+}
+
+describe('config view', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('prints a pretty layout with the token masked by default', async () => {
+        mockReadConfig.mockResolvedValue(fullConfig)
+        mockToken('config-file')
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'td', 'config', 'view'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('/tmp/fake-todoist-cli/config.json')
+        expect(output).toContain('Authentication')
+        expect(output).toContain('Updates')
+        expect(output).toContain('Help Center')
+        expect(output).toContain('****…7890')
+        expect(output).not.toContain('tdo_abcdefghij1234567890')
+        expect(output).toContain('config file (plaintext fallback)')
+        expect(output).toContain('read-write')
+        expect(output).toContain('en-us')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('labels tokens stored in the system credential manager', async () => {
+        mockReadConfig.mockResolvedValue({ auth_mode: 'read-write' })
+        mockToken('secure-store', 'tdo_keychainXXXXXXXX1234')
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'td', 'config', 'view'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('****…1234')
+        expect(output).toContain('system credential manager')
+        expect(output).not.toContain('plaintext')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('labels tokens coming from the environment variable', async () => {
+        mockReadConfig.mockResolvedValue({})
+        mockToken('env', 'tdo_envXXXXXXXX5678')
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'td', 'config', 'view'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('****…5678')
+        expect(output).toContain('TODOIST_API_TOKEN')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('--json emits the raw config with api_token masked', async () => {
+        mockReadConfig.mockResolvedValue(fullConfig)
+        mockToken('config-file')
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'td', 'config', 'view', '--json'])
+
+        const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string)
+        expect(parsed.api_token).toBe('****…7890')
+        expect(parsed.auth_mode).toBe('read-write')
+        expect(parsed.hc).toEqual({ defaultLocale: 'en-us' })
+
+        consoleSpy.mockRestore()
+    })
+
+    it('--show-token reveals the full token in both views', async () => {
+        mockReadConfig.mockResolvedValue(fullConfig)
+        mockToken('config-file')
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'td', 'config', 'view', '--show-token'])
+        const pretty = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(pretty).toContain('tdo_abcdefghij1234567890')
+
+        consoleSpy.mockClear()
+        await createProgram().parseAsync(['node', 'td', 'config', 'view', '--json', '--show-token'])
+        const json = JSON.parse(consoleSpy.mock.calls[0][0] as string)
+        expect(json.api_token).toBe('tdo_abcdefghij1234567890')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('handles a missing / empty config gracefully', async () => {
+        mockReadConfig.mockResolvedValue({})
+        mockProbeApiToken.mockRejectedValue(new NoTokenError())
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'td', 'config', 'view'])
+        expect(consoleSpy.mock.calls[0][0]).toContain('not created yet')
+
+        consoleSpy.mockClear()
+        await createProgram().parseAsync(['node', 'td', 'config', 'view', '--json'])
+        expect(consoleSpy.mock.calls[0][0]).toBe('{}')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('shows "not set" when no token can be found anywhere', async () => {
+        mockReadConfig.mockResolvedValue({ update_channel: 'stable' })
+        mockProbeApiToken.mockRejectedValue(new NoTokenError())
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'td', 'config', 'view'])
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('not set')
+        expect(output).toContain('stable')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('masks very short tokens without exposing characters', async () => {
+        mockReadConfig.mockResolvedValue({ api_token: 'abcd' })
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'td', 'config', 'view', '--json'])
+        const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string)
+        expect(parsed.api_token).toBe('****')
+        expect(parsed.api_token).not.toContain('abcd')
+
+        consoleSpy.mockRestore()
+    })
+})

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -1,0 +1,22 @@
+import { Command } from 'commander'
+import { viewConfig } from './view.js'
+
+export function registerConfigCommand(program: Command): void {
+    const config = program.command('config').description('Manage CLI configuration')
+
+    config
+        .command('view')
+        .description('Show the current CLI configuration file')
+        .option('--json', 'Output the raw config as JSON')
+        .option('--show-token', 'Include the full api_token instead of masking it')
+        .action(viewConfig)
+
+    config.addHelpText(
+        'after',
+        `
+Examples:
+  $ td config view                  # pretty-printed, token masked
+  $ td config view --json           # raw JSON, token masked
+  $ td config view --show-token     # include the full token`,
+    )
+}

--- a/src/commands/config/view.ts
+++ b/src/commands/config/view.ts
@@ -1,0 +1,96 @@
+import chalk from 'chalk'
+import { type AuthMetadata, NoTokenError, probeApiToken, TOKEN_ENV_VAR } from '../../lib/auth.js'
+import { type Config, CONFIG_PATH, readConfig } from '../../lib/config.js'
+
+export interface ViewConfigOptions {
+    json?: boolean
+    showToken?: boolean
+}
+
+interface TokenPresence {
+    token: string
+    source: AuthMetadata['source']
+}
+
+function maskToken(token: string): string {
+    if (token.length < 5) return '****'
+    return `****…${token.slice(-4)}`
+}
+
+function describeTokenSource(source: AuthMetadata['source']): string {
+    switch (source) {
+        case 'env':
+            return `environment variable ${TOKEN_ENV_VAR}`
+        case 'secure-store':
+            return 'system credential manager'
+        case 'config-file':
+            return 'config file (plaintext fallback)'
+    }
+}
+
+async function probeTokenPresence(): Promise<TokenPresence | null> {
+    try {
+        const { token, metadata } = await probeApiToken()
+        return { token, source: metadata.source }
+    } catch (error) {
+        if (error instanceof NoTokenError) return null
+        throw error
+    }
+}
+
+function formatValue(value: unknown): string {
+    if (value === undefined || value === null) return chalk.dim('not set')
+    if (typeof value === 'boolean') return value ? 'true' : 'false'
+    if (Array.isArray(value)) {
+        return value.length === 0 ? chalk.dim('none') : value.join(', ')
+    }
+    return String(value)
+}
+
+function formatConfigView(config: Config, token: TokenPresence | null, showToken: boolean): string {
+    const lines: string[] = []
+    lines.push(`${chalk.dim('Config file:')} ${CONFIG_PATH}`)
+    lines.push('')
+
+    const tokenLine = token
+        ? `${showToken ? token.token : maskToken(token.token)} ${chalk.dim(`(${describeTokenSource(token.source)})`)}`
+        : formatValue(undefined)
+
+    lines.push(chalk.bold('Authentication'))
+    lines.push(`  Token:         ${tokenLine}`)
+    lines.push(`  Mode:          ${formatValue(config.auth_mode)}`)
+    lines.push(`  Scope:         ${formatValue(config.auth_scope)}`)
+    lines.push(`  Flags:         ${formatValue(config.auth_flags)}`)
+    lines.push('')
+
+    lines.push(chalk.bold('Updates'))
+    lines.push(`  Channel:       ${formatValue(config.update_channel)}`)
+    lines.push('')
+
+    lines.push(chalk.bold('Help Center'))
+    lines.push(`  Default locale: ${formatValue(config.hc?.defaultLocale)}`)
+
+    return lines.join('\n')
+}
+
+export async function viewConfig(options: ViewConfigOptions): Promise<void> {
+    const config = await readConfig()
+
+    if (options.json) {
+        const output: Config = { ...config }
+        if (output.api_token && !options.showToken) {
+            output.api_token = maskToken(output.api_token)
+        }
+        console.log(JSON.stringify(output, null, 2))
+        return
+    }
+
+    const token = await probeTokenPresence()
+
+    if (Object.keys(config).length === 0 && !token) {
+        console.log(`${chalk.dim('Config file:')} ${CONFIG_PATH} ${chalk.dim('(not created yet)')}`)
+        return
+    }
+
+    console.log(formatConfigView(config, token, options.showToken ?? false))
+}

--- a/src/commands/config/view.ts
+++ b/src/commands/config/view.ts
@@ -1,16 +1,17 @@
 import chalk from 'chalk'
 import { type AuthMetadata, NoTokenError, probeApiToken, TOKEN_ENV_VAR } from '../../lib/auth.js'
-import { type Config, CONFIG_PATH, readConfig } from '../../lib/config.js'
+import { type Config, CONFIG_PATH, readConfigStrict } from '../../lib/config.js'
+import { SECURE_STORE_DESCRIPTION, SecureStoreUnavailableError } from '../../lib/secure-store.js'
 
 export interface ViewConfigOptions {
     json?: boolean
     showToken?: boolean
 }
 
-interface TokenPresence {
-    token: string
-    source: AuthMetadata['source']
-}
+type TokenStatus =
+    | { state: 'present'; token: string; metadata: AuthMetadata }
+    | { state: 'missing' }
+    | { state: 'unavailable'; reason: string }
 
 function maskToken(token: string): string {
     if (token.length < 5) return '****'
@@ -22,18 +23,24 @@ function describeTokenSource(source: AuthMetadata['source']): string {
         case 'env':
             return `environment variable ${TOKEN_ENV_VAR}`
         case 'secure-store':
-            return 'system credential manager'
+            return SECURE_STORE_DESCRIPTION
         case 'config-file':
             return 'config file (plaintext fallback)'
     }
 }
 
-async function probeTokenPresence(): Promise<TokenPresence | null> {
+async function probeTokenPresence(): Promise<TokenStatus> {
     try {
         const { token, metadata } = await probeApiToken()
-        return { token, source: metadata.source }
+        return { state: 'present', token, metadata }
     } catch (error) {
-        if (error instanceof NoTokenError) return null
+        if (error instanceof NoTokenError) return { state: 'missing' }
+        if (error instanceof SecureStoreUnavailableError) {
+            return {
+                state: 'unavailable',
+                reason: `${SECURE_STORE_DESCRIPTION} unavailable (${error.message})`,
+            }
+        }
         throw error
     }
 }
@@ -47,20 +54,38 @@ function formatValue(value: unknown): string {
     return String(value)
 }
 
-function formatConfigView(config: Config, token: TokenPresence | null, showToken: boolean): string {
+function renderTokenLine(token: TokenStatus, showToken: boolean): string {
+    switch (token.state) {
+        case 'present': {
+            const value = showToken ? token.token : maskToken(token.token)
+            return `${value} ${chalk.dim(`(${describeTokenSource(token.metadata.source)})`)}`
+        }
+        case 'unavailable':
+            return chalk.dim(`unknown — ${token.reason}`)
+        case 'missing':
+            return formatValue(undefined)
+    }
+}
+
+function formatConfigView(config: Config, token: TokenStatus, showToken: boolean): string {
     const lines: string[] = []
     lines.push(`${chalk.dim('Config file:')} ${CONFIG_PATH}`)
     lines.push('')
 
-    const tokenLine = token
-        ? `${showToken ? token.token : maskToken(token.token)} ${chalk.dim(`(${describeTokenSource(token.source)})`)}`
-        : formatValue(undefined)
+    // When a token is present, its metadata is the ground truth for the active
+    // mode/scope/flags — this matters most for env-sourced tokens, whose scope
+    // the CLI does not actually know and where config.auth_* may be stale from
+    // an unrelated `td auth login`. For missing/unavailable tokens, fall back
+    // to the config file values (what the CLI would attempt once auth recovers).
+    const effectiveMode = token.state === 'present' ? token.metadata.authMode : config.auth_mode
+    const effectiveScope = token.state === 'present' ? token.metadata.authScope : config.auth_scope
+    const effectiveFlags = token.state === 'present' ? token.metadata.authFlags : config.auth_flags
 
     lines.push(chalk.bold('Authentication'))
-    lines.push(`  Token:         ${tokenLine}`)
-    lines.push(`  Mode:          ${formatValue(config.auth_mode)}`)
-    lines.push(`  Scope:         ${formatValue(config.auth_scope)}`)
-    lines.push(`  Flags:         ${formatValue(config.auth_flags)}`)
+    lines.push(`  Token:         ${renderTokenLine(token, showToken)}`)
+    lines.push(`  Mode:          ${formatValue(effectiveMode)}`)
+    lines.push(`  Scope:         ${formatValue(effectiveScope)}`)
+    lines.push(`  Flags:         ${formatValue(effectiveFlags)}`)
     lines.push('')
 
     lines.push(chalk.bold('Updates'))
@@ -74,7 +99,8 @@ function formatConfigView(config: Config, token: TokenPresence | null, showToken
 }
 
 export async function viewConfig(options: ViewConfigOptions): Promise<void> {
-    const config = await readConfig()
+    const read = await readConfigStrict()
+    const config: Config = read.state === 'present' ? read.config : {}
 
     if (options.json) {
         const output: Config = { ...config }
@@ -87,7 +113,7 @@ export async function viewConfig(options: ViewConfigOptions): Promise<void> {
 
     const token = await probeTokenPresence()
 
-    if (Object.keys(config).length === 0 && !token) {
+    if (read.state === 'missing' && token.state === 'missing') {
         console.log(`${chalk.dim('Config file:')} ${CONFIG_PATH} ${chalk.dim('(not created yet)')}`)
         return
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,10 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
         'Manage shell completions',
         async () => (await import('./commands/completion/index.js')).registerCompletionCommand,
     ],
+    config: [
+        'View CLI configuration',
+        async () => (await import('./commands/config/index.js')).registerConfigCommand,
+    ],
     view: [
         'View a Todoist entity or page by URL',
         async () => (await import('./commands/view.js')).registerViewCommand,

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,7 +143,7 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
         async () => (await import('./commands/completion/index.js')).registerCompletionCommand,
     ],
     config: [
-        'View CLI configuration',
+        'Manage CLI configuration',
         async () => (await import('./commands/config/index.js')).registerConfigCommand,
     ],
     view: [

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,7 @@
 import { chmod, mkdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { CliError } from './errors.js'
 import { normalizeHelpCenterLocale } from './help-center.js'
 
 export const CONFIG_PATH = join(homedir(), '.config', 'todoist-cli', 'config.json')
@@ -56,6 +57,51 @@ export async function readConfig(): Promise<Config> {
     } catch {
         return {}
     }
+}
+
+export type StrictReadResult = { state: 'missing' } | { state: 'present'; config: Config }
+
+/**
+ * Read and parse the config file strictly — for inspection commands that need
+ * to distinguish "missing" from "present but broken". `readConfig` deliberately
+ * swallows errors for runtime code paths; this one surfaces them.
+ */
+export async function readConfigStrict(): Promise<StrictReadResult> {
+    let content: string
+    try {
+        content = await readFile(CONFIG_PATH, 'utf-8')
+    } catch (error) {
+        if (isMissingFileError(error)) return { state: 'missing' }
+        const detail = error instanceof Error ? error.message : String(error)
+        throw new CliError(
+            'CONFIG_READ_FAILED',
+            `Could not read config file ${CONFIG_PATH}: ${detail}`,
+            ['Check file permissions, or run `td doctor` to diagnose'],
+        )
+    }
+
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(content)
+    } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error)
+        throw new CliError(
+            'CONFIG_INVALID_JSON',
+            `Config file at ${CONFIG_PATH} is not valid JSON: ${detail}`,
+            ['Fix the JSON by hand, or delete the file and re-authenticate with `td auth login`'],
+        )
+    }
+
+    if (!isObject(parsed)) {
+        const actual = Array.isArray(parsed) ? 'array' : typeof parsed
+        throw new CliError(
+            'CONFIG_INVALID_SHAPE',
+            `Config file at ${CONFIG_PATH} must contain a JSON object (got ${actual})`,
+            ['Fix the JSON by hand, or delete the file and re-authenticate with `td auth login`'],
+        )
+    }
+
+    return { state: 'present', config: parsed as Config }
 }
 
 export async function writeConfig(config: Config): Promise<void> {

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -59,7 +59,7 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 - Collaboration: \`td comment ...\`, \`td notification ...\`, \`td reminder ...\`
 - Templates and files: \`td template ...\`, \`td attachment view <file-url>\`, \`td backup ...\`
 - Help Center: \`td hc locales/search/view\`
-- Account and tooling: \`td stats\`, \`td settings ...\`, \`td completion ...\`, \`td view <todoist-url>\`, \`td doctor\`, \`td update\`, \`td changelog\`
+- Account and tooling: \`td stats\`, \`td settings ...\`, \`td config view\`, \`td completion ...\`, \`td view <todoist-url>\`, \`td doctor\`, \`td update\`, \`td changelog\`
 - Developer apps: \`td apps list/view\` (requires \`td auth login --additional-scopes=app-management\`)
 - Backups: \`td backup list/download\` (requires \`td auth login --additional-scopes=backups\`)
 
@@ -276,6 +276,10 @@ td stats vacation --on
 td settings view
 td settings update --timezone "America/New_York" --time-format 24 --date-format intl
 td settings themes
+
+td config view
+td config view --json
+td config view --show-token
 
 td completion install zsh
 td completion uninstall


### PR DESCRIPTION
## Summary

- Adds a new `td config view` command that pretty-prints the CLI config at `~/.config/todoist-cli/config.json`, grouped into Authentication / Updates / Help Center sections.
- `--json` echoes the raw config as-is (with the `api_token` masked).
- `api_token` is always masked to `****…<last4>` by default; `--show-token` reveals it. Short/unusable tokens mask to `****`.
- Pretty output labels the token's actual storage location: *system credential manager*, *config file (plaintext fallback)*, or *environment variable `TODOIST_API_TOKEN`* — so users can verify storage without cross-referencing `td auth status`.

## Sample output

```
Config file: /Users/you/.config/todoist-cli/config.json

Authentication
  Token:         ****…be4a (system credential manager)
  Mode:          read-write
  Scope:         data:read_write,data:delete,project:delete,dev:app_console
  Flags:         app-management

Updates
  Channel:       not set

Help Center
  Default locale: not set
```

## Test plan

- [x] `npm run type-check`
- [x] `npm test` (1471 passing, 8 new)
- [x] `npm run check`
- [x] Manual smoke: `td config view`, `td config view --json`, `td config view --show-token`, `td config --help`
- [x] Missing config-file case (renamed file, re-ran — reports `(not created yet)` in pretty, `{}` in JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)