### PR TITLE
feat(task): add --no-due flag to clear due date

### DIFF
--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -117,7 +117,7 @@ Choosing between `task add` and `task quickadd`:
 Useful task flags:
 - `--stdin` on `task add` reads the task description from stdin; on `task quickadd` (and the top-level `td add`) it reads the full natural-language text from stdin.
 - `--parent`, `--section`, `--project`, `--workspace`, `--assignee`, `--labels`, `--due`, `--deadline`, `--duration`, and `--priority` cover most task workflows.
-- `td task complete --forever` stops recurrence; `td task update --no-deadline` clears deadlines; `td task move --no-parent` and `--no-section` detach from hierarchy.
+- `td task complete --forever` stops recurrence; `td task update --no-due` clears the due date and `--no-deadline` clears deadlines; `td task move --no-parent` and `--no-section` detach from hierarchy.
 
 ### Projects And Workspaces
 ```bash

--- a/src/commands/task/index.ts
+++ b/src/commands/task/index.ts
@@ -180,6 +180,7 @@ Examples:
         .description('Update a task')
         .option('--content <text>', 'New content')
         .option('--due <date>', 'New due date')
+        .option('--no-due', 'Remove due date')
         .option('--deadline <date>', 'Deadline date (YYYY-MM-DD)')
         .option('--no-deadline', 'Remove deadline')
         .addOption(

--- a/src/commands/task/task.test.ts
+++ b/src/commands/task/task.test.ts
@@ -1642,6 +1642,35 @@ describe('task update --deadline', () => {
     })
 })
 
+describe('task update --no-due', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+    })
+
+    it('removes due date with --no-due', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getTask.mockResolvedValue({
+            id: 'task-1',
+            content: 'Task',
+            due: { date: '2026-12-31', string: 'Dec 31' },
+        })
+        mockApi.updateTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
+
+        await program.parseAsync(['node', 'td', 'task', 'update', 'id:task-1', '--no-due'])
+
+        expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', {
+            dueString: null,
+        })
+        consoleSpy.mockRestore()
+    })
+})
+
 describe('task add/update --uncompletable', () => {
     let mockApi: MockApi
 

--- a/src/commands/task/update.ts
+++ b/src/commands/task/update.ts
@@ -10,7 +10,7 @@ import { applyDuration, type DurationArgs } from './helpers.js'
 
 export interface UpdateOptions {
     content?: string
-    due?: string
+    due?: string | false
     deadline?: string | false
     priority?: string
     labels?: string
@@ -33,7 +33,11 @@ export async function updateTask(ref: string, options: UpdateOptions): Promise<v
     const args: Parameters<typeof api.updateTask>[1] = {}
 
     if (options.content) args.content = options.content
-    if (options.due) args.dueString = options.due
+    if (options.due === false) {
+        args.dueString = null
+    } else if (options.due) {
+        args.dueString = options.due
+    }
     if (options.deadline === false) {
         args.deadlineDate = null
     } else if (options.deadline) {

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -113,7 +113,7 @@ Choosing between \`task add\` and \`task quickadd\`:
 Useful task flags:
 - \`--stdin\` on \`task add\` reads the task description from stdin; on \`task quickadd\` (and the top-level \`td add\`) it reads the full natural-language text from stdin.
 - \`--parent\`, \`--section\`, \`--project\`, \`--workspace\`, \`--assignee\`, \`--labels\`, \`--due\`, \`--deadline\`, \`--duration\`, and \`--priority\` cover most task workflows.
-- \`td task complete --forever\` stops recurrence; \`td task update --no-deadline\` clears deadlines; \`td task move --no-parent\` and \`--no-section\` detach from hierarchy.
+- \`td task complete --forever\` stops recurrence; \`td task update --no-due\` clears the due date and \`--no-deadline\` clears deadlines; \`td task move --no-parent\` and \`--no-section\` detach from hierarchy.
 
 ### Projects And Workspaces
 \`\`\`bash


### PR DESCRIPTION
Adds `--no-due` to `td task update` to clear a task's due date, mirroring the existing `--no-deadline` flag. Sends `dueString: null` (the SDK's documented clear mechanism).