### PR TITLE
feat(user,config,doctor): polish multi-user surface

### DIFF
--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -61,7 +61,9 @@ The CLI can hold credentials for multiple Todoist accounts at once.
 ```bash
 td auth login                       # adds the account; first one becomes default
 td user list                        # all stored accounts (with default marker)
-td user use <id|email>              # set the default account
+td user use <id|email>              # set the default account (alias: td user default)
+td user current                     # show the active account
+td user remove <id|email>           # delete an account (and its token)
 td --user <id|email> task list      # one-off override for any command
 td auth logout --user <id|email>    # log out a specific account
 ```

--- a/src/commands/config/config.test.ts
+++ b/src/commands/config/config.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('../../lib/config.js', () => ({
     CONFIG_PATH: '/tmp/fake-todoist-cli/config.json',
     readConfigStrict: vi.fn(),
+    readConfig: vi.fn().mockResolvedValue({}),
 }))
 
 vi.mock('../../lib/auth.js', async () => {
@@ -11,12 +12,13 @@ vi.mock('../../lib/auth.js', async () => {
     return {
         ...actual,
         probeApiToken: vi.fn(),
+        listStoredUsers: vi.fn().mockResolvedValue([]),
     }
 })
 
 vi.mock('chalk')
 
-import { NoTokenError, probeApiToken } from '../../lib/auth.js'
+import { listStoredUsers, NoTokenError, probeApiToken } from '../../lib/auth.js'
 import { type Config, readConfigStrict } from '../../lib/config.js'
 import { CliError } from '../../lib/errors.js'
 import { SecureStoreUnavailableError } from '../../lib/secure-store.js'
@@ -24,6 +26,7 @@ import { registerConfigCommand } from './index.js'
 
 const mockReadConfigStrict = vi.mocked(readConfigStrict)
 const mockProbeApiToken = vi.mocked(probeApiToken)
+const mockListStoredUsers = vi.mocked(listStoredUsers)
 
 function createProgram() {
     const program = new Command()
@@ -234,6 +237,100 @@ describe('config view', () => {
         const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string)
         expect(parsed.api_token).toBe('****')
         expect(parsed.api_token).not.toContain('abcd')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('lists stored accounts and marks the default in pretty mode', async () => {
+        presentConfig({
+            config_version: 2,
+            user: { defaultUser: '111' },
+            users: [
+                { id: '111', email: 'first@example.com', auth_mode: 'read-write' },
+                {
+                    id: '222',
+                    email: 'second@example.com',
+                    auth_mode: 'read-only',
+                    auth_scope: 'data:read',
+                },
+            ],
+        })
+        mockListStoredUsers.mockResolvedValue([
+            { id: '111', email: 'first@example.com', auth_mode: 'read-write' },
+            {
+                id: '222',
+                email: 'second@example.com',
+                auth_mode: 'read-only',
+                auth_scope: 'data:read',
+            },
+        ])
+        mockProbeApiToken.mockResolvedValue({
+            token: 'tdo_first_token_xxxx1111',
+            metadata: {
+                authMode: 'read-write',
+                source: 'secure-store',
+                userId: '111',
+                email: 'first@example.com',
+            },
+        })
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'td', 'config', 'view'])
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+
+        expect(output).toContain('Stored accounts (2)')
+        expect(output).toContain('first@example.com')
+        expect(output).toContain('second@example.com')
+        expect(output).toContain('(default)')
+        expect(output).toContain('Active:        first@example.com')
+        expect(output).toContain('read-only (data:read)')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('flags ambiguous resolution when multiple users with no default', async () => {
+        presentConfig({
+            config_version: 2,
+            users: [
+                { id: '111', email: 'a@b.c' },
+                { id: '222', email: 'd@e.f' },
+            ],
+        })
+        mockListStoredUsers.mockResolvedValue([
+            { id: '111', email: 'a@b.c' },
+            { id: '222', email: 'd@e.f' },
+        ])
+        const { NoUserSelectedError } = await import('../../lib/users.js')
+        mockProbeApiToken.mockRejectedValue(new NoUserSelectedError())
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'td', 'config', 'view'])
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+
+        expect(output).toContain('multiple stored accounts')
+        expect(output).toContain('--user')
+        expect(output).toContain('Stored accounts (2)')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('--json masks per-user api_token entries', async () => {
+        presentConfig({
+            config_version: 2,
+            users: [
+                {
+                    id: '111',
+                    email: 'a@b.c',
+                    api_token: 'tdo_plaintext_user_token_xxxx',
+                },
+            ],
+        })
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'td', 'config', 'view', '--json'])
+        const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string)
+        expect(parsed.users[0].api_token).toBe('****…xxxx')
+        expect(parsed.users[0].api_token).not.toContain('plaintext')
 
         consoleSpy.mockRestore()
     })

--- a/src/commands/config/view.ts
+++ b/src/commands/config/view.ts
@@ -1,7 +1,15 @@
 import chalk from 'chalk'
-import { type AuthMetadata, NoTokenError, probeApiToken, TOKEN_ENV_VAR } from '../../lib/auth.js'
+import {
+    type AuthMetadata,
+    listStoredUsers,
+    NoTokenError,
+    probeApiToken,
+    type StoredUser,
+    TOKEN_ENV_VAR,
+} from '../../lib/auth.js'
 import { type Config, CONFIG_PATH, readConfigStrict } from '../../lib/config.js'
 import { SECURE_STORE_DESCRIPTION, SecureStoreUnavailableError } from '../../lib/secure-store.js'
+import { getDefaultUserId, NoUserSelectedError } from '../../lib/users.js'
 
 export interface ViewConfigOptions {
     json?: boolean
@@ -11,6 +19,7 @@ export interface ViewConfigOptions {
 type TokenStatus =
     | { state: 'present'; token: string; metadata: AuthMetadata }
     | { state: 'missing' }
+    | { state: 'ambiguous' }
     | { state: 'unavailable'; reason: string }
 
 function maskToken(token: string): string {
@@ -35,6 +44,7 @@ async function probeTokenPresence(): Promise<TokenStatus> {
         return { state: 'present', token, metadata }
     } catch (error) {
         if (error instanceof NoTokenError) return { state: 'missing' }
+        if (error instanceof NoUserSelectedError) return { state: 'ambiguous' }
         if (error instanceof SecureStoreUnavailableError) {
             return {
                 state: 'unavailable',
@@ -62,31 +72,84 @@ function renderTokenLine(token: TokenStatus, showToken: boolean): string {
         }
         case 'unavailable':
             return chalk.dim(`unknown — ${token.reason}`)
+        case 'ambiguous':
+            return chalk.dim(
+                'multiple stored accounts; pass --user <id|email> or set a default with `td user use`',
+            )
         case 'missing':
             return formatValue(undefined)
     }
 }
 
-function formatConfigView(config: Config, token: TokenStatus, showToken: boolean): string {
+function formatStoredUserMode(user: StoredUser): string {
+    if (user.auth_mode === 'read-only') {
+        return `read-only (${user.auth_scope ?? 'data:read'})`
+    }
+    if (user.auth_mode === 'read-write') {
+        return 'read-write'
+    }
+    return chalk.dim('unknown')
+}
+
+function formatConfigView(
+    config: Config,
+    token: TokenStatus,
+    showToken: boolean,
+    users: StoredUser[],
+    defaultUserId: string | undefined,
+): string {
     const lines: string[] = []
     lines.push(`${chalk.dim('Config file:')} ${CONFIG_PATH}`)
     lines.push('')
 
+    // Active-user line: who would the next command run as?
+    lines.push(chalk.bold('Authentication'))
+    if (token.state === 'present' && token.metadata.email) {
+        const isDefault = token.metadata.userId === defaultUserId
+        const marker =
+            token.metadata.source === 'env' ? ' (TODOIST_API_TOKEN)' : isDefault ? ' (default)' : ''
+        lines.push(
+            `  Active:        ${token.metadata.email} ${chalk.dim(`(id:${token.metadata.userId ?? '—'})`)}${marker}`,
+        )
+    } else if (token.state === 'present' && token.metadata.source === 'env') {
+        lines.push(`  Active:        ${chalk.dim('(TODOIST_API_TOKEN)')}`)
+    } else if (token.state === 'ambiguous') {
+        lines.push(`  Active:        ${chalk.dim('(none — multiple accounts, no default)')}`)
+    } else if (token.state === 'missing') {
+        lines.push(`  Active:        ${chalk.dim('(none)')}`)
+    }
     // When a token is present, its metadata is the ground truth for the active
     // mode/scope/flags — this matters most for env-sourced tokens, whose scope
-    // the CLI does not actually know and where config.auth_* may be stale from
-    // an unrelated `td auth login`. For missing/unavailable tokens, fall back
-    // to the config file values (what the CLI would attempt once auth recovers).
+    // the CLI does not actually know. For missing/unavailable tokens, fall
+    // back to the config file values (what the CLI would attempt once auth
+    // recovers — only relevant for legacy v1 state).
     const effectiveMode = token.state === 'present' ? token.metadata.authMode : config.auth_mode
     const effectiveScope = token.state === 'present' ? token.metadata.authScope : config.auth_scope
     const effectiveFlags = token.state === 'present' ? token.metadata.authFlags : config.auth_flags
 
-    lines.push(chalk.bold('Authentication'))
     lines.push(`  Token:         ${renderTokenLine(token, showToken)}`)
     lines.push(`  Mode:          ${formatValue(effectiveMode)}`)
     lines.push(`  Scope:         ${formatValue(effectiveScope)}`)
     lines.push(`  Flags:         ${formatValue(effectiveFlags)}`)
     lines.push('')
+
+    if (users.length > 0) {
+        lines.push(chalk.bold(`Stored accounts (${users.length})`))
+        for (const u of users) {
+            const isDefault = u.id === defaultUserId
+            const marker = isDefault ? chalk.green(' (default)') : ''
+            const storage = u.api_token
+                ? chalk.yellow('plaintext fallback')
+                : chalk.dim(SECURE_STORE_DESCRIPTION)
+            lines.push(`  ${u.email} ${chalk.dim(`(id:${u.id})`)}${marker}`)
+            lines.push(`    Mode:    ${formatStoredUserMode(u)}`)
+            if (u.auth_flags && u.auth_flags.length > 0) {
+                lines.push(`    Flags:   ${u.auth_flags.join(', ')}`)
+            }
+            lines.push(`    Storage: ${storage}`)
+        }
+        lines.push('')
+    }
 
     lines.push(chalk.bold('Updates'))
     lines.push(`  Channel:       ${formatValue(config.update_channel)}`)
@@ -108,25 +171,37 @@ function formatConfigView(config: Config, token: TokenStatus, showToken: boolean
     return lines.join('\n')
 }
 
+function maskConfigForJson(config: Config, showToken: boolean): Config {
+    if (showToken) return config
+    const masked: Config = { ...config }
+    if (typeof masked.api_token === 'string') {
+        masked.api_token = maskToken(masked.api_token)
+    }
+    if (Array.isArray(masked.users)) {
+        masked.users = masked.users.map((u) =>
+            typeof u.api_token === 'string' ? { ...u, api_token: maskToken(u.api_token) } : u,
+        )
+    }
+    return masked
+}
+
 export async function viewConfig(options: ViewConfigOptions): Promise<void> {
     const read = await readConfigStrict()
     const config: Config = read.state === 'present' ? read.config : {}
 
     if (options.json) {
-        const output: Config = { ...config }
-        if (output.api_token && !options.showToken) {
-            output.api_token = maskToken(output.api_token)
-        }
-        console.log(JSON.stringify(output, null, 2))
+        console.log(JSON.stringify(maskConfigForJson(config, options.showToken ?? false), null, 2))
         return
     }
 
     const token = await probeTokenPresence()
+    const users = await listStoredUsers()
+    const defaultUserId = getDefaultUserId(config)
 
-    if (read.state === 'missing' && token.state === 'missing') {
+    if (read.state === 'missing' && token.state === 'missing' && users.length === 0) {
         console.log(`${chalk.dim('Config file:')} ${CONFIG_PATH} ${chalk.dim('(not created yet)')}`)
         return
     }
 
-    console.log(formatConfigView(config, token, options.showToken ?? false))
+    console.log(formatConfigView(config, token, options.showToken ?? false, users, defaultUserId))
 }

--- a/src/commands/config/view.ts
+++ b/src/commands/config/view.ts
@@ -113,10 +113,17 @@ function formatConfigView(
         )
     } else if (token.state === 'present' && token.metadata.source === 'env') {
         lines.push(`  Active:        ${chalk.dim('(TODOIST_API_TOKEN)')}`)
+    } else if (token.state === 'present') {
+        // Token is resolvable but we don't know which Todoist account it
+        // belongs to — i.e. legacy v1 single-user credentials before
+        // postinstall migration runs.
+        lines.push(`  Active:        ${chalk.dim('(legacy single-user credentials)')}`)
     } else if (token.state === 'ambiguous') {
         lines.push(`  Active:        ${chalk.dim('(none — multiple accounts, no default)')}`)
     } else if (token.state === 'missing') {
         lines.push(`  Active:        ${chalk.dim('(none)')}`)
+    } else {
+        lines.push(`  Active:        ${chalk.dim('(unknown)')}`)
     }
     // When a token is present, its metadata is the ground truth for the active
     // mode/scope/flags — this matters most for env-sourced tokens, whose scope

--- a/src/commands/config/view.ts
+++ b/src/commands/config/view.ts
@@ -119,7 +119,15 @@ function formatConfigView(
         // postinstall migration runs.
         lines.push(`  Active:        ${chalk.dim('(legacy single-user credentials)')}`)
     } else if (token.state === 'ambiguous') {
-        lines.push(`  Active:        ${chalk.dim('(none — multiple accounts, no default)')}`)
+        // `NoUserSelectedError` covers two distinct states — distinguish
+        // them so the user knows whether to set a default or fix a stale
+        // pointer.
+        const orphanedDefault =
+            defaultUserId !== undefined && !users.some((u) => u.id === defaultUserId)
+        const reason = orphanedDefault
+            ? `default points at unknown user "${defaultUserId}"`
+            : 'multiple accounts, no default'
+        lines.push(`  Active:        ${chalk.dim(`(none — ${reason})`)}`)
     } else if (token.state === 'missing') {
         lines.push(`  Active:        ${chalk.dim('(none)')}`)
     } else {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -286,23 +286,27 @@ async function checkForUpdates(offline: boolean): Promise<DoctorCheck> {
     }
 }
 
-async function checkStoredUsers(): Promise<DoctorCheck | null> {
+/**
+ * Returns 0–3 `users` checks: a summary of stored accounts plus optional
+ * warnings for missing/orphaned defaults and plaintext-fallback storage. Both
+ * warnings can fire on the same install, so we emit them as separate checks
+ * rather than collapsing into one.
+ */
+async function checkStoredUsers(): Promise<DoctorCheck[]> {
     const users = await listStoredUsers()
-    if (users.length === 0) return null
+    if (users.length === 0) return []
 
     const config = await readConfig()
     const defaultId = getDefaultUserId(config)
     // Mirror `resolveActiveUser`: a `defaultUser` pointer only counts when
-    // it actually resolves to a stored user. An orphaned pointer means
-    // commands without `--user` would still throw NoUserSelectedError, so
-    // we should warn the same way.
+    // it actually resolves to a stored user.
     const defaultResolved = defaultId ? users.find((u) => u.id === defaultId)?.email : undefined
     const hasUsableDefault = Boolean(defaultResolved)
     // TODOIST_API_TOKEN bypasses the resolver entirely — multi-user state
-    // can't break commands while it's set, so don't raise the warning.
+    // can't break commands while it's set, so don't raise the default warning.
     const envTokenSet = Boolean(process.env[TOKEN_ENV_VAR])
     const plaintext = users.filter((u) => u.api_token).map((u) => u.email)
-    const details: Record<string, unknown> = {
+    const baseDetails: Record<string, unknown> = {
         count: users.length,
         defaultUserId: defaultId,
         defaultUserResolved: hasUsableDefault,
@@ -310,28 +314,11 @@ async function checkStoredUsers(): Promise<DoctorCheck | null> {
         plaintextFallbackEmails: plaintext,
     }
 
-    if (users.length > 1 && !hasUsableDefault && !envTokenSet) {
-        const reason = defaultId
-            ? `default points at unknown user "${defaultId}"`
-            : 'no default selected'
-        return {
-            name: 'users',
-            status: 'warn',
-            message: `${users.length} stored accounts; ${reason}. Commands without --user will error`,
-            details,
-        }
-    }
+    const checks: DoctorCheck[] = []
 
-    if (plaintext.length > 0) {
-        return {
-            name: 'users',
-            status: 'warn',
-            message: `${plaintext.length} account(s) using plaintext fallback storage: ${plaintext.join(', ')}`,
-            details,
-        }
-    }
-
-    return {
+    // Always emit the summary first so output reads top-down: state, then
+    // any warnings about that state.
+    checks.push({
         name: 'users',
         status: 'pass',
         message:
@@ -340,15 +327,38 @@ async function checkStoredUsers(): Promise<DoctorCheck | null> {
                 : `${users.length} stored accounts; default is ${
                       defaultResolved ?? (envTokenSet ? '(TODOIST_API_TOKEN)' : '(none)')
                   }`,
-        details,
+        details: baseDetails,
+    })
+
+    if (users.length > 1 && !hasUsableDefault && !envTokenSet) {
+        const reason = defaultId
+            ? `default points at unknown user "${defaultId}"`
+            : 'no default selected'
+        checks.push({
+            name: 'users',
+            status: 'warn',
+            message: `${reason}. Commands without --user will error`,
+            details: baseDetails,
+        })
     }
+
+    if (plaintext.length > 0) {
+        checks.push({
+            name: 'users',
+            status: 'warn',
+            message: `${plaintext.length} account(s) using plaintext fallback storage: ${plaintext.join(', ')}`,
+            details: baseDetails,
+        })
+    }
+
+    return checks
 }
 
 async function runDoctorChecks(options: DoctorOptions): Promise<DoctorCheck[]> {
     return [
         checkNodeVersion(),
         await checkConfigFile(),
-        await checkStoredUsers(),
+        ...(await checkStoredUsers()),
         await checkAuthentication(Boolean(options.offline)),
         await checkForUpdates(Boolean(options.offline)),
     ].filter((check): check is DoctorCheck => check !== null)

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3,7 +3,14 @@ import chalk from 'chalk'
 import { Command } from 'commander'
 import packageJson from '../../package.json' with { type: 'json' }
 import { createApiForToken } from '../lib/api/core.js'
-import { CONFIG_PATH, NoTokenError, TOKEN_ENV_VAR, probeApiToken } from '../lib/auth.js'
+import {
+    CONFIG_PATH,
+    listStoredUsers,
+    NoTokenError,
+    readConfig,
+    TOKEN_ENV_VAR,
+    probeApiToken,
+} from '../lib/auth.js'
 import { validateConfigForDoctor } from '../lib/config.js'
 import { LoadingSpinner } from '../lib/spinner.js'
 import {
@@ -12,6 +19,7 @@ import {
     getConfiguredUpdateChannel,
     isNewer,
 } from '../lib/update.js'
+import { getDefaultUserId, NoUserSelectedError } from '../lib/users.js'
 
 type CheckStatus = 'pass' | 'warn' | 'fail' | 'skip'
 
@@ -161,6 +169,15 @@ async function checkAuthentication(offline: boolean): Promise<DoctorCheck> {
             }
         }
 
+        if (error instanceof NoUserSelectedError) {
+            return {
+                name: 'auth',
+                status: 'warn',
+                message:
+                    'Multiple stored Todoist accounts but no default. Set one with `td user use <id|email>` or pass --user.',
+            }
+        }
+
         const message = error instanceof Error ? error.message : String(error)
         return {
             name: 'auth',
@@ -269,10 +286,54 @@ async function checkForUpdates(offline: boolean): Promise<DoctorCheck> {
     }
 }
 
+async function checkStoredUsers(): Promise<DoctorCheck | null> {
+    const users = await listStoredUsers()
+    if (users.length === 0) return null
+
+    const config = await readConfig()
+    const defaultId = getDefaultUserId(config)
+    const plaintext = users.filter((u) => u.api_token).map((u) => u.email)
+    const details: Record<string, unknown> = {
+        count: users.length,
+        defaultUserId: defaultId,
+        plaintextFallbackEmails: plaintext,
+    }
+
+    if (users.length > 1 && !defaultId) {
+        return {
+            name: 'users',
+            status: 'warn',
+            message: `${users.length} stored accounts but no default selected; commands without --user will error`,
+            details,
+        }
+    }
+
+    if (plaintext.length > 0) {
+        return {
+            name: 'users',
+            status: 'warn',
+            message: `${plaintext.length} account(s) using plaintext fallback storage: ${plaintext.join(', ')}`,
+            details,
+        }
+    }
+
+    const defaultEmail = users.find((u) => u.id === defaultId)?.email
+    return {
+        name: 'users',
+        status: 'pass',
+        message:
+            users.length === 1
+                ? `1 stored account (${users[0].email})`
+                : `${users.length} stored accounts; default is ${defaultEmail ?? '(none)'}`,
+        details,
+    }
+}
+
 async function runDoctorChecks(options: DoctorOptions): Promise<DoctorCheck[]> {
     return [
         checkNodeVersion(),
         await checkConfigFile(),
+        await checkStoredUsers(),
         await checkAuthentication(Boolean(options.offline)),
         await checkForUpdates(Boolean(options.offline)),
     ].filter((check): check is DoctorCheck => check !== null)

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -292,18 +292,32 @@ async function checkStoredUsers(): Promise<DoctorCheck | null> {
 
     const config = await readConfig()
     const defaultId = getDefaultUserId(config)
+    // Mirror `resolveActiveUser`: a `defaultUser` pointer only counts when
+    // it actually resolves to a stored user. An orphaned pointer means
+    // commands without `--user` would still throw NoUserSelectedError, so
+    // we should warn the same way.
+    const defaultResolved = defaultId ? users.find((u) => u.id === defaultId)?.email : undefined
+    const hasUsableDefault = Boolean(defaultResolved)
+    // TODOIST_API_TOKEN bypasses the resolver entirely — multi-user state
+    // can't break commands while it's set, so don't raise the warning.
+    const envTokenSet = Boolean(process.env[TOKEN_ENV_VAR])
     const plaintext = users.filter((u) => u.api_token).map((u) => u.email)
     const details: Record<string, unknown> = {
         count: users.length,
         defaultUserId: defaultId,
+        defaultUserResolved: hasUsableDefault,
+        envTokenSet,
         plaintextFallbackEmails: plaintext,
     }
 
-    if (users.length > 1 && !defaultId) {
+    if (users.length > 1 && !hasUsableDefault && !envTokenSet) {
+        const reason = defaultId
+            ? `default points at unknown user "${defaultId}"`
+            : 'no default selected'
         return {
             name: 'users',
             status: 'warn',
-            message: `${users.length} stored accounts but no default selected; commands without --user will error`,
+            message: `${users.length} stored accounts; ${reason}. Commands without --user will error`,
             details,
         }
     }
@@ -317,14 +331,15 @@ async function checkStoredUsers(): Promise<DoctorCheck | null> {
         }
     }
 
-    const defaultEmail = users.find((u) => u.id === defaultId)?.email
     return {
         name: 'users',
         status: 'pass',
         message:
             users.length === 1
                 ? `1 stored account (${users[0].email})`
-                : `${users.length} stored accounts; default is ${defaultEmail ?? '(none)'}`,
+                : `${users.length} stored accounts; default is ${
+                      defaultResolved ?? (envTokenSet ? '(TODOIST_API_TOKEN)' : '(none)')
+                  }`,
         details,
     }
 }

--- a/src/commands/user/current.ts
+++ b/src/commands/user/current.ts
@@ -1,0 +1,50 @@
+import chalk from 'chalk'
+import { readConfig, resolveActiveUser } from '../../lib/auth.js'
+import { getDefaultUserId } from '../../lib/users.js'
+
+export interface CurrentUserOptions {
+    json?: boolean
+}
+
+export async function currentUserCommand(options: CurrentUserOptions): Promise<void> {
+    const resolved = await resolveActiveUser()
+    const config = await readConfig()
+    const defaultId = getDefaultUserId(config)
+    const isDefault = resolved.id === defaultId
+
+    if (options.json) {
+        console.log(
+            JSON.stringify(
+                {
+                    id: resolved.id === 'env' || resolved.id === 'legacy' ? null : resolved.id,
+                    email: resolved.email || null,
+                    source: resolved.source,
+                    isDefault,
+                    authMode: resolved.authMode,
+                    authScope: resolved.authScope,
+                    authFlags: resolved.authFlags,
+                },
+                null,
+                2,
+            ),
+        )
+        return
+    }
+
+    if (resolved.source === 'env') {
+        console.log(chalk.dim('Using TODOIST_API_TOKEN environment variable (no stored user).'))
+        return
+    }
+
+    if (resolved.id === 'legacy') {
+        console.log(
+            chalk.dim(
+                'Using legacy single-user credentials. Run `td auth login` to migrate to a stored account.',
+            ),
+        )
+        return
+    }
+
+    const marker = isDefault ? chalk.green(' (default)') : ''
+    console.log(`${resolved.email} ${chalk.dim(`(id:${resolved.id})`)}${marker}`)
+}

--- a/src/commands/user/index.ts
+++ b/src/commands/user/index.ts
@@ -1,5 +1,7 @@
 import { Command } from 'commander'
+import { currentUserCommand } from './current.js'
 import { listUsersCommand } from './list.js'
+import { removeUserCommand } from './remove.js'
 import { useUserCommand } from './use.js'
 
 export function registerUserCommand(program: Command): void {
@@ -14,6 +16,20 @@ export function registerUserCommand(program: Command): void {
         .description('Set the default account used when --user is not provided')
         .action((ref: string) => useUserCommand(ref))
 
+    // `default` is an explicit alias for `use` — same behavior, different verb.
+    user.command('default <ref>')
+        .description('Alias of `td user use <ref>`')
+        .action((ref: string) => useUserCommand(ref))
+
+    user.command('current')
+        .description('Show the active account (resolved from --user, default, or single login)')
+        .option('--json', 'Output as JSON')
+        .action(currentUserCommand)
+
+    user.command('remove <ref>')
+        .description('Remove a stored account (deletes its token and config entry)')
+        .action((ref: string) => removeUserCommand(ref))
+
     user.addHelpText(
         'after',
         `
@@ -21,6 +37,8 @@ Examples:
   $ td auth login                 # add an account (sets it as default if first)
   $ td user list                  # see all stored accounts
   $ td user use scott@doist.com   # set default
-  $ td --user other@example.com task list   # one-off override`,
+  $ td user current               # show the active account
+  $ td --user other@example.com task list   # one-off override
+  $ td user remove old@example.com`,
     )
 }

--- a/src/commands/user/remove.ts
+++ b/src/commands/user/remove.ts
@@ -25,8 +25,11 @@ export async function removeUserCommand(ref: string | undefined): Promise<void> 
                 chalk.dim('Cleared default account. Set a new one with `td user use <id|email>`.'),
             )
         }
-        if (result.warning) {
-            console.error(chalk.yellow('Warning:'), result.warning)
-        }
+    }
+
+    // Always surface partial-cleanup warnings, even with --quiet — the user
+    // needs to know if the keyring or config wasn't fully cleared.
+    if (result.warning) {
+        console.error(chalk.yellow('Warning:'), result.warning)
     }
 }

--- a/src/commands/user/remove.ts
+++ b/src/commands/user/remove.ts
@@ -1,0 +1,32 @@
+import chalk from 'chalk'
+import { readConfig, removeUserById } from '../../lib/auth.js'
+import { CliError } from '../../lib/errors.js'
+import { isQuiet } from '../../lib/global-args.js'
+import { getDefaultUserId, requireUserByRef } from '../../lib/users.js'
+
+export async function removeUserCommand(ref: string | undefined): Promise<void> {
+    if (!ref) {
+        throw new CliError(
+            'MISSING_REF',
+            'Please provide a user id or email: `td user remove <id|email>`',
+        )
+    }
+
+    const config = await readConfig()
+    const { user } = requireUserByRef(config, ref)
+    const wasDefault = getDefaultUserId(config) === user.id
+
+    const result = await removeUserById(user.id)
+
+    if (!isQuiet()) {
+        console.log(chalk.green('✓'), `Removed ${user.email}`)
+        if (wasDefault) {
+            console.log(
+                chalk.dim('Cleared default account. Set a new one with `td user use <id|email>`.'),
+            )
+        }
+        if (result.warning) {
+            console.error(chalk.yellow('Warning:'), result.warning)
+        }
+    }
+}

--- a/src/commands/user/user.test.ts
+++ b/src/commands/user/user.test.ts
@@ -8,17 +8,27 @@ vi.mock('../../lib/auth.js', async (importOriginal) => {
         listStoredUsers: vi.fn(),
         readConfig: vi.fn(),
         setDefaultUserId: vi.fn(),
+        removeUserById: vi.fn(),
+        resolveActiveUser: vi.fn(),
     }
 })
 
 vi.mock('chalk')
 
-import { listStoredUsers, readConfig, setDefaultUserId } from '../../lib/auth.js'
+import {
+    listStoredUsers,
+    readConfig,
+    removeUserById,
+    resolveActiveUser,
+    setDefaultUserId,
+} from '../../lib/auth.js'
 import { registerUserCommand } from './index.js'
 
 const mockListStoredUsers = vi.mocked(listStoredUsers)
 const mockReadConfig = vi.mocked(readConfig)
 const mockSetDefaultUserId = vi.mocked(setDefaultUserId)
+const mockRemoveUserById = vi.mocked(removeUserById)
+const mockResolveActiveUser = vi.mocked(resolveActiveUser)
 
 function createProgram() {
     const program = new Command()
@@ -118,6 +128,83 @@ describe('user command', () => {
             await expect(
                 createProgram().parseAsync(['node', 'td', 'user', 'use', 'nope']),
             ).rejects.toHaveProperty('code', 'USER_NOT_FOUND')
+        })
+
+        it('default subcommand is an alias of use', async () => {
+            mockReadConfig.mockResolvedValue({
+                config_version: 2,
+                users: [{ id: '111', email: 'a@b.c' }],
+            })
+
+            await createProgram().parseAsync(['node', 'td', 'user', 'default', '111'])
+
+            expect(mockSetDefaultUserId).toHaveBeenCalledWith('111')
+        })
+    })
+
+    describe('current', () => {
+        it('prints the active user', async () => {
+            mockResolveActiveUser.mockResolvedValue({
+                id: '111',
+                email: 'a@b.c',
+                token: 't',
+                authMode: 'read-write',
+                source: 'secure-store',
+            })
+            mockReadConfig.mockResolvedValue({
+                config_version: 2,
+                user: { defaultUser: '111' },
+                users: [],
+            })
+
+            await createProgram().parseAsync(['node', 'td', 'user', 'current'])
+
+            const out = consoleSpy.mock.calls.flat().join('\n')
+            expect(out).toContain('a@b.c')
+            expect(out).toContain('default')
+        })
+
+        it('says env when running on TODOIST_API_TOKEN', async () => {
+            mockResolveActiveUser.mockResolvedValue({
+                id: 'env',
+                email: '',
+                token: 'envtoken',
+                authMode: 'unknown',
+                source: 'env',
+            })
+
+            await createProgram().parseAsync(['node', 'td', 'user', 'current'])
+
+            const out = consoleSpy.mock.calls.flat().join('\n')
+            expect(out).toContain('TODOIST_API_TOKEN')
+        })
+    })
+
+    describe('remove', () => {
+        it('removes the user by id and clears default', async () => {
+            mockReadConfig.mockResolvedValue({
+                config_version: 2,
+                user: { defaultUser: '111' },
+                users: [{ id: '111', email: 'a@b.c' }],
+            })
+            mockRemoveUserById.mockResolvedValue({ storage: 'secure-store' })
+
+            await createProgram().parseAsync(['node', 'td', 'user', 'remove', '111'])
+
+            expect(mockRemoveUserById).toHaveBeenCalledWith('111')
+            expect(consoleSpy.mock.calls.flat().join('\n')).toContain('Cleared default')
+        })
+
+        it('rejects an unknown ref', async () => {
+            mockReadConfig.mockResolvedValue({
+                config_version: 2,
+                users: [{ id: '111', email: 'a@b.c' }],
+            })
+
+            await expect(
+                createProgram().parseAsync(['node', 'td', 'user', 'remove', 'nope']),
+            ).rejects.toHaveProperty('code', 'USER_NOT_FOUND')
+            expect(mockRemoveUserById).not.toHaveBeenCalled()
         })
     })
 })

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -57,7 +57,9 @@ The CLI can hold credentials for multiple Todoist accounts at once.
 \`\`\`bash
 td auth login                       # adds the account; first one becomes default
 td user list                        # all stored accounts (with default marker)
-td user use <id|email>              # set the default account
+td user use <id|email>              # set the default account (alias: td user default)
+td user current                     # show the active account
+td user remove <id|email>           # delete an account (and its token)
 td --user <id|email> task list      # one-off override for any command
 td auth logout --user <id|email>    # log out a specific account
 \`\`\`


### PR DESCRIPTION
Stacked on top of #300 — review/merge that one first.

## Summary

- Add `td user current`, `td user remove <ref>`, and a `td user default <ref>` alias for `use`.
- Teach `td config view` about multi-user state: shows the active account, lists all stored accounts (mode/scope/flags/storage) with a default marker, surfaces the ambiguous-resolution case, and masks per-user \`api_token\` entries in JSON output.
- Add a \`users\` check to \`td doctor\` (count, default presence, plaintext fallback) and recognise the \"multiple stored, no default\" warning state in the auth check.

## Test plan
- [x] \`npm run type-check\`
- [x] \`npm test\` — 1557 tests
- [x] \`npm run check\` (lint + format)
- [x] \`npm run check:skill-sync\`
- [ ] Smoke: \`td user current\` shows the right account in default / \`--user\` / env / legacy modes
- [ ] Smoke: \`td user remove <ref>\` deletes the keyring slot + config entry; clears default if it was the target
- [ ] Smoke: \`td config view\` with two accounts shows the active + others block; \`--json\` masks plaintext tokens
- [ ] Smoke: \`td doctor\` warns when multiple accounts are stored without a default

🤖 Generated with [Claude Code](https://claude.com/claude-code)