### PR TITLE
feat(skill): prompt when install agent is omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ td skill install pi
 td skill install universal
 ```
 
+Running `td skill install` without an agent opens an interactive checklist. The first viable target is preselected, and you can toggle additional installs before pressing Enter.
+
 Skills are installed to `~/<agent-dir>/skills/todoist-cli/SKILL.md` (e.g. `~/.claude/` for claude-code, `~/.agents/` for universal, etc.). When updating the CLI, installed skills are updated automatically. The `universal` agent is compatible with Amp, OpenCode, and other agents that read from `~/.agents/`.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A command-line interface for Todoist.
 Install skills for your coding agent:
 
 ```bash
+td skill install
 td skill install claude-code
 td skill install codex
 td skill install cursor

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@doist/todoist-sdk": "9.8.0",
+        "@inquirer/checkbox": "5.1.4",
         "@napi-rs/keyring": "1.2.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
@@ -188,6 +189,102 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.4.tgz",
+      "integrity": "sha512-w6KF8ZYRvqHhROkOTHXYC3qIV/KYEu5o12oLqQySvch61vrYtRxNSHTONSdJqWiFJPlCUQAHT5OgOIyuTr+MHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.9.tgz",
+      "integrity": "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jimp/core": {
@@ -2991,7 +3088,7 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -3696,6 +3793,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/cliui": {
@@ -4515,6 +4621,30 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/figures": {
       "version": "6.1.0",
@@ -6257,6 +6387,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -10403,7 +10542,7 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   ],
   "dependencies": {
     "@doist/todoist-sdk": "9.8.0",
+    "@inquirer/checkbox": "5.1.4",
     "@napi-rs/keyring": "1.2.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",

--- a/src/commands/skill/index.ts
+++ b/src/commands/skill/index.ts
@@ -31,8 +31,9 @@ Supported agents:
   ${listAgents().join(', ')}
 
 Interactive prompt:
-  Run without an agent to choose from a numbered list.
-  Press Enter for the default, or Ctrl+C to cancel.
+  Run without an agent to choose one or more from an interactive checklist.
+  Use arrow keys to navigate, Space to toggle, Enter to install, or Ctrl+C to cancel.
+  The first viable target is preselected by default.
 
 Examples:
   $ td skill install

--- a/src/commands/skill/index.ts
+++ b/src/commands/skill/index.ts
@@ -1,21 +1,52 @@
 import { Command } from 'commander'
-import { installSkill } from './install.js'
+import { listAgents } from '../../lib/skills/index.js'
+import { canPromptForSkillInstall, installSkill, promptAndInstallSkill } from './install.js'
 import { listSkills } from './list.js'
 import { uninstallSkill } from './uninstall.js'
 import { updateAllSkills, updateSkill } from './update.js'
 
 export function registerSkillCommand(program: Command): void {
-    const skill = program.command('skill').description('Manage coding agent skills/integrations')
+    const skill = program
+        .command('skill')
+        .description('Manage coding agent skills/integrations')
+        .addHelpText(
+            'after',
+            `
+Examples:
+  $ td skill install
+  $ td skill install codex
+  $ td skill update all
+`,
+        )
 
     const installCmd = skill
         .command('install [agent]')
         .description('Install skill for a coding agent')
         .option('--local', 'Install in current project instead of global')
         .option('--force', 'Overwrite existing skill file')
+        .addHelpText(
+            'after',
+            `
+Supported agents:
+  ${listAgents().join(', ')}
+
+Interactive prompt:
+  Run without an agent to choose from a numbered list.
+  Press Enter for the default, or Ctrl+C to cancel.
+
+Examples:
+  $ td skill install
+  $ td skill install codex
+  $ td skill install claude-code --local
+`,
+        )
         .action((agent, options) => {
             if (!agent) {
-                installCmd.help()
-                return
+                if (!canPromptForSkillInstall()) {
+                    installCmd.help()
+                    return
+                }
+                return promptAndInstallSkill(options)
             }
             return installSkill(agent, options)
         })

--- a/src/commands/skill/install.ts
+++ b/src/commands/skill/install.ts
@@ -53,17 +53,18 @@ async function getInstallChoices(local: boolean): Promise<InstallChoice[]> {
     const undetectedUniversal = choices.filter(
         (choice) => !choice.detected && choice.agent === 'universal',
     )
+    const unavailableNonUniversal = local ? undetectedNonUniversal : []
 
     if (detectedNonUniversal.length > 0) {
         return [
             ...detectedNonUniversal,
             ...detectedUniversal,
-            ...undetectedNonUniversal,
             ...undetectedUniversal,
+            ...unavailableNonUniversal,
         ]
     }
 
-    return [...detectedUniversal, ...undetectedUniversal, ...undetectedNonUniversal]
+    return [...detectedUniversal, ...undetectedUniversal, ...unavailableNonUniversal]
 }
 
 async function promptForAgent(options: InstallOptions): Promise<string> {
@@ -116,8 +117,17 @@ async function promptForAgent(options: InstallOptions): Promise<string> {
                 return
             }
 
-            const selection = Number.parseInt(input, 10)
-            if (Number.isNaN(selection) || selection < 1 || selection > choices.length) {
+            if (!/^\d+$/.test(input)) {
+                reject(
+                    new CliError('INVALID_SELECTION', `Invalid selection: ${input}`, [
+                        `Enter a number from 1 to ${choices.length}, or press Enter for ${defaultChoice.agent}. Press Ctrl+C to cancel.`,
+                    ]),
+                )
+                return
+            }
+
+            const selection = Number(input)
+            if (!Number.isInteger(selection) || selection < 1 || selection > choices.length) {
                 reject(
                     new CliError('INVALID_SELECTION', `Invalid selection: ${input}`, [
                         `Enter a number from 1 to ${choices.length}, or press Enter for ${defaultChoice.agent}. Press Ctrl+C to cancel.`,

--- a/src/commands/skill/install.ts
+++ b/src/commands/skill/install.ts
@@ -1,5 +1,5 @@
 import { access } from 'node:fs/promises'
-import { createInterface } from 'node:readline'
+import checkbox, { Separator } from '@inquirer/checkbox'
 import chalk from 'chalk'
 import { CliError } from '../../lib/errors.js'
 import { getInstaller, listAgents, skillInstallers } from '../../lib/skills/index.js'
@@ -14,6 +14,13 @@ interface InstallChoice {
     agent: string
     detected: boolean
     installer: SkillInstaller
+}
+
+interface PromptChoice {
+    value: string
+    name: string
+    checked: boolean
+    description: string
 }
 
 export function canPromptForSkillInstall(): boolean {
@@ -67,7 +74,49 @@ async function getInstallChoices(local: boolean): Promise<InstallChoice[]> {
     return [...detectedUniversal, ...undetectedUniversal, ...unavailableNonUniversal]
 }
 
-async function promptForAgent(options: InstallOptions): Promise<string> {
+function getPromptChoices(
+    choices: InstallChoice[],
+    local: boolean,
+): Array<PromptChoice | Separator> {
+    const [defaultChoice] = choices
+    if (!defaultChoice) {
+        return []
+    }
+
+    const detectedChoices = choices.filter((choice) => choice.detected)
+    const undetectedChoices = choices.filter((choice) => !choice.detected)
+    const groups: Array<PromptChoice | Separator> = []
+
+    const mapChoices = (entries: InstallChoice[]): PromptChoice[] =>
+        entries.map((choice) => {
+            const status = choice.detected ? 'detected' : 'available'
+            return {
+                value: choice.agent,
+                name: `${choice.agent} (${status})`,
+                checked: choice.agent === defaultChoice.agent,
+                description: choice.installer.getInstallPath(local),
+            }
+        })
+
+    if (detectedChoices.length > 0 && undetectedChoices.length > 0) {
+        groups.push(new Separator('Detected locations'))
+        groups.push(...mapChoices(detectedChoices))
+        groups.push(new Separator('Other supported agents'))
+        groups.push(...mapChoices(undetectedChoices))
+        return groups
+    }
+
+    return mapChoices(choices)
+}
+
+function isPromptCancelError(error: unknown): boolean {
+    return (
+        error instanceof Error &&
+        ['AbortPromptError', 'CancelPromptError', 'ExitPromptError'].includes(error.name)
+    )
+}
+
+async function promptForAgents(options: InstallOptions): Promise<string[]> {
     const local = options.local ?? false
     const choices = await getInstallChoices(local)
     const [defaultChoice] = choices
@@ -76,84 +125,74 @@ async function promptForAgent(options: InstallOptions): Promise<string> {
     }
     const scopeLabel = local ? 'current project' : 'home directory'
 
-    console.log('Select where to install the Todoist CLI skill:')
-    console.log(`Checking agent roots in the ${scopeLabel}; detected locations are shown first.`)
-    console.log('')
-
-    for (const [index, choice] of choices.entries()) {
-        const annotations: string[] = []
-        if (index === 0) {
-            annotations.push('default')
+    try {
+        return await checkbox({
+            message: `Select install targets. Detected locations in the ${scopeLabel} are shown first. Press Enter to install the current selection or Ctrl+C to cancel.`,
+            choices: getPromptChoices(choices, local),
+            loop: false,
+            pageSize: Math.max(choices.length + 2, 6),
+            shortcuts: {
+                all: null,
+                invert: null,
+            },
+            validate: (selectedChoices) => {
+                return (
+                    selectedChoices.length > 0 ||
+                    `Select at least one agent, or press Ctrl+C to cancel. Press Enter to install ${defaultChoice.agent}.`
+                )
+            },
+        })
+    } catch (error) {
+        if (isPromptCancelError(error)) {
+            return []
         }
-        if (choice.detected) {
-            annotations.push('detected')
-        }
-        const annotation = annotations.length > 0 ? ` (${annotations.join(', ')})` : ''
-        console.log(`  ${index + 1}. ${choice.agent}${annotation}`)
-        console.log(`     ${chalk.dim(choice.installer.getInstallPath(local))}`)
+        throw error
     }
-
-    console.log('Press Ctrl+C to cancel without installing.')
-    console.log('')
-
-    const rl = createInterface({
-        input: process.stdin,
-        output: process.stdout,
-    })
-
-    return new Promise((resolve, reject) => {
-        rl.on('SIGINT', () => {
-            rl.close()
-            process.stdout.write('\n')
-            resolve('')
-        })
-
-        rl.question(`Enter a number [1]: `, (answer) => {
-            rl.close()
-            const input = answer.trim()
-
-            if (!input) {
-                resolve(defaultChoice.agent)
-                return
-            }
-
-            if (!/^\d+$/.test(input)) {
-                reject(
-                    new CliError('INVALID_SELECTION', `Invalid selection: ${input}`, [
-                        `Enter a number from 1 to ${choices.length}, or press Enter for ${defaultChoice.agent}. Press Ctrl+C to cancel.`,
-                    ]),
-                )
-                return
-            }
-
-            const selection = Number(input)
-            if (!Number.isInteger(selection) || selection < 1 || selection > choices.length) {
-                reject(
-                    new CliError('INVALID_SELECTION', `Invalid selection: ${input}`, [
-                        `Enter a number from 1 to ${choices.length}, or press Enter for ${defaultChoice.agent}. Press Ctrl+C to cancel.`,
-                    ]),
-                )
-                return
-            }
-
-            const selectedChoice = choices[selection - 1]
-            if (!selectedChoice) {
-                reject(new CliError('INVALID_SELECTION', `Invalid selection: ${input}`))
-                return
-            }
-
-            resolve(selectedChoice.agent)
-        })
-    })
 }
 
 export async function promptAndInstallSkill(options: InstallOptions): Promise<void> {
-    const agent = await promptForAgent(options)
-    if (!agent) {
+    const agents = await promptForAgents(options)
+    if (agents.length === 0) {
         console.log(chalk.dim('Cancelled.'))
         return
     }
-    await installSkill(agent, options)
+
+    await validateInstallTargets(agents, options)
+
+    for (const agent of agents) {
+        await installSkill(agent, options)
+    }
+}
+
+async function validateInstallTargets(agents: string[], options: InstallOptions): Promise<void> {
+    const local = options.local ?? false
+    const force = options.force ?? false
+
+    await Promise.all(
+        agents.map(async (agent) => {
+            const installer = getInstaller(agent)
+            if (!installer) {
+                const available = listAgents().join(', ')
+                throw new CliError('UNKNOWN_AGENT', `Unknown agent: ${agent}`, [
+                    `Available agents: ${available}`,
+                ])
+            }
+
+            if (!local && agent !== 'universal' && !(await rootExists(installer, false))) {
+                throw new CliError(
+                    'NOT_INSTALLED',
+                    `${agent} does not appear to be installed (${installer.getAgentRootPath(false)} not found)`,
+                )
+            }
+
+            if (!force && (await installer.isInstalled(local))) {
+                throw new CliError(
+                    'ALREADY_EXISTS',
+                    `Skill file already exists at ${installer.getInstallPath(local)}. Use --force to overwrite.`,
+                )
+            }
+        }),
+    )
 }
 
 export async function installSkill(agent: string, options: InstallOptions): Promise<void> {

--- a/src/commands/skill/install.ts
+++ b/src/commands/skill/install.ts
@@ -1,10 +1,149 @@
+import { access } from 'node:fs/promises'
+import { createInterface } from 'node:readline'
 import chalk from 'chalk'
 import { CliError } from '../../lib/errors.js'
-import { getInstaller, listAgents } from '../../lib/skills/index.js'
+import { getInstaller, listAgents, skillInstallers } from '../../lib/skills/index.js'
+import type { SkillInstaller } from '../../lib/skills/types.js'
 
 export interface InstallOptions {
     local?: boolean
     force?: boolean
+}
+
+interface InstallChoice {
+    agent: string
+    detected: boolean
+    installer: SkillInstaller
+}
+
+export function canPromptForSkillInstall(): boolean {
+    return Boolean(process.stdin.isTTY && process.stdout.isTTY)
+}
+
+async function rootExists(installer: SkillInstaller, local: boolean): Promise<boolean> {
+    try {
+        await access(installer.getAgentRootPath(local))
+        return true
+    } catch {
+        return false
+    }
+}
+
+async function getInstallChoices(local: boolean): Promise<InstallChoice[]> {
+    const choices = await Promise.all(
+        listAgents().map(async (agent) => {
+            const installer = skillInstallers[agent]
+            return {
+                agent,
+                detected: await rootExists(installer, local),
+                installer,
+            }
+        }),
+    )
+
+    const detectedNonUniversal = choices.filter(
+        (choice) => choice.detected && choice.agent !== 'universal',
+    )
+    const detectedUniversal = choices.filter(
+        (choice) => choice.detected && choice.agent === 'universal',
+    )
+    const undetectedNonUniversal = choices.filter(
+        (choice) => !choice.detected && choice.agent !== 'universal',
+    )
+    const undetectedUniversal = choices.filter(
+        (choice) => !choice.detected && choice.agent === 'universal',
+    )
+
+    if (detectedNonUniversal.length > 0) {
+        return [
+            ...detectedNonUniversal,
+            ...detectedUniversal,
+            ...undetectedNonUniversal,
+            ...undetectedUniversal,
+        ]
+    }
+
+    return [...detectedUniversal, ...undetectedUniversal, ...undetectedNonUniversal]
+}
+
+async function promptForAgent(options: InstallOptions): Promise<string> {
+    const local = options.local ?? false
+    const choices = await getInstallChoices(local)
+    const [defaultChoice] = choices
+    if (!defaultChoice) {
+        throw new CliError('NO_AGENTS', 'No skill installers are configured.')
+    }
+    const scopeLabel = local ? 'current project' : 'home directory'
+
+    console.log('Select where to install the Todoist CLI skill:')
+    console.log(`Checking agent roots in the ${scopeLabel}; detected locations are shown first.`)
+    console.log('')
+
+    for (const [index, choice] of choices.entries()) {
+        const annotations: string[] = []
+        if (index === 0) {
+            annotations.push('default')
+        }
+        if (choice.detected) {
+            annotations.push('detected')
+        }
+        const annotation = annotations.length > 0 ? ` (${annotations.join(', ')})` : ''
+        console.log(`  ${index + 1}. ${choice.agent}${annotation}`)
+        console.log(`     ${chalk.dim(choice.installer.getInstallPath(local))}`)
+    }
+
+    console.log('Press Ctrl+C to cancel without installing.')
+    console.log('')
+
+    const rl = createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    })
+
+    return new Promise((resolve, reject) => {
+        rl.on('SIGINT', () => {
+            rl.close()
+            process.stdout.write('\n')
+            resolve('')
+        })
+
+        rl.question(`Enter a number [1]: `, (answer) => {
+            rl.close()
+            const input = answer.trim()
+
+            if (!input) {
+                resolve(defaultChoice.agent)
+                return
+            }
+
+            const selection = Number.parseInt(input, 10)
+            if (Number.isNaN(selection) || selection < 1 || selection > choices.length) {
+                reject(
+                    new CliError('INVALID_SELECTION', `Invalid selection: ${input}`, [
+                        `Enter a number from 1 to ${choices.length}, or press Enter for ${defaultChoice.agent}. Press Ctrl+C to cancel.`,
+                    ]),
+                )
+                return
+            }
+
+            const selectedChoice = choices[selection - 1]
+            if (!selectedChoice) {
+                reject(new CliError('INVALID_SELECTION', `Invalid selection: ${input}`))
+                return
+            }
+
+            resolve(selectedChoice.agent)
+        })
+    })
+}
+
+export async function promptAndInstallSkill(options: InstallOptions): Promise<void> {
+    const agent = await promptForAgent(options)
+    if (!agent) {
+        console.log(chalk.dim('Cancelled.'))
+        return
+    }
+    await installSkill(agent, options)
 }
 
 export async function installSkill(agent: string, options: InstallOptions): Promise<void> {

--- a/src/commands/skill/skill.test.ts
+++ b/src/commands/skill/skill.test.ts
@@ -1,39 +1,55 @@
 import { access, mkdir, mkdtemp, readFile, rm, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import checkbox from '@inquirer/checkbox'
 import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('chalk')
 
-vi.mock('node:readline', () => ({
-    createInterface: vi.fn(() => {
-        const rl = {
-            question: vi.fn(),
-            close: vi.fn(),
-            on: vi.fn(),
+vi.mock('@inquirer/checkbox', () => ({
+    default: vi.fn(),
+    Separator: class Separator {
+        separator: string
+
+        constructor(separator = '') {
+            this.separator = separator
         }
-        return rl
-    }),
+    },
 }))
 
 vi.mock('../../lib/skills/update-installed.js', () => ({
     updateAllInstalledSkills: vi.fn(),
 }))
 
-import { createInterface, type Interface } from 'node:readline'
 import { createInstaller } from '../../lib/skills/create-installer.js'
 import { getInstaller, listAgents, skillInstallers } from '../../lib/skills/index.js'
 import { updateAllInstalledSkills } from '../../lib/skills/update-installed.js'
 import { registerSkillCommand } from './index.js'
-
-const mockCreateInterface = vi.mocked(createInterface)
 
 function createProgram() {
     const program = new Command()
     program.exitOverride()
     registerSkillCommand(program)
     return program
+}
+
+const mockCheckbox = vi.mocked(checkbox)
+
+function getPromptEntries() {
+    const [config] = mockCheckbox.mock.calls.at(-1) ?? []
+    if (!config || !('choices' in config)) {
+        throw new Error('Expected checkbox prompt to be called with choices.')
+    }
+
+    return config.choices
+}
+
+function getPromptChoices() {
+    return getPromptEntries().filter(
+        (choice): choice is { value: string; name: string; checked?: boolean } =>
+            typeof choice === 'object' && choice !== null && 'value' in choice,
+    )
 }
 
 describe('skill command', () => {
@@ -95,7 +111,10 @@ describe('skill command', () => {
             writeSpy.mockRestore()
             expect(output).toContain('Supported agents:')
             expect(output).toContain('claude-code, codex, cursor, gemini, pi, universal')
-            expect(output).toContain('Press Enter for the default, or Ctrl+C to cancel.')
+            expect(output).toContain(
+                'Use arrow keys to navigate, Space to toggle, Enter to install, or Ctrl+C to cancel.',
+            )
+            expect(output).toContain('The first viable target is preselected by default.')
         })
 
         it('shows help when no agent provided in a non-interactive environment', async () => {
@@ -119,17 +138,10 @@ describe('skill command', () => {
             const program = createProgram()
             const testDir = await mkdtemp(join(tmpdir(), 'skill-install-local-'))
             const originalCwd = process.cwd()
-            const mockRl = {
-                question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
-                    cb('')
-                }),
-                close: vi.fn(),
-                on: vi.fn(),
-            }
 
             Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
             Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
-            mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
+            mockCheckbox.mockResolvedValue(['codex'])
 
             process.chdir(testDir)
             try {
@@ -137,16 +149,15 @@ describe('skill command', () => {
 
                 await program.parseAsync(['node', 'td', 'skill', 'install', '--local'])
 
+                const choices = getPromptChoices()
                 await expect(
                     access(join(testDir, '.codex', 'skills', 'todoist-cli', 'SKILL.md')),
                 ).resolves.toBeUndefined()
-                expect(consoleSpy).toHaveBeenCalledWith(
-                    'Checking agent roots in the current project; detected locations are shown first.',
-                )
-                expect(consoleSpy).toHaveBeenCalledWith('  1. codex (default, detected)')
-                expect(consoleSpy).toHaveBeenCalledWith(
-                    'Press Ctrl+C to cancel without installing.',
-                )
+                expect(choices[0]).toMatchObject({
+                    value: 'codex',
+                    name: 'codex (detected)',
+                    checked: true,
+                })
                 expect(consoleSpy).toHaveBeenCalledWith('✓', 'Installed codex skill')
             } finally {
                 process.chdir(originalCwd)
@@ -158,26 +169,24 @@ describe('skill command', () => {
             const program = createProgram()
             const testDir = await mkdtemp(join(tmpdir(), 'skill-install-universal-'))
             const originalCwd = process.cwd()
-            const mockRl = {
-                question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
-                    cb('')
-                }),
-                close: vi.fn(),
-                on: vi.fn(),
-            }
 
             Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
             Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
-            mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
+            mockCheckbox.mockResolvedValue(['universal'])
 
             process.chdir(testDir)
             try {
                 await program.parseAsync(['node', 'td', 'skill', 'install', '--local'])
 
+                const choices = getPromptChoices()
                 await expect(
                     access(join(testDir, '.agents', 'skills', 'todoist-cli', 'SKILL.md')),
                 ).resolves.toBeUndefined()
-                expect(consoleSpy).toHaveBeenCalledWith('  1. universal (default)')
+                expect(choices[0]).toMatchObject({
+                    value: 'universal',
+                    name: 'universal (available)',
+                    checked: true,
+                })
                 expect(consoleSpy).toHaveBeenCalledWith('✓', 'Installed universal skill')
             } finally {
                 process.chdir(originalCwd)
@@ -188,56 +197,50 @@ describe('skill command', () => {
         it('omits unavailable non-universal options in global mode', async () => {
             const program = createProgram()
             const testDir = await mkdtemp(join(tmpdir(), 'skill-install-global-'))
-            const mockRl = {
-                question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
-                    cb('')
-                }),
-                close: vi.fn(),
-                on: vi.fn(),
-            }
 
             process.env.HOME = testDir
             Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
             Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
-            mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
+            mockCheckbox.mockResolvedValue(['universal'])
 
             try {
                 await program.parseAsync(['node', 'td', 'skill', 'install'])
 
+                const choices = getPromptChoices()
                 await expect(
                     access(join(testDir, '.agents', 'skills', 'todoist-cli', 'SKILL.md')),
                 ).resolves.toBeUndefined()
-                expect(consoleSpy).toHaveBeenCalledWith('  1. universal (default)')
-                expect(consoleSpy).not.toHaveBeenCalledWith('  2. claude-code')
-                expect(consoleSpy).not.toHaveBeenCalledWith('  2. codex')
+                expect(choices).toHaveLength(1)
+                expect(choices[0]).toMatchObject({
+                    value: 'universal',
+                    name: 'universal (available)',
+                    checked: true,
+                })
             } finally {
                 await rm(testDir, { recursive: true, force: true })
             }
         })
 
-        it('installs the selected numbered option', async () => {
+        it('installs every selected option from the checklist', async () => {
             const program = createProgram()
             const testDir = await mkdtemp(join(tmpdir(), 'skill-install-choice-'))
             const originalCwd = process.cwd()
-            const mockRl = {
-                question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
-                    cb('2')
-                }),
-                close: vi.fn(),
-                on: vi.fn(),
-            }
 
             Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
             Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
-            mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
+            mockCheckbox.mockResolvedValue(['codex', 'claude-code'])
 
             process.chdir(testDir)
             try {
                 await program.parseAsync(['node', 'td', 'skill', 'install', '--local'])
 
                 await expect(
+                    access(join(testDir, '.codex', 'skills', 'todoist-cli', 'SKILL.md')),
+                ).resolves.toBeUndefined()
+                await expect(
                     access(join(testDir, '.claude', 'skills', 'todoist-cli', 'SKILL.md')),
                 ).resolves.toBeUndefined()
+                expect(consoleSpy).toHaveBeenCalledWith('✓', 'Installed codex skill')
                 expect(consoleSpy).toHaveBeenCalledWith('✓', 'Installed claude-code skill')
             } finally {
                 process.chdir(originalCwd)
@@ -245,30 +248,35 @@ describe('skill command', () => {
             }
         })
 
-        it('rejects partial numeric input instead of truncating it', async () => {
+        it('validates the full multi-select before writing any files', async () => {
             const program = createProgram()
             const testDir = await mkdtemp(join(tmpdir(), 'skill-install-invalid-'))
             const originalCwd = process.cwd()
-            const mockRl = {
-                question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
-                    cb('2abc')
-                }),
-                close: vi.fn(),
-                on: vi.fn(),
-            }
 
             Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
             Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
-            mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
+            mockCheckbox.mockResolvedValue(['codex', 'claude-code'])
 
             process.chdir(testDir)
             try {
-                await expect(
-                    program.parseAsync(['node', 'td', 'skill', 'install', '--local']),
-                ).rejects.toThrow('Invalid selection: 2abc')
+                const existingSkillPath = join(
+                    testDir,
+                    '.claude',
+                    'skills',
+                    'todoist-cli',
+                    'SKILL.md',
+                )
+                await mkdir(join(testDir, '.claude', 'skills', 'todoist-cli'), { recursive: true })
+                await writeFile(existingSkillPath, 'existing skill', 'utf-8')
 
                 await expect(
-                    access(join(testDir, '.claude', 'skills', 'todoist-cli', 'SKILL.md')),
+                    program.parseAsync(['node', 'td', 'skill', 'install', '--local']),
+                ).rejects.toThrow(
+                    /Skill file already exists at .*\.claude\/skills\/todoist-cli\/SKILL\.md\. Use --force to overwrite\./,
+                )
+
+                await expect(
+                    access(join(testDir, '.codex', 'skills', 'todoist-cli', 'SKILL.md')),
                 ).rejects.toThrow()
             } finally {
                 process.chdir(originalCwd)
@@ -280,22 +288,12 @@ describe('skill command', () => {
             const program = createProgram()
             const testDir = await mkdtemp(join(tmpdir(), 'skill-install-cancel-'))
             const originalCwd = process.cwd()
-            let handleSigint: (() => void) | undefined
-            const mockRl = {
-                question: vi.fn(() => {
-                    handleSigint?.()
-                }),
-                close: vi.fn(),
-                on: vi.fn((event: string, handler: () => void) => {
-                    if (event === 'SIGINT') {
-                        handleSigint = handler
-                    }
-                }),
-            }
 
             Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
             Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
-            mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
+            const promptError = new Error('Prompt cancelled')
+            promptError.name = 'ExitPromptError'
+            mockCheckbox.mockRejectedValue(promptError)
 
             process.chdir(testDir)
             try {

--- a/src/commands/skill/skill.test.ts
+++ b/src/commands/skill/skill.test.ts
@@ -40,12 +40,14 @@ describe('skill command', () => {
     let consoleSpy: ReturnType<typeof vi.spyOn>
     let originalStdinIsTTY: PropertyDescriptor | undefined
     let originalStdoutIsTTY: PropertyDescriptor | undefined
+    let originalHome: string | undefined
 
     beforeEach(() => {
         vi.clearAllMocks()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
         originalStdinIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY')
         originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+        originalHome = process.env.HOME
     })
 
     afterEach(() => {
@@ -55,6 +57,11 @@ describe('skill command', () => {
         }
         if (originalStdoutIsTTY) {
             Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY)
+        }
+        if (originalHome === undefined) {
+            delete process.env.HOME
+        } else {
+            process.env.HOME = originalHome
         }
     })
 
@@ -178,6 +185,36 @@ describe('skill command', () => {
             }
         })
 
+        it('omits unavailable non-universal options in global mode', async () => {
+            const program = createProgram()
+            const testDir = await mkdtemp(join(tmpdir(), 'skill-install-global-'))
+            const mockRl = {
+                question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
+                    cb('')
+                }),
+                close: vi.fn(),
+                on: vi.fn(),
+            }
+
+            process.env.HOME = testDir
+            Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+            Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+            mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
+
+            try {
+                await program.parseAsync(['node', 'td', 'skill', 'install'])
+
+                await expect(
+                    access(join(testDir, '.agents', 'skills', 'todoist-cli', 'SKILL.md')),
+                ).resolves.toBeUndefined()
+                expect(consoleSpy).toHaveBeenCalledWith('  1. universal (default)')
+                expect(consoleSpy).not.toHaveBeenCalledWith('  2. claude-code')
+                expect(consoleSpy).not.toHaveBeenCalledWith('  2. codex')
+            } finally {
+                await rm(testDir, { recursive: true, force: true })
+            }
+        })
+
         it('installs the selected numbered option', async () => {
             const program = createProgram()
             const testDir = await mkdtemp(join(tmpdir(), 'skill-install-choice-'))
@@ -202,6 +239,37 @@ describe('skill command', () => {
                     access(join(testDir, '.claude', 'skills', 'todoist-cli', 'SKILL.md')),
                 ).resolves.toBeUndefined()
                 expect(consoleSpy).toHaveBeenCalledWith('✓', 'Installed claude-code skill')
+            } finally {
+                process.chdir(originalCwd)
+                await rm(testDir, { recursive: true, force: true })
+            }
+        })
+
+        it('rejects partial numeric input instead of truncating it', async () => {
+            const program = createProgram()
+            const testDir = await mkdtemp(join(tmpdir(), 'skill-install-invalid-'))
+            const originalCwd = process.cwd()
+            const mockRl = {
+                question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
+                    cb('2abc')
+                }),
+                close: vi.fn(),
+                on: vi.fn(),
+            }
+
+            Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+            Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+            mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
+
+            process.chdir(testDir)
+            try {
+                await expect(
+                    program.parseAsync(['node', 'td', 'skill', 'install', '--local']),
+                ).rejects.toThrow('Invalid selection: 2abc')
+
+                await expect(
+                    access(join(testDir, '.claude', 'skills', 'todoist-cli', 'SKILL.md')),
+                ).rejects.toThrow()
             } finally {
                 process.chdir(originalCwd)
                 await rm(testDir, { recursive: true, force: true })

--- a/src/commands/skill/skill.test.ts
+++ b/src/commands/skill/skill.test.ts
@@ -6,14 +6,28 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('chalk')
 
+vi.mock('node:readline', () => ({
+    createInterface: vi.fn(() => {
+        const rl = {
+            question: vi.fn(),
+            close: vi.fn(),
+            on: vi.fn(),
+        }
+        return rl
+    }),
+}))
+
 vi.mock('../../lib/skills/update-installed.js', () => ({
     updateAllInstalledSkills: vi.fn(),
 }))
 
+import { createInterface, type Interface } from 'node:readline'
 import { createInstaller } from '../../lib/skills/create-installer.js'
 import { getInstaller, listAgents, skillInstallers } from '../../lib/skills/index.js'
 import { updateAllInstalledSkills } from '../../lib/skills/update-installed.js'
 import { registerSkillCommand } from './index.js'
+
+const mockCreateInterface = vi.mocked(createInterface)
 
 function createProgram() {
     const program = new Command()
@@ -24,14 +38,24 @@ function createProgram() {
 
 describe('skill command', () => {
     let consoleSpy: ReturnType<typeof vi.spyOn>
+    let originalStdinIsTTY: PropertyDescriptor | undefined
+    let originalStdoutIsTTY: PropertyDescriptor | undefined
 
     beforeEach(() => {
         vi.clearAllMocks()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        originalStdinIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY')
+        originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
     })
 
     afterEach(() => {
         consoleSpy.mockRestore()
+        if (originalStdinIsTTY) {
+            Object.defineProperty(process.stdin, 'isTTY', originalStdinIsTTY)
+        }
+        if (originalStdoutIsTTY) {
+            Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY)
+        }
     })
 
     describe('list subcommand', () => {
@@ -50,8 +74,28 @@ describe('skill command', () => {
     })
 
     describe('install subcommand', () => {
-        it('shows help when no agent provided', async () => {
+        it('includes supported agent names in install help', async () => {
             const program = createProgram()
+            let output = ''
+            const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+                output += String(chunk)
+                return true
+            })
+
+            await expect(
+                program.parseAsync(['node', 'td', 'skill', 'install', '--help']),
+            ).rejects.toThrow()
+            writeSpy.mockRestore()
+            expect(output).toContain('Supported agents:')
+            expect(output).toContain('claude-code, codex, cursor, gemini, pi, universal')
+            expect(output).toContain('Press Enter for the default, or Ctrl+C to cancel.')
+        })
+
+        it('shows help when no agent provided in a non-interactive environment', async () => {
+            const program = createProgram()
+
+            Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true })
+            Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true })
 
             await expect(program.parseAsync(['node', 'td', 'skill', 'install'])).rejects.toThrow()
         })
@@ -62,6 +106,141 @@ describe('skill command', () => {
             await expect(
                 program.parseAsync(['node', 'td', 'skill', 'install', 'unknown-agent']),
             ).rejects.toThrow('Unknown agent: unknown-agent')
+        })
+
+        it('prompts interactively and defaults to the first detected agent root', async () => {
+            const program = createProgram()
+            const testDir = await mkdtemp(join(tmpdir(), 'skill-install-local-'))
+            const originalCwd = process.cwd()
+            const mockRl = {
+                question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
+                    cb('')
+                }),
+                close: vi.fn(),
+                on: vi.fn(),
+            }
+
+            Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+            Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+            mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
+
+            process.chdir(testDir)
+            try {
+                await mkdir(join(testDir, '.codex'), { recursive: true })
+
+                await program.parseAsync(['node', 'td', 'skill', 'install', '--local'])
+
+                await expect(
+                    access(join(testDir, '.codex', 'skills', 'todoist-cli', 'SKILL.md')),
+                ).resolves.toBeUndefined()
+                expect(consoleSpy).toHaveBeenCalledWith(
+                    'Checking agent roots in the current project; detected locations are shown first.',
+                )
+                expect(consoleSpy).toHaveBeenCalledWith('  1. codex (default, detected)')
+                expect(consoleSpy).toHaveBeenCalledWith(
+                    'Press Ctrl+C to cancel without installing.',
+                )
+                expect(consoleSpy).toHaveBeenCalledWith('✓', 'Installed codex skill')
+            } finally {
+                process.chdir(originalCwd)
+                await rm(testDir, { recursive: true, force: true })
+            }
+        })
+
+        it('puts universal first when no agent-specific roots exist', async () => {
+            const program = createProgram()
+            const testDir = await mkdtemp(join(tmpdir(), 'skill-install-universal-'))
+            const originalCwd = process.cwd()
+            const mockRl = {
+                question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
+                    cb('')
+                }),
+                close: vi.fn(),
+                on: vi.fn(),
+            }
+
+            Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+            Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+            mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
+
+            process.chdir(testDir)
+            try {
+                await program.parseAsync(['node', 'td', 'skill', 'install', '--local'])
+
+                await expect(
+                    access(join(testDir, '.agents', 'skills', 'todoist-cli', 'SKILL.md')),
+                ).resolves.toBeUndefined()
+                expect(consoleSpy).toHaveBeenCalledWith('  1. universal (default)')
+                expect(consoleSpy).toHaveBeenCalledWith('✓', 'Installed universal skill')
+            } finally {
+                process.chdir(originalCwd)
+                await rm(testDir, { recursive: true, force: true })
+            }
+        })
+
+        it('installs the selected numbered option', async () => {
+            const program = createProgram()
+            const testDir = await mkdtemp(join(tmpdir(), 'skill-install-choice-'))
+            const originalCwd = process.cwd()
+            const mockRl = {
+                question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
+                    cb('2')
+                }),
+                close: vi.fn(),
+                on: vi.fn(),
+            }
+
+            Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+            Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+            mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
+
+            process.chdir(testDir)
+            try {
+                await program.parseAsync(['node', 'td', 'skill', 'install', '--local'])
+
+                await expect(
+                    access(join(testDir, '.claude', 'skills', 'todoist-cli', 'SKILL.md')),
+                ).resolves.toBeUndefined()
+                expect(consoleSpy).toHaveBeenCalledWith('✓', 'Installed claude-code skill')
+            } finally {
+                process.chdir(originalCwd)
+                await rm(testDir, { recursive: true, force: true })
+            }
+        })
+
+        it('allows cancelling the interactive chooser without installing anything', async () => {
+            const program = createProgram()
+            const testDir = await mkdtemp(join(tmpdir(), 'skill-install-cancel-'))
+            const originalCwd = process.cwd()
+            let handleSigint: (() => void) | undefined
+            const mockRl = {
+                question: vi.fn(() => {
+                    handleSigint?.()
+                }),
+                close: vi.fn(),
+                on: vi.fn((event: string, handler: () => void) => {
+                    if (event === 'SIGINT') {
+                        handleSigint = handler
+                    }
+                }),
+            }
+
+            Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+            Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+            mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
+
+            process.chdir(testDir)
+            try {
+                await program.parseAsync(['node', 'td', 'skill', 'install', '--local'])
+
+                await expect(
+                    access(join(testDir, '.agents', 'skills', 'todoist-cli', 'SKILL.md')),
+                ).rejects.toThrow()
+                expect(consoleSpy).toHaveBeenCalledWith('Cancelled.')
+            } finally {
+                process.chdir(originalCwd)
+                await rm(testDir, { recursive: true, force: true })
+            }
         })
     })
 
@@ -206,6 +385,12 @@ describe('installer paths', () => {
                 expect(globalPath).toContain('skills')
                 expect(globalPath).toContain('todoist-cli')
                 expect(globalPath).toContain('SKILL.md')
+            })
+
+            it(`returns global root path containing ${dir}`, () => {
+                const globalRootPath = installer.getAgentRootPath(false)
+                expect(globalRootPath).toContain(dir)
+                expect(globalRootPath.endsWith(dir)).toBe(true)
             })
 
             it('returns local path containing cwd', () => {

--- a/src/lib/skills/create-installer.ts
+++ b/src/lib/skills/create-installer.ts
@@ -28,14 +28,20 @@ metadata:
 }
 
 export function createInstaller(config: InstallerConfig): SkillInstaller {
-    function getInstallPath(local: boolean): string {
+    function getAgentRootPath(local: boolean): string {
         const base = local ? process.cwd() : homedir()
-        return join(base, config.dirName, 'skills', SKILL_NAME, 'SKILL.md')
+        return join(base, config.dirName)
+    }
+
+    function getInstallPath(local: boolean): string {
+        return join(getAgentRootPath(local), 'skills', SKILL_NAME, 'SKILL.md')
     }
 
     return {
         name: config.name,
         description: config.description,
+
+        getAgentRootPath,
 
         getInstallPath,
 

--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -1,6 +1,7 @@
 export interface SkillInstaller {
     name: string
     description: string
+    getAgentRootPath(local: boolean): string
     getInstallPath(local: boolean): string
     generateContent(): string
     isInstalled(local: boolean): Promise<boolean>

--- a/src/lib/skills/update-installed.test.ts
+++ b/src/lib/skills/update-installed.test.ts
@@ -12,6 +12,7 @@ function mockInstaller(overrides: Partial<SkillInstaller> = {}): SkillInstaller 
     return {
         name: 'test',
         description: 'test',
+        getAgentRootPath: vi.fn(() => '/test'),
         getInstallPath: vi.fn(() => '/test/path'),
         generateContent: vi.fn(() => 'content'),
         isInstalled: vi.fn(async () => false),


### PR DESCRIPTION
This updates `td skill install` so running it without an agent opens an interactive checklist in TTY sessions, while non-interactive runs still show help.

The checklist keeps the first viable target preselected for a fast Enter-to-install flow, allows selecting multiple install targets in one run, and still ranks detected agent roots first. In global mode it only shows install targets that can actually succeed on that machine; in local mode it also shows the other supported agents.

The install flow now preflights the full selection before writing anything, so a bad target does not leave partial installs behind. It also keeps clean cancellation via `Ctrl+C`, updates the `--help` text and README guidance, and switches the prompt implementation to `@inquirer/checkbox`.

## Test

```shell
npm run build
npm run type-check
npm test
npx oxlint src
```

## Demo


https://github.com/user-attachments/assets/957890c6-ce2a-45c6-b196-1f0ead347d6f

