### PR TITLE
feat(workspace): add `td workspace use <ref>` to persist a default workspace

### DIFF
--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -152,6 +152,8 @@ td workspace update "Acme" --description "Acme Inc." --dry-run   # admin-only
 td workspace delete "Old WS" --yes                                # admin-only
 td workspace user-tasks "Acme" --user alice@example.com
 td workspace activity "Acme" --json
+td workspace use "Acme"              # persist a default; omitted refs on other workspace commands fall back to it
+td workspace use --clear             # forget the stored default
 td folder list "Acme"
 td folder view "Engineering"
 td folder create "Acme" --name "Engineering"

--- a/src/commands/config/view.ts
+++ b/src/commands/config/view.ts
@@ -94,6 +94,16 @@ function formatConfigView(config: Config, token: TokenStatus, showToken: boolean
 
     lines.push(chalk.bold('Help Center'))
     lines.push(`  Default locale: ${formatValue(config.hc?.defaultLocale)}`)
+    lines.push('')
+
+    lines.push(chalk.bold('Workspace'))
+    lines.push(
+        `  Default workspace: ${
+            config.workspace?.defaultWorkspace
+                ? `id:${config.workspace.defaultWorkspace}`
+                : formatValue(undefined)
+        }`,
+    )
 
     return lines.join('\n')
 }

--- a/src/commands/folder/create.ts
+++ b/src/commands/folder/create.ts
@@ -14,13 +14,17 @@ interface CreateFolderOptions {
 }
 
 export async function createFolder(
-    workspaceRef: string,
+    workspaceRef: string | undefined,
     options: CreateFolderOptions,
 ): Promise<void> {
+    // Resolve up front so --dry-run previews the workspace by its real name
+    // and still fails fast on an unknown ref or missing default.
+    const workspace = await resolveWorkspaceRef(workspaceRef)
+
     if (options.dryRun) {
         printDryRun('create folder', {
             Name: options.name,
-            Workspace: workspaceRef,
+            Workspace: workspace.name,
             'Default order':
                 options.defaultOrder !== undefined ? String(options.defaultOrder) : undefined,
             'Child order':
@@ -29,7 +33,6 @@ export async function createFolder(
         return
     }
 
-    const workspace = await resolveWorkspaceRef(workspaceRef)
     const api = await getApi()
 
     const folder = await api.addFolder({

--- a/src/commands/folder/helpers.ts
+++ b/src/commands/folder/helpers.ts
@@ -1,19 +1,15 @@
 import type { Folder } from '@doist/todoist-sdk'
 import { getApi } from '../../lib/api/core.js'
 import { fetchWorkspaces, type Workspace } from '../../lib/api/workspaces.js'
-import { readConfig } from '../../lib/config.js'
 import { CliError } from '../../lib/errors.js'
-import { resolveFolderRef, resolveWorkspaceRef } from '../../lib/refs.js'
+import { readDefaultWorkspaceRef, resolveFolderRef, resolveWorkspaceRef } from '../../lib/refs.js'
 
 export async function resolveWorkspaceForFolder(options: {
     workspace?: string
 }): Promise<Workspace> {
-    if (options.workspace) {
-        return resolveWorkspaceRef(options.workspace)
-    }
-    const savedId = (await readConfig()).workspace?.defaultWorkspace
-    if (savedId) {
-        return resolveWorkspaceRef(`id:${savedId}`)
+    const ref = options.workspace ?? (await readDefaultWorkspaceRef())
+    if (ref) {
+        return resolveWorkspaceRef(ref)
     }
     const workspaces = await fetchWorkspaces()
     if (workspaces.length === 0) {

--- a/src/commands/folder/helpers.ts
+++ b/src/commands/folder/helpers.ts
@@ -1,6 +1,7 @@
 import type { Folder } from '@doist/todoist-sdk'
 import { getApi } from '../../lib/api/core.js'
 import { fetchWorkspaces, type Workspace } from '../../lib/api/workspaces.js'
+import { readConfig } from '../../lib/config.js'
 import { CliError } from '../../lib/errors.js'
 import { resolveFolderRef, resolveWorkspaceRef } from '../../lib/refs.js'
 
@@ -9,6 +10,10 @@ export async function resolveWorkspaceForFolder(options: {
 }): Promise<Workspace> {
     if (options.workspace) {
         return resolveWorkspaceRef(options.workspace)
+    }
+    const savedId = (await readConfig()).workspace?.defaultWorkspace
+    if (savedId) {
+        return resolveWorkspaceRef(`id:${savedId}`)
     }
     const workspaces = await fetchWorkspaces()
     if (workspaces.length === 0) {
@@ -23,6 +28,7 @@ export async function resolveWorkspaceForFolder(options: {
     throw new CliError('WORKSPACE_NOT_FOUND', 'Multiple workspaces found. Specify --workspace.', [
         'Available workspaces:',
         ...workspaces.map((w) => `  "${w.name}" (id:${w.id})`),
+        'Or set a default with `td workspace use <ref>`.',
     ])
 }
 

--- a/src/commands/folder/index.ts
+++ b/src/commands/folder/index.ts
@@ -32,7 +32,7 @@ Examples:
   td folder delete "Engineering" --workspace "Acme" --yes`,
         )
 
-    const listCmd = folder
+    folder
         .command('list [workspace]')
         .description('List folders in a workspace')
         .option('--workspace <ref>', 'Workspace name or id:xxx')
@@ -52,12 +52,7 @@ Examples:
                         'Cannot specify workspace both as argument and --workspace flag',
                     )
                 }
-                const ref = refArg || options.workspace
-                if (!ref) {
-                    listCmd.help()
-                    return
-                }
-                return listFolders(ref, options)
+                return listFolders(refArg || options.workspace, options)
             },
         )
 
@@ -102,12 +97,14 @@ Examples:
                         'Cannot specify workspace both as argument and --workspace flag',
                     )
                 }
-                const ref = refArg || options.workspace
-                if (!ref || !options.name) {
+                if (!options.name) {
                     createCmd.help()
                     return
                 }
-                return createFolder(ref, options as { name: string } & typeof options)
+                return createFolder(
+                    refArg || options.workspace,
+                    options as { name: string } & typeof options,
+                )
             },
         )
 

--- a/src/commands/folder/list.ts
+++ b/src/commands/folder/list.ts
@@ -5,7 +5,10 @@ import { formatNextCursorFooter } from '../../lib/output.js'
 import { paginate } from '../../lib/pagination.js'
 import { resolveWorkspaceRef } from '../../lib/refs.js'
 
-export async function listFolders(ref: string, options: PaginatedViewOptions): Promise<void> {
+export async function listFolders(
+    ref: string | undefined,
+    options: PaginatedViewOptions,
+): Promise<void> {
     const workspace = await resolveWorkspaceRef(ref)
     const api = await getApi()
 

--- a/src/commands/workspace/activity.ts
+++ b/src/commands/workspace/activity.ts
@@ -12,7 +12,7 @@ export interface WorkspaceActivityOptions {
 }
 
 export async function showWorkspaceActivity(
-    ref: string,
+    ref: string | undefined,
     options: WorkspaceActivityOptions,
 ): Promise<void> {
     const workspace = await resolveWorkspaceRef(ref)

--- a/src/commands/workspace/delete.ts
+++ b/src/commands/workspace/delete.ts
@@ -6,7 +6,7 @@ import { resolveWorkspaceRef } from '../../lib/refs.js'
 import { assertWorkspaceAdmin } from './helpers.js'
 
 export async function deleteWorkspaceCommand(
-    ref: string,
+    ref: string | undefined,
     options: { yes?: boolean; dryRun?: boolean },
 ): Promise<void> {
     const workspace = await resolveWorkspaceRef(ref)

--- a/src/commands/workspace/index.ts
+++ b/src/commands/workspace/index.ts
@@ -11,6 +11,7 @@ import { showWorkspaceInsights } from './insights.js'
 import { listWorkspaces } from './list.js'
 import { listWorkspaceProjects } from './projects.js'
 import { updateWorkspaceCommand, type UpdateWorkspaceOptions } from './update.js'
+import { useWorkspace, type UseWorkspaceOptions } from './use.js'
 import { listWorkspaceUserTasks, type WorkspaceUserTasksOptions } from './user-tasks.js'
 import { listWorkspaceUsers } from './users.js'
 import { viewWorkspace } from './view.js'
@@ -28,16 +29,10 @@ export function registerWorkspaceCommand(program: Command): void {
 
     workspace
         .command('view [ref]', { isDefault: true })
-        .description('View workspace details')
+        .description('View workspace details (uses the default workspace when [ref] is omitted)')
         .option('--json', 'Output as JSON')
         .option('--full', 'Include all fields in JSON output')
-        .action((ref, options) => {
-            if (!ref) {
-                workspace.help()
-                return
-            }
-            return viewWorkspace(ref, options)
-        })
+        .action((ref: string | undefined, options) => viewWorkspace(ref, options))
 
     const createCmd = workspace
         .command('create')
@@ -64,7 +59,7 @@ export function registerWorkspaceCommand(program: Command): void {
             return createWorkspace(options)
         })
 
-    const updateCmd = workspace
+    workspace
         .command('update [ref]')
         .description('Update a workspace (admin only)')
         .option('--name <name>', 'New workspace name')
@@ -83,28 +78,20 @@ export function registerWorkspaceCommand(program: Command): void {
         .option('--json', 'Output as JSON')
         .option('--full', 'Include all fields in JSON output')
         .option('--dry-run', 'Preview what would happen without executing')
-        .action((ref: string | undefined, options: UpdateWorkspaceOptions) => {
-            if (!ref) {
-                updateCmd.help()
-                return
-            }
-            return updateWorkspaceCommand(ref, options)
-        })
+        .action((ref: string | undefined, options: UpdateWorkspaceOptions) =>
+            updateWorkspaceCommand(ref, options),
+        )
 
-    const deleteCmd = workspace
+    workspace
         .command('delete [ref]')
         .description('Delete a workspace (admin only)')
         .option('--yes', 'Skip confirmation prompt')
         .option('--dry-run', 'Preview what would happen without executing')
-        .action((ref: string | undefined, options: { yes?: boolean; dryRun?: boolean }) => {
-            if (!ref) {
-                deleteCmd.help()
-                return
-            }
-            return deleteWorkspaceCommand(ref, options)
-        })
+        .action((ref: string | undefined, options: { yes?: boolean; dryRun?: boolean }) =>
+            deleteWorkspaceCommand(ref, options),
+        )
 
-    const projectsCmd = workspace
+    workspace
         .command('projects [ref]')
         .description('List projects in a workspace')
         .option('--workspace <ref>', 'Workspace name or id:xxx')
@@ -125,16 +112,11 @@ export function registerWorkspaceCommand(program: Command): void {
                         'Cannot specify workspace both as argument and --workspace flag',
                     )
                 }
-                const ref = refArg || options.workspace
-                if (!ref) {
-                    projectsCmd.help()
-                    return
-                }
-                return listWorkspaceProjects(ref, options)
+                return listWorkspaceProjects(refArg || options.workspace, options)
             },
         )
 
-    const usersCmd = workspace
+    workspace
         .command('users [ref]')
         .description('List users in a workspace')
         .option('--workspace <ref>', 'Workspace name or id:xxx')
@@ -164,16 +146,11 @@ export function registerWorkspaceCommand(program: Command): void {
                         'Cannot specify workspace both as argument and --workspace flag',
                     )
                 }
-                const ref = refArg || options.workspace
-                if (!ref) {
-                    usersCmd.help()
-                    return
-                }
-                return listWorkspaceUsers(ref, options)
+                return listWorkspaceUsers(refArg || options.workspace, options)
             },
         )
 
-    const userTasksCmd = workspace
+    workspace
         .command('user-tasks [ref]')
         .description('List tasks assigned to a user in a workspace')
         .option('--workspace <ref>', 'Workspace name or id:xxx')
@@ -193,16 +170,11 @@ export function registerWorkspaceCommand(program: Command): void {
                         'Cannot specify workspace both as argument and --workspace flag',
                     )
                 }
-                const ref = refArg || options.workspace
-                if (!ref) {
-                    userTasksCmd.help()
-                    return
-                }
-                return listWorkspaceUserTasks(ref, options)
+                return listWorkspaceUserTasks(refArg || options.workspace, options)
             },
         )
 
-    const activityCmd = workspace
+    workspace
         .command('activity [ref]')
         .description('Show workspace members activity (tasks assigned/overdue)')
         .option('--workspace <ref>', 'Workspace name or id:xxx')
@@ -222,16 +194,11 @@ export function registerWorkspaceCommand(program: Command): void {
                         'Cannot specify workspace both as argument and --workspace flag',
                     )
                 }
-                const ref = refArg || options.workspace
-                if (!ref) {
-                    activityCmd.help()
-                    return
-                }
-                return showWorkspaceActivity(ref, options)
+                return showWorkspaceActivity(refArg || options.workspace, options)
             },
         )
 
-    const insightsCmd = workspace
+    workspace
         .command('insights [ref]')
         .description('Show health and progress insights for workspace projects')
         .option('--workspace <ref>', 'Workspace name or id:xxx')
@@ -248,14 +215,21 @@ export function registerWorkspaceCommand(program: Command): void {
                         'Cannot specify workspace both as argument and --workspace flag',
                     )
                 }
-                const ref = refArg || options.workspace
-                if (!ref) {
-                    insightsCmd.help()
-                    return
-                }
-                return showWorkspaceInsights(ref, options)
+                return showWorkspaceInsights(refArg || options.workspace, options)
             },
         )
+
+    const useCmd = workspace
+        .command('use [ref]')
+        .description('Set the default workspace used when [ref] is omitted from other commands')
+        .option('--clear', 'Remove the saved default workspace')
+        .action((ref: string | undefined, options: UseWorkspaceOptions) => {
+            if (!ref && !options.clear) {
+                useCmd.help()
+                return
+            }
+            return useWorkspace(ref, options)
+        })
 
     workspace.addHelpText(
         'after',
@@ -265,6 +239,9 @@ Examples:
   $ td workspace update "Acme" --description "Acme Inc." --dry-run
   $ td workspace delete "Old WS" --yes
   $ td workspace user-tasks "Acme" --user alice@example.com
-  $ td workspace activity "Acme" --json`,
+  $ td workspace activity "Acme" --json
+  $ td workspace use "Acme"          # set default, used by subsequent commands
+  $ td workspace projects            # uses the default workspace
+  $ td workspace use --clear         # forget the default`,
     )
 }

--- a/src/commands/workspace/index.ts
+++ b/src/commands/workspace/index.ts
@@ -219,17 +219,13 @@ export function registerWorkspaceCommand(program: Command): void {
             },
         )
 
-    const useCmd = workspace
+    workspace
         .command('use [ref]')
         .description('Set the default workspace used when [ref] is omitted from other commands')
         .option('--clear', 'Remove the saved default workspace')
-        .action((ref: string | undefined, options: UseWorkspaceOptions) => {
-            if (!ref && !options.clear) {
-                useCmd.help()
-                return
-            }
-            return useWorkspace(ref, options)
-        })
+        .action((ref: string | undefined, options: UseWorkspaceOptions) =>
+            useWorkspace(ref, options),
+        )
 
     workspace.addHelpText(
         'after',

--- a/src/commands/workspace/insights.ts
+++ b/src/commands/workspace/insights.ts
@@ -5,7 +5,7 @@ import { paginate } from '../../lib/pagination.js'
 import { lenientIdRef, resolveWorkspaceRef } from '../../lib/refs.js'
 
 export async function showWorkspaceInsights(
-    ref: string,
+    ref: string | undefined,
     options: { json?: boolean; projectIds?: string },
 ): Promise<void> {
     const workspace = await resolveWorkspaceRef(ref)

--- a/src/commands/workspace/projects.ts
+++ b/src/commands/workspace/projects.ts
@@ -7,7 +7,7 @@ import { LIMITS, paginate } from '../../lib/pagination.js'
 import { resolveWorkspaceRef } from '../../lib/refs.js'
 
 export async function listWorkspaceProjects(
-    ref: string,
+    ref: string | undefined,
     options: PaginatedViewOptions,
 ): Promise<void> {
     const workspace = await resolveWorkspaceRef(ref)

--- a/src/commands/workspace/update.ts
+++ b/src/commands/workspace/update.ts
@@ -22,7 +22,7 @@ export interface UpdateWorkspaceOptions {
 }
 
 export async function updateWorkspaceCommand(
-    ref: string,
+    ref: string | undefined,
     options: UpdateWorkspaceOptions,
 ): Promise<void> {
     const workspace = await resolveWorkspaceRef(ref)

--- a/src/commands/workspace/use.ts
+++ b/src/commands/workspace/use.ts
@@ -11,6 +11,14 @@ export async function useWorkspace(
     ref: string | undefined,
     options: UseWorkspaceOptions = {},
 ): Promise<void> {
+    if (options.clear && ref) {
+        throw new CliError(
+            'CONFLICTING_OPTIONS',
+            'Cannot pass a workspace ref together with --clear.',
+            ['Use one or the other: `td workspace use <ref>` OR `td workspace use --clear`.'],
+        )
+    }
+
     if (options.clear) {
         await clearDefaultWorkspace()
         return

--- a/src/commands/workspace/use.ts
+++ b/src/commands/workspace/use.ts
@@ -1,0 +1,65 @@
+import chalk from 'chalk'
+import { readConfig, writeConfig } from '../../lib/config.js'
+import { CliError } from '../../lib/errors.js'
+import { resolveWorkspaceRef } from '../../lib/refs.js'
+
+export interface UseWorkspaceOptions {
+    clear?: boolean
+}
+
+export async function useWorkspace(
+    ref: string | undefined,
+    options: UseWorkspaceOptions = {},
+): Promise<void> {
+    if (options.clear) {
+        await clearDefaultWorkspace()
+        return
+    }
+
+    if (!ref) {
+        throw new CliError(
+            'INVALID_OPTIONS',
+            'A workspace ref is required unless --clear is passed.',
+            [
+                'Example: `td workspace use "My Workspace"`',
+                'Clear with: `td workspace use --clear`',
+            ],
+        )
+    }
+
+    const workspace = await resolveWorkspaceRef(ref)
+
+    const config = await readConfig()
+    const existing = isPlainObject(config.workspace) ? config.workspace : {}
+    config.workspace = { ...existing, defaultWorkspace: workspace.id }
+    await writeConfig(config)
+
+    console.log(
+        chalk.green('✓'),
+        `Default workspace set to ${chalk.cyan(workspace.name)} ${chalk.dim(`(id:${workspace.id})`)}`,
+    )
+}
+
+async function clearDefaultWorkspace(): Promise<void> {
+    const config = await readConfig()
+    const existing = isPlainObject(config.workspace) ? { ...config.workspace } : undefined
+
+    if (!existing || existing.defaultWorkspace === undefined) {
+        console.log(chalk.dim('No default workspace was set.'))
+        return
+    }
+
+    delete existing.defaultWorkspace
+    if (Object.keys(existing).length === 0) {
+        delete config.workspace
+    } else {
+        config.workspace = existing
+    }
+    await writeConfig(config)
+
+    console.log(chalk.green('✓'), 'Default workspace cleared.')
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/commands/workspace/user-tasks.ts
+++ b/src/commands/workspace/user-tasks.ts
@@ -13,7 +13,7 @@ export interface WorkspaceUserTasksOptions {
 }
 
 export async function listWorkspaceUserTasks(
-    ref: string,
+    ref: string | undefined,
     options: WorkspaceUserTasksOptions,
 ): Promise<void> {
     if (!options.user) {

--- a/src/commands/workspace/users.ts
+++ b/src/commands/workspace/users.ts
@@ -7,7 +7,7 @@ import { resolveWorkspaceRef } from '../../lib/refs.js'
 import { WORKSPACE_ROLES } from './helpers.js'
 
 export async function listWorkspaceUsers(
-    ref: string,
+    ref: string | undefined,
     options: PaginatedViewOptions & { role?: string },
 ): Promise<void> {
     const workspace = await resolveWorkspaceRef(ref)

--- a/src/commands/workspace/view.ts
+++ b/src/commands/workspace/view.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import { resolveWorkspaceRef } from '../../lib/refs.js'
 
 export async function viewWorkspace(
-    ref: string,
+    ref: string | undefined,
     options: { json?: boolean; full?: boolean } = {},
 ): Promise<void> {
     const workspace = await resolveWorkspaceRef(ref)

--- a/src/commands/workspace/workspace.test.ts
+++ b/src/commands/workspace/workspace.test.ts
@@ -1316,6 +1316,14 @@ describe('workspace use (default workspace)', () => {
         expect(mockWriteConfig).toHaveBeenCalledWith({ update_channel: 'stable' })
     })
 
+    it('rejects passing a ref together with --clear', async () => {
+        const program = createProgram()
+        await expect(
+            program.parseAsync(['node', 'td', 'workspace', 'use', 'Doist', '--clear']),
+        ).rejects.toMatchObject({ code: 'CONFLICTING_OPTIONS' })
+        expect(mockWriteConfig).not.toHaveBeenCalled()
+    })
+
     it('--clear is a no-op and does not write when no default was set', async () => {
         mockReadConfig.mockResolvedValue({ update_channel: 'stable' })
 

--- a/src/commands/workspace/workspace.test.ts
+++ b/src/commands/workspace/workspace.test.ts
@@ -11,14 +11,22 @@ vi.mock('../../lib/api/workspaces.js', () => ({
     clearWorkspaceCache: vi.fn(),
 }))
 
+vi.mock('../../lib/config.js', () => ({
+    readConfig: vi.fn().mockResolvedValue({}),
+    writeConfig: vi.fn().mockResolvedValue(undefined),
+}))
+
 import { getApi } from '../../lib/api/core.js'
 import { fetchWorkspaceFolders, fetchWorkspaces } from '../../lib/api/workspaces.js'
+import { readConfig, writeConfig } from '../../lib/config.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
 import { registerWorkspaceCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
 const mockFetchWorkspaces = vi.mocked(fetchWorkspaces)
 const mockFetchWorkspaceFolders = vi.mocked(fetchWorkspaceFolders)
+const mockReadConfig = vi.mocked(readConfig)
+const mockWriteConfig = vi.mocked(writeConfig)
 
 function createProgram() {
     const program = new Command()
@@ -1248,5 +1256,110 @@ describe('workspace activity', () => {
         const parsed = JSON.parse(output)
         expect(parsed.results[0]).toMatchObject({ userId: 'u-1', tasksAssigned: 5 })
         expect(parsed.nextCursor).toBeNull()
+    })
+})
+
+describe('workspace use (default workspace)', () => {
+    let mockApi: MockApi
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+        mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
+        mockFetchWorkspaceFolders.mockResolvedValue([])
+        mockReadConfig.mockResolvedValue({})
+        mockWriteConfig.mockResolvedValue(undefined)
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        consoleSpy.mockRestore()
+    })
+
+    it('stores the resolved workspace id under workspace.defaultWorkspace', async () => {
+        mockReadConfig.mockResolvedValue({ update_channel: 'stable' })
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'td', 'workspace', 'use', 'Doist'])
+
+        expect(mockWriteConfig).toHaveBeenCalledWith({
+            update_channel: 'stable',
+            workspace: { defaultWorkspace: 'ws-1' },
+        })
+        const output = consoleSpy.mock.calls
+            .map((c: unknown[]) => c.map(String).join(' '))
+            .join('\n')
+        expect(output).toContain('Default workspace set to')
+        expect(output).toContain('Doist')
+    })
+
+    it('accepts id: prefix refs and stores the raw id', async () => {
+        const program = createProgram()
+        await program.parseAsync(['node', 'td', 'workspace', 'use', 'id:ws-2'])
+
+        expect(mockWriteConfig).toHaveBeenCalledWith({
+            workspace: { defaultWorkspace: 'ws-2' },
+        })
+    })
+
+    it('--clear removes the stored default and drops the workspace object when empty', async () => {
+        mockReadConfig.mockResolvedValue({
+            update_channel: 'stable',
+            workspace: { defaultWorkspace: 'ws-1' },
+        })
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'td', 'workspace', 'use', '--clear'])
+
+        expect(mockWriteConfig).toHaveBeenCalledWith({ update_channel: 'stable' })
+    })
+
+    it('--clear is a no-op and does not write when no default was set', async () => {
+        mockReadConfig.mockResolvedValue({ update_channel: 'stable' })
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'td', 'workspace', 'use', '--clear'])
+
+        expect(mockWriteConfig).not.toHaveBeenCalled()
+    })
+
+    it('uses the configured default when ref is omitted on a workspace subcommand', async () => {
+        mockReadConfig.mockResolvedValue({
+            workspace: { defaultWorkspace: 'ws-2' },
+        })
+        mockApi.getWorkspaceMembersActivity.mockResolvedValue({ members: [] })
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'td', 'workspace', 'activity', '--json'])
+
+        expect(mockApi.getWorkspaceMembersActivity).toHaveBeenCalledWith(
+            expect.objectContaining({ workspaceId: 'ws-2' }),
+        )
+    })
+
+    it('prefers an explicit ref over the configured default', async () => {
+        mockReadConfig.mockResolvedValue({
+            workspace: { defaultWorkspace: 'ws-2' },
+        })
+        mockApi.getWorkspaceMembersActivity.mockResolvedValue({ members: [] })
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'td', 'workspace', 'activity', 'Doist', '--json'])
+
+        expect(mockApi.getWorkspaceMembersActivity).toHaveBeenCalledWith(
+            expect.objectContaining({ workspaceId: 'ws-1' }),
+        )
+    })
+
+    it('throws WORKSPACE_REQUIRED when no ref and no default are set', async () => {
+        const program = createProgram()
+        await expect(
+            program.parseAsync(['node', 'td', 'workspace', 'projects']),
+        ).rejects.toMatchObject({
+            code: 'WORKSPACE_REQUIRED',
+            hints: expect.arrayContaining([expect.stringContaining('td workspace use')]),
+        })
     })
 })

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -13,6 +13,10 @@ export interface HelpCenterConfig {
     defaultLocale?: string
 }
 
+export interface WorkspaceConfig {
+    defaultWorkspace?: string
+}
+
 /**
  * Canonical ordered list of login flags. Acts as the single source of truth —
  * `AuthFlag`, `AUTH_FLAGS` (validation), and the display order of re-login
@@ -31,6 +35,7 @@ export interface Config extends Record<string, unknown> {
     auth_flags?: AuthFlag[]
     update_channel?: UpdateChannel
     hc?: HelpCenterConfig
+    workspace?: WorkspaceConfig
 }
 
 const KNOWN_CONFIG_KEYS: ReadonlySet<string> = new Set([
@@ -41,9 +46,11 @@ const KNOWN_CONFIG_KEYS: ReadonlySet<string> = new Set([
     'auth_flags',
     'update_channel',
     'hc',
+    'workspace',
 ])
 
 const KNOWN_HC_CONFIG_KEYS: ReadonlySet<string> = new Set(['defaultLocale'])
+const KNOWN_WORKSPACE_CONFIG_KEYS: ReadonlySet<string> = new Set(['defaultWorkspace'])
 
 const AUTH_MODES: ReadonlySet<AuthMode> = new Set(['read-only', 'read-write', 'unknown'])
 export const AUTH_FLAGS: ReadonlySet<AuthFlag> = new Set(AUTH_FLAG_ORDER)
@@ -201,6 +208,22 @@ export function validateConfigForDoctor(config: Record<string, unknown>): string
                         )
                     }
                 }
+            }
+        }
+    }
+
+    if (config.workspace !== undefined) {
+        if (!isObject(config.workspace)) {
+            issues.push('workspace must be an object')
+        } else {
+            for (const key of Object.keys(config.workspace)) {
+                if (!KNOWN_WORKSPACE_CONFIG_KEYS.has(key)) {
+                    issues.push(`workspace contains unrecognized key "${key}"`)
+                }
+            }
+            const defaultWorkspace = (config.workspace as Record<string, unknown>).defaultWorkspace
+            if (defaultWorkspace !== undefined && typeof defaultWorkspace !== 'string') {
+                issues.push('workspace.defaultWorkspace must be a string')
             }
         }
     }

--- a/src/lib/refs.ts
+++ b/src/lib/refs.ts
@@ -398,7 +398,14 @@ export async function resolveWorkspaceRef(ref?: string): Promise<Workspace> {
     return resolveFromList(effectiveRef, workspaces, (w) => w.name, 'workspace')
 }
 
-async function readDefaultWorkspaceRef(): Promise<string | undefined> {
+/**
+ * Return the stored default workspace as a ref string (`id:xxx`) if one is
+ * configured, else undefined. Shared by callers that need to distinguish
+ * "default available" from "no default" instead of letting
+ * `resolveWorkspaceRef` throw — e.g. folder commands with their own
+ * single-workspace fallback.
+ */
+export async function readDefaultWorkspaceRef(): Promise<string | undefined> {
     const savedId = (await readConfig()).workspace?.defaultWorkspace
     return savedId ? `id:${savedId}` : undefined
 }

--- a/src/lib/refs.ts
+++ b/src/lib/refs.ts
@@ -6,6 +6,7 @@ import {
     type Workspace,
     type WorkspaceFolder,
 } from './api/workspaces.js'
+import { readConfig } from './config.js'
 import { CliError } from './errors.js'
 import { paginate } from './pagination.js'
 
@@ -376,9 +377,30 @@ export async function resolveParentTaskId(
     throw new CliError('PARENT_NOT_FOUND', `Parent task "${ref}" not found in project.`)
 }
 
-export async function resolveWorkspaceRef(ref: string): Promise<Workspace> {
+/**
+ * Resolve a workspace ref, falling back to the default configured via
+ * `td workspace use` when the caller doesn't pass one. Throws
+ * WORKSPACE_REQUIRED with actionable hints if neither is available.
+ */
+export async function resolveWorkspaceRef(ref?: string): Promise<Workspace> {
+    const effectiveRef = ref ?? (await readDefaultWorkspaceRef())
+    if (!effectiveRef) {
+        throw new CliError(
+            'WORKSPACE_REQUIRED',
+            'No workspace specified and no default workspace is set.',
+            [
+                'Pass a workspace ref, e.g. `td workspace view "My WS"`',
+                'Or set a default with `td workspace use <ref>`',
+            ],
+        )
+    }
     const workspaces = await fetchWorkspaces()
-    return resolveFromList(ref, workspaces, (w) => w.name, 'workspace')
+    return resolveFromList(effectiveRef, workspaces, (w) => w.name, 'workspace')
+}
+
+async function readDefaultWorkspaceRef(): Promise<string | undefined> {
+    const savedId = (await readConfig()).workspace?.defaultWorkspace
+    return savedId ? `id:${savedId}` : undefined
 }
 
 export async function resolveFolderRef(ref: string, workspaceId: string): Promise<WorkspaceFolder> {

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -148,6 +148,8 @@ td workspace update "Acme" --description "Acme Inc." --dry-run   # admin-only
 td workspace delete "Old WS" --yes                                # admin-only
 td workspace user-tasks "Acme" --user alice@example.com
 td workspace activity "Acme" --json
+td workspace use "Acme"              # persist a default; omitted refs on other workspace commands fall back to it
+td workspace use --clear             # forget the stored default
 td folder list "Acme"
 td folder view "Engineering"
 td folder create "Acme" --name "Engineering"


### PR DESCRIPTION
## Summary
- Adds `td workspace use <ref>` to store a default workspace id under `workspace.defaultWorkspace` in the user config, and `td workspace use --clear` to remove it.
- When a workspace ref is omitted from `td workspace view/update/delete/projects/users/user-tasks/activity/insights` and `td folder list/create`, the command falls back to the stored default. `resolveWorkspaceRef` absorbs the fallback behind its existing signature, widened to `string | undefined`.
- Commands where "no workspace" has distinct semantics (`td template create`, `td project move --to-workspace`, `td project archived-count --workspace`) are deliberately unchanged.
- `td config view` now shows the configured default under a Workspace section, and `td doctor`'s validator understands the new nested config block.

## Test plan
- [x] `npm run type-check`
- [x] `npm test` (7 new tests cover: set, `id:` refs, `--clear`, `--clear` no-op, default fallback, explicit ref overrides default, `WORKSPACE_REQUIRED` error when neither is set)
- [x] `npm run check` (oxlint + oxfmt)
- [x] `npm run sync:skill` — committed regenerated `skills/todoist-cli/SKILL.md`
- [ ] Manual smoke: `td workspace use "My WS"` → `td workspace projects` (uses default) → `td workspace use --clear`

🤖 Generated with [Claude Code](https://claude.com/claude-code)