### PR TITLE
feat: track cli usage in request headers

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -154,6 +154,8 @@ New subcommand? Copy a sibling in the target group, wire it in that group's
 - **`permissions.ts`** — collaborator permission parsing
 - **`help-center.ts`** — Help Center article search/fetch
 - **`progress.ts`** — `--progress-jsonl` JSONL event writer
+- **`usage-tracking.ts`** — request markers (`User-Agent`,
+  `X-Todoist-CLI-*`), invocation ID, command path, AI-agent detection
 - **`browser.ts` / `stdin.ts` / `update.ts`** — small single-purpose helpers
 - **`skills/content.ts`** — `SKILL_NAME`, `SKILL_DESCRIPTION`, `SKILL_CONTENT`
 

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -155,7 +155,7 @@ New subcommand? Copy a sibling in the target group, wire it in that group's
 - **`help-center.ts`** — Help Center article search/fetch
 - **`progress.ts`** — `--progress-jsonl` JSONL event writer
 - **`usage-tracking.ts`** — request markers (`User-Agent`, `doist-*`,
-  `X-TD-*`, `X-Todoist-CLI-Command`), session/request ids, command path
+  `X-TD-*`, including `X-TD-CLI-Command`), session/request ids, command path
 - **`browser.ts` / `stdin.ts` / `update.ts`** — small single-purpose helpers
 - **`skills/content.ts`** — `SKILL_NAME`, `SKILL_DESCRIPTION`, `SKILL_CONTENT`
 

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -154,8 +154,8 @@ New subcommand? Copy a sibling in the target group, wire it in that group's
 - **`permissions.ts`** — collaborator permission parsing
 - **`help-center.ts`** — Help Center article search/fetch
 - **`progress.ts`** — `--progress-jsonl` JSONL event writer
-- **`usage-tracking.ts`** — request markers (`User-Agent`,
-  `X-Todoist-CLI-*`), invocation ID, command path, AI-agent detection
+- **`usage-tracking.ts`** — request markers (`User-Agent`, `doist-*`,
+  `X-TD-*`, `X-Todoist-CLI-Command`), session/request ids, command path
 - **`browser.ts` / `stdin.ts` / `update.ts`** — small single-purpose helpers
 - **`skills/content.ts`** — `SKILL_NAME`, `SKILL_DESCRIPTION`, `SKILL_CONTENT`
 

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { CliError } from '../lib/errors.js'
 import { classifyTodoistUrl } from '../lib/refs.js'
+import { setActiveCommandPath } from '../lib/usage-tracking.js'
 
 function looksLikeTodoistAppUrl(token: string): boolean {
     return /^https?:\/\/app\.todoist\.com\/app\/\S+/.test(token)
@@ -36,11 +37,16 @@ function extractViewInvocation(
 async function runRoutedCommand(
     loadRegister: () => Promise<(program: Command) => void>,
     argv: string[],
+    commandPath: string,
 ): Promise<void> {
     const proxy = new Command()
     proxy.exitOverride()
     const register = await loadRegister()
     register(proxy)
+    // `src/index.ts` already recorded the top-level `view` command on the main
+    // program. Override it here so downstream API requests are attributed to
+    // the routed target command (`task.view`, `today`, etc.) instead.
+    setActiveCommandPath(commandPath)
     await proxy.parseAsync(['node', 'td', ...argv])
 }
 
@@ -78,11 +84,13 @@ Examples:
                         return runRoutedCommand(
                             async () => (await import('./today.js')).registerTodayCommand,
                             ['today', ...invocation.passthroughArgs],
+                            'today',
                         )
                     case 'upcoming':
                         return runRoutedCommand(
                             async () => (await import('./upcoming.js')).registerUpcomingCommand,
                             ['upcoming', ...invocation.passthroughArgs],
+                            'upcoming',
                         )
                 }
             }
@@ -93,21 +101,25 @@ Examples:
                     return runRoutedCommand(
                         async () => (await import('./task/index.js')).registerTaskCommand,
                         ['task', 'view', ref, ...invocation.passthroughArgs],
+                        'task.view',
                     )
                 case 'project':
                     return runRoutedCommand(
                         async () => (await import('./project/index.js')).registerProjectCommand,
                         ['project', 'view', ref, ...invocation.passthroughArgs],
+                        'project.view',
                     )
                 case 'label':
                     return runRoutedCommand(
                         async () => (await import('./label/index.js')).registerLabelCommand,
                         ['label', 'view', ref, ...invocation.passthroughArgs],
+                        'label.view',
                     )
                 case 'filter':
                     return runRoutedCommand(
                         async () => (await import('./filter/index.js')).registerFilterCommand,
                         ['filter', 'show', ref, ...invocation.passthroughArgs],
+                        'filter.show',
                     )
             }
         })

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -45,7 +45,7 @@ async function runRoutedCommand(
     register(proxy)
     // `src/index.ts` already recorded the top-level `view` command on the main
     // program. Override it here so downstream API requests are attributed to
-    // the routed target command (`task.view`, `today`, etc.) instead.
+    // the routed target command (`task:view`, `today`, etc.) instead.
     setActiveCommandPath(commandPath)
     await proxy.parseAsync(['node', 'td', ...argv])
 }
@@ -101,25 +101,25 @@ Examples:
                     return runRoutedCommand(
                         async () => (await import('./task/index.js')).registerTaskCommand,
                         ['task', 'view', ref, ...invocation.passthroughArgs],
-                        'task.view',
+                        'task:view',
                     )
                 case 'project':
                     return runRoutedCommand(
                         async () => (await import('./project/index.js')).registerProjectCommand,
                         ['project', 'view', ref, ...invocation.passthroughArgs],
-                        'project.view',
+                        'project:view',
                     )
                 case 'label':
                     return runRoutedCommand(
                         async () => (await import('./label/index.js')).registerLabelCommand,
                         ['label', 'view', ref, ...invocation.passthroughArgs],
-                        'label.view',
+                        'label:view',
                     )
                 case 'filter':
                     return runRoutedCommand(
                         async () => (await import('./filter/index.js')).registerFilterCommand,
                         ['filter', 'show', ref, ...invocation.passthroughArgs],
-                        'filter.show',
+                        'filter:show',
                     )
             }
         })

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,19 @@ import { initializeLogger } from './lib/logger.js'
 import { preloadMarkdown } from './lib/markdown.js'
 import { formatError, formatErrorJson } from './lib/output.js'
 import { startEarlySpinner, stopEarlySpinner } from './lib/spinner.js'
+import { setActiveCommandPath } from './lib/usage-tracking.js'
+
+function getActionCommandPath(command: Command): string {
+    const segments: string[] = []
+    let current: Command | null = command
+
+    while (current?.parent) {
+        segments.push(current.name())
+        current = current.parent
+    }
+
+    return `td ${segments.reverse().join(' ')}`
+}
 
 program
     .name('td')
@@ -175,6 +188,10 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
 for (const [name, [description]] of Object.entries(commands)) {
     program.command(name).description(description)
 }
+
+program.hook('preAction', (_thisCommand, actionCommand) => {
+    setActiveCommandPath(getActionCommandPath(actionCommand))
+})
 
 // Validate `--user` and strip it from argv before commander parses.
 //

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -16,6 +16,7 @@ import { type AdditionalScopeFlag, oauthScopeFor } from '../oauth-scopes.js'
 import { ensureWriteAllowed, isMutatingApiMethod, isMutatingSyncPayload } from '../permissions.js'
 import { getProgressTracker } from '../progress.js'
 import { withSpinner } from '../spinner.js'
+import { createTrackedFetch } from '../usage-tracking.js'
 
 let apiClient: TodoistApi | null = null
 
@@ -289,7 +290,7 @@ function analyzeAndEmitApiResponse(
 }
 
 export function createApiForToken(token: string): TodoistApi {
-    const rawApi = new TodoistApi(token)
+    const rawApi = new TodoistApi(token, { customFetch: createTrackedFetch() })
     return createSpinnerWrappedApi(rawApi)
 }
 

--- a/src/lib/migrate-auth.test.ts
+++ b/src/lib/migrate-auth.test.ts
@@ -138,6 +138,19 @@ describe('migrateLegacyAuth', () => {
                 },
             ],
         })
+        expect(fetchImpl).toHaveBeenCalledWith(
+            'https://api.todoist.com/api/v1/user',
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    authorization: 'Bearer legacy-1234567',
+                    'doist-platform': 'cli',
+                    'doist-version': expect.stringMatching(/^\d+\.\d+\.\d+$/),
+                    'x-td-request-id': expect.any(String),
+                    'x-td-session-id': expect.any(String),
+                    'x-todoist-cli-command': 'postinstall:auth-migrate',
+                }),
+            }),
+        )
     })
 
     it('migrates a legacy keyring token (api-token account)', async () => {

--- a/src/lib/migrate-auth.test.ts
+++ b/src/lib/migrate-auth.test.ts
@@ -147,7 +147,7 @@ describe('migrateLegacyAuth', () => {
                     'doist-version': expect.stringMatching(/^\d+\.\d+\.\d+$/),
                     'x-td-request-id': expect.any(String),
                     'x-td-session-id': expect.any(String),
-                    'x-todoist-cli-command': 'postinstall:auth-migrate',
+                    'x-td-cli-command': 'postinstall:auth-migrate',
                 }),
             }),
         )

--- a/src/lib/migrate-auth.ts
+++ b/src/lib/migrate-auth.ts
@@ -14,6 +14,7 @@ import {
     LEGACY_ACCOUNT_NAME,
     SecureStoreUnavailableError,
 } from './secure-store.js'
+import { fetchTodoist } from './usage-tracking.js'
 
 export interface MigrateAuthResult {
     status: 'already-migrated' | 'no-legacy-state' | 'migrated' | 'skipped'
@@ -142,9 +143,14 @@ async function loadLegacyToken(config: Config): Promise<string | null> {
 }
 
 async function fetchUser(token: string, fetchImpl: typeof fetch): Promise<TodoistUser> {
-    const response = await fetchImpl(USER_ENDPOINT, {
-        headers: { Authorization: `Bearer ${token}` },
-    })
+    const response = await fetchTodoist(
+        USER_ENDPOINT,
+        {
+            headers: { Authorization: `Bearer ${token}` },
+        },
+        fetchImpl,
+        'postinstall:auth-migrate',
+    )
     if (!response.ok) {
         throw new Error(`HTTP ${response.status} ${response.statusText}`)
     }

--- a/src/lib/oauth.test.ts
+++ b/src/lib/oauth.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest'
-import { buildAuthorizationUrl } from './oauth.js'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildAuthorizationUrl, exchangeCodeForToken } from './oauth.js'
+import { resetUsageTrackingForTests, setActiveCommandPath } from './usage-tracking.js'
 
 describe('buildAuthorizationUrl', () => {
     it('uses read-write scope by default', () => {
@@ -65,5 +66,36 @@ describe('buildAuthorizationUrl', () => {
         const params = new URL(url).searchParams
 
         expect(params.get('redirect_uri')).toBe('http://localhost:8765/callback')
+    })
+
+    afterEach(() => {
+        resetUsageTrackingForTests()
+        vi.unstubAllGlobals()
+    })
+
+    it('sends tracking headers during token exchange', async () => {
+        setActiveCommandPath('td auth login')
+        const fetchMock = vi.fn(async (_url: string | URL, options?: RequestInit) => {
+            const headers = options?.headers as Record<string, string>
+            expect(headers['content-type']).toBe('application/x-www-form-urlencoded')
+            expect(headers['user-agent']).toMatch(/^todoist-cli\/\d+\.\d+\.\d+$/)
+            expect(headers['doist-platform']).toBe('cli')
+            expect(headers['doist-version']).toMatch(/^\d+\.\d+\.\d+$/)
+            expect(headers['x-td-request-id']).toBeTruthy()
+            expect(headers['x-td-session-id']).toBeTruthy()
+            expect(headers['x-todoist-cli-command']).toBe('auth:login')
+            return new Response(
+                JSON.stringify({ access_token: 'token-123', token_type: 'bearer' }),
+                {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                },
+            )
+        })
+        vi.stubGlobal('fetch', fetchMock)
+
+        await expect(exchangeCodeForToken('code-123', 'verifier-456', 8765)).resolves.toBe(
+            'token-123',
+        )
     })
 })

--- a/src/lib/oauth.test.ts
+++ b/src/lib/oauth.test.ts
@@ -83,7 +83,7 @@ describe('buildAuthorizationUrl', () => {
             expect(headers['doist-version']).toMatch(/^\d+\.\d+\.\d+$/)
             expect(headers['x-td-request-id']).toBeTruthy()
             expect(headers['x-td-session-id']).toBeTruthy()
-            expect(headers['x-todoist-cli-command']).toBe('auth:login')
+            expect(headers['x-td-cli-command']).toBe('auth:login')
             return new Response(
                 JSON.stringify({ access_token: 'token-123', token_type: 'bearer' }),
                 {

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -1,6 +1,7 @@
 import { CliError } from './errors.js'
 import { type AdditionalScopeFlag, oauthScopeFor } from './oauth-scopes.js'
 import { DEFAULT_PORT, getRedirectUri } from './oauth-server.js'
+import { fetchTodoist } from './usage-tracking.js'
 
 const TODOIST_CLIENT_ID = '04863cc1e3584830a578622f50224d5b'
 const OAUTH_AUTHORIZE_URL = 'https://todoist.com/oauth/authorize'
@@ -56,7 +57,7 @@ export async function exchangeCodeForToken(
         redirect_uri: getRedirectUri(port),
     })
 
-    const response = await fetch(OAUTH_TOKEN_URL, {
+    const response = await fetchTodoist(OAUTH_TOKEN_URL, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded',

--- a/src/lib/usage-tracking.test.ts
+++ b/src/lib/usage-tracking.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
     buildUsageTrackingHeaders,
     createTrackedFetch,
-    detectAiAgent,
+    fetchTodoist,
     normalizeCommandPath,
     resetUsageTrackingForTests,
     setActiveCommandPath,
@@ -10,7 +10,7 @@ import {
 
 describe('usage tracking', () => {
     it('normalizes commander command paths into header-friendly values', () => {
-        expect(normalizeCommandPath('td task view')).toBe('task.view')
+        expect(normalizeCommandPath('td task view')).toBe('task:view')
         expect(normalizeCommandPath('td today')).toBe('today')
     })
 
@@ -21,43 +21,72 @@ describe('usage tracking', () => {
         const headers = buildUsageTrackingHeaders()
 
         expect(headers['User-Agent']).toMatch(/^todoist-cli\/\d+\.\d+\.\d+$/)
-        expect(headers['X-Todoist-Client']).toBe('todoist-cli')
-        expect(headers['X-Todoist-CLI-Version']).toMatch(/^\d+\.\d+\.\d+$/)
-        expect(headers['X-Todoist-CLI-Invocation-Id']).toBeTruthy()
-        expect(headers['X-Todoist-CLI-Command']).toBe('task.view')
-    })
-
-    it('detects known ai agents from environment variables', () => {
-        expect(detectAiAgent({ CLAUDECODE: '1' })).toBe('claude_code')
-        expect(detectAiAgent({ CODEX_THREAD_ID: 'thread_123' })).toBe('codex_cli')
-        expect(detectAiAgent({})).toBeUndefined()
+        expect(headers['doist-platform']).toBe('cli')
+        expect(headers['doist-version']).toMatch(/^\d+\.\d+\.\d+$/)
+        expect(headers['doist-os']).toMatch(/^(macos|linux|windows|unknown)$/)
+        expect(headers['X-TD-Request-Id']).toBeTruthy()
+        expect(headers['X-TD-Session-Id']).toBeTruthy()
+        expect(headers['X-Todoist-CLI-Command']).toBe('task:view')
     })
 
     it('injects tracking headers into sdk custom fetch requests', async () => {
         resetUsageTrackingForTests()
         setActiveCommandPath('td today')
 
-        let captured: RequestInit | undefined
+        const captured: RequestInit[] = []
         const trackedFetch = createTrackedFetch(async (_url, options) => {
-            captured = options
+            captured.push(options ?? {})
             return new Response(JSON.stringify({ ok: true }), {
                 status: 200,
                 headers: { 'content-type': 'application/json' },
             })
         })
 
+        await trackedFetch('https://api.todoist.com/api/v1/tasks', {
+            method: 'GET',
+            headers: { Authorization: 'Bearer token' },
+        })
         const response = await trackedFetch('https://api.todoist.com/api/v1/tasks', {
             method: 'GET',
             headers: { Authorization: 'Bearer token' },
         })
 
-        expect(captured).toBeTruthy()
-        if (!captured) {
-            throw new Error('tracked fetch did not capture request options')
+        expect(captured).toHaveLength(2)
+        const firstHeaders = captured[0].headers as Record<string, string>
+        const secondHeaders = captured[1].headers as Record<string, string>
+        expect(firstHeaders.authorization).toBe('Bearer token')
+        expect(firstHeaders['doist-platform']).toBe('cli')
+        expect(firstHeaders['doist-version']).toMatch(/^\d+\.\d+\.\d+$/)
+        expect(firstHeaders['x-todoist-cli-command']).toBe('today')
+        expect(firstHeaders['x-td-session-id']).toBe(secondHeaders['x-td-session-id'])
+        expect(firstHeaders['x-td-request-id']).not.toBe(secondHeaders['x-td-request-id'])
+        expect(response.ok).toBe(true)
+    })
+
+    it('supports explicit command overrides for non-command direct fetches', async () => {
+        let captured: RequestInit | undefined
+        const fetchImpl: typeof fetch = async (
+            _url: RequestInfo | URL,
+            options?: RequestInit,
+        ): Promise<Response> => {
+            captured = options
+            return new Response('{}', {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+            })
         }
+
+        await fetchTodoist(
+            'https://api.todoist.com/api/v1/user',
+            { headers: { Authorization: 'Bearer token' } },
+            fetchImpl,
+            'postinstall:auth-migrate',
+        )
+
+        expect(captured).toBeTruthy()
+        if (!captured) throw new Error('direct fetch did not capture request options')
         const headers = captured.headers as Record<string, string>
         expect(headers.authorization).toBe('Bearer token')
-        expect(headers['x-todoist-cli-command']).toBe('today')
-        expect(response.ok).toBe(true)
+        expect(headers['x-todoist-cli-command']).toBe('postinstall:auth-migrate')
     })
 })

--- a/src/lib/usage-tracking.test.ts
+++ b/src/lib/usage-tracking.test.ts
@@ -63,6 +63,56 @@ describe('usage tracking', () => {
         expect(response.ok).toBe(true)
     })
 
+    it('maps sdk timeouts to abort signals', async () => {
+        let captured: RequestInit | undefined
+        const trackedFetch = createTrackedFetch(async (_url, options) => {
+            captured = options
+            return new Response(JSON.stringify({ ok: true }), {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+            })
+        })
+
+        await trackedFetch('https://api.todoist.com/api/v1/tasks', {
+            method: 'GET',
+            timeout: 250,
+        })
+
+        expect(captured?.signal).toBeInstanceOf(AbortSignal)
+        expect(captured?.signal?.aborted).toBe(false)
+
+        await new Promise((resolve) => setTimeout(resolve, 300))
+
+        expect(captured?.signal?.aborted).toBe(true)
+    })
+
+    it('combines sdk timeouts with existing abort signals', async () => {
+        const abortController = new AbortController()
+
+        let captured: RequestInit | undefined
+        const trackedFetch = createTrackedFetch(async (_url, options) => {
+            captured = options
+            return new Response(JSON.stringify({ ok: true }), {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+            })
+        })
+
+        await trackedFetch('https://api.todoist.com/api/v1/tasks', {
+            method: 'GET',
+            signal: abortController.signal,
+            timeout: 250,
+        })
+
+        expect(captured?.signal).toBeInstanceOf(AbortSignal)
+        expect(captured?.signal).not.toBe(abortController.signal)
+        expect(captured?.signal?.aborted).toBe(false)
+
+        abortController.abort()
+
+        expect(captured?.signal?.aborted).toBe(true)
+    })
+
     it('supports explicit command overrides for non-command direct fetches', async () => {
         let captured: RequestInit | undefined
         const fetchImpl: typeof fetch = async (

--- a/src/lib/usage-tracking.test.ts
+++ b/src/lib/usage-tracking.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+    buildUsageTrackingHeaders,
+    createTrackedFetch,
+    detectAiAgent,
+    normalizeCommandPath,
+    resetUsageTrackingForTests,
+    setActiveCommandPath,
+} from './usage-tracking.js'
+
+describe('usage tracking', () => {
+    it('normalizes commander command paths into header-friendly values', () => {
+        expect(normalizeCommandPath('td task view')).toBe('task.view')
+        expect(normalizeCommandPath('td today')).toBe('today')
+    })
+
+    it('builds cli tracking headers with command metadata', () => {
+        resetUsageTrackingForTests()
+        setActiveCommandPath('td task view')
+
+        const headers = buildUsageTrackingHeaders()
+
+        expect(headers['User-Agent']).toMatch(/^todoist-cli\/\d+\.\d+\.\d+$/)
+        expect(headers['X-Todoist-Client']).toBe('todoist-cli')
+        expect(headers['X-Todoist-CLI-Version']).toMatch(/^\d+\.\d+\.\d+$/)
+        expect(headers['X-Todoist-CLI-Invocation-Id']).toBeTruthy()
+        expect(headers['X-Todoist-CLI-Command']).toBe('task.view')
+    })
+
+    it('detects known ai agents from environment variables', () => {
+        expect(detectAiAgent({ CLAUDECODE: '1' })).toBe('claude_code')
+        expect(detectAiAgent({ CODEX_THREAD_ID: 'thread_123' })).toBe('codex_cli')
+        expect(detectAiAgent({})).toBeUndefined()
+    })
+
+    it('injects tracking headers into sdk custom fetch requests', async () => {
+        resetUsageTrackingForTests()
+        setActiveCommandPath('td today')
+
+        let captured: RequestInit | undefined
+        const trackedFetch = createTrackedFetch(async (_url, options) => {
+            captured = options
+            return new Response(JSON.stringify({ ok: true }), {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+            })
+        })
+
+        const response = await trackedFetch('https://api.todoist.com/api/v1/tasks', {
+            method: 'GET',
+            headers: { Authorization: 'Bearer token' },
+        })
+
+        expect(captured).toBeTruthy()
+        if (!captured) {
+            throw new Error('tracked fetch did not capture request options')
+        }
+        const headers = captured.headers as Record<string, string>
+        expect(headers.authorization).toBe('Bearer token')
+        expect(headers['x-todoist-cli-command']).toBe('today')
+        expect(response.ok).toBe(true)
+    })
+})

--- a/src/lib/usage-tracking.test.ts
+++ b/src/lib/usage-tracking.test.ts
@@ -26,7 +26,7 @@ describe('usage tracking', () => {
         expect(headers['doist-os']).toMatch(/^(macos|linux|windows|unknown)$/)
         expect(headers['X-TD-Request-Id']).toBeTruthy()
         expect(headers['X-TD-Session-Id']).toBeTruthy()
-        expect(headers['X-Todoist-CLI-Command']).toBe('task:view')
+        expect(headers['X-TD-CLI-Command']).toBe('task:view')
     })
 
     it('injects tracking headers into sdk custom fetch requests', async () => {
@@ -57,7 +57,7 @@ describe('usage tracking', () => {
         expect(firstHeaders.authorization).toBe('Bearer token')
         expect(firstHeaders['doist-platform']).toBe('cli')
         expect(firstHeaders['doist-version']).toMatch(/^\d+\.\d+\.\d+$/)
-        expect(firstHeaders['x-todoist-cli-command']).toBe('today')
+        expect(firstHeaders['x-td-cli-command']).toBe('today')
         expect(firstHeaders['x-td-session-id']).toBe(secondHeaders['x-td-session-id'])
         expect(firstHeaders['x-td-request-id']).not.toBe(secondHeaders['x-td-request-id'])
         expect(response.ok).toBe(true)
@@ -137,6 +137,6 @@ describe('usage tracking', () => {
         if (!captured) throw new Error('direct fetch did not capture request options')
         const headers = captured.headers as Record<string, string>
         expect(headers.authorization).toBe('Bearer token')
-        expect(headers['x-todoist-cli-command']).toBe('postinstall:auth-migrate')
+        expect(headers['x-td-cli-command']).toBe('postinstall:auth-migrate')
     })
 })

--- a/src/lib/usage-tracking.ts
+++ b/src/lib/usage-tracking.ts
@@ -98,9 +98,17 @@ function toCustomFetchResponse(response: Response): CustomFetchResponse {
 
 export function createTrackedFetch(baseFetch: typeof fetch = globalThis.fetch): CustomFetch {
     return async (url, options = {}) => {
-        const { timeout: _timeout, headers, ...rest } = options
+        const { timeout: timeoutMs, headers, signal, ...rest } = options
+
+        let abortSignal = signal
+        if (timeoutMs) {
+            const timeoutSignal = AbortSignal.timeout(timeoutMs)
+            abortSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
+        }
+
         const response = await baseFetch(url, {
             ...rest,
+            signal: abortSignal,
             headers: mergeTodoistHeaders(headers),
         })
         return toCustomFetchResponse(response)

--- a/src/lib/usage-tracking.ts
+++ b/src/lib/usage-tracking.ts
@@ -1,0 +1,118 @@
+import { randomUUID } from 'node:crypto'
+import packageJson from '../../package.json' with { type: 'json' }
+
+type CustomFetchResponse = {
+    ok: boolean
+    status: number
+    statusText: string
+    headers: Record<string, string>
+    text(): Promise<string>
+    json(): Promise<unknown>
+}
+
+type CustomFetch = (
+    url: string,
+    options?: RequestInit & { timeout?: number },
+) => Promise<CustomFetchResponse>
+
+const CLI_NAME = 'todoist-cli'
+const CLI_VERSION = packageJson.version
+const INVOCATION_ID = randomUUID()
+
+let activeCommandPath: string | undefined
+
+export function detectAiAgent(env: NodeJS.ProcessEnv = process.env): string | undefined {
+    // Best-effort analytics only. There is no cross-vendor standard for
+    // "which agent launched this process", and most of these environment
+    // variables are observable implementation details rather than documented
+    // public contracts. This list mirrors Stripe CLI's upstream detector:
+    // https://github.com/stripe/stripe-cli/blob/master/pkg/useragent/useragent.go
+    //
+    // When adding new entries, prefer a public upstream source that shows the
+    // variable being set or consumed.
+    if (env.ANTIGRAVITY_CLI_ALIAS) return 'antigravity'
+    if (env.CLAUDECODE) return 'claude_code'
+    if (env.CLINE_ACTIVE) return 'cline'
+    if (
+        env.CODEX_SANDBOX ||
+        env.CODEX_THREAD_ID ||
+        env.CODEX_SANDBOX_NETWORK_DISABLED ||
+        env.CODEX_CI
+    ) {
+        return 'codex_cli'
+    }
+    if (env.CURSOR_AGENT) return 'cursor'
+    if (env.GEMINI_CLI) return 'gemini_cli'
+    if (env.OPENCODE) return 'open_code'
+    if (env.OPENCLAW_SHELL) return 'openclaw'
+    return undefined
+}
+
+function getUserAgent(): string {
+    return `${CLI_NAME}/${CLI_VERSION}`
+}
+
+export function normalizeCommandPath(commandPath: string): string {
+    return commandPath
+        .replace(/^td\s+/, '')
+        .trim()
+        .replace(/\s+/g, '.')
+}
+
+export function setActiveCommandPath(commandPath: string | undefined): void {
+    activeCommandPath = commandPath ? normalizeCommandPath(commandPath) : undefined
+}
+
+export function getActiveCommandPath(): string | undefined {
+    return activeCommandPath
+}
+
+export function buildUsageTrackingHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+        'User-Agent': getUserAgent(),
+        'X-Todoist-Client': CLI_NAME,
+        'X-Todoist-CLI-Version': CLI_VERSION,
+        'X-Todoist-CLI-Invocation-Id': INVOCATION_ID,
+    }
+
+    if (activeCommandPath) {
+        headers['X-Todoist-CLI-Command'] = activeCommandPath
+    }
+
+    const aiAgent = detectAiAgent()
+    if (aiAgent) {
+        headers['X-Todoist-CLI-AI-Agent'] = aiAgent
+    }
+
+    return headers
+}
+
+function toCustomFetchResponse(response: Response): CustomFetchResponse {
+    return {
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        headers: Object.fromEntries(response.headers.entries()),
+        text: () => response.text(),
+        json: () => response.json(),
+    }
+}
+
+export function createTrackedFetch(baseFetch: typeof fetch = globalThis.fetch): CustomFetch {
+    return async (url, options = {}) => {
+        const { timeout: _timeout, headers, ...rest } = options
+        const mergedHeaders = new Headers(headers)
+        for (const [key, value] of Object.entries(buildUsageTrackingHeaders())) {
+            mergedHeaders.set(key, value)
+        }
+        const response = await baseFetch(url, {
+            ...rest,
+            headers: Object.fromEntries(mergedHeaders.entries()),
+        })
+        return toCustomFetchResponse(response)
+    }
+}
+
+export function resetUsageTrackingForTests(): void {
+    activeCommandPath = undefined
+}

--- a/src/lib/usage-tracking.ts
+++ b/src/lib/usage-tracking.ts
@@ -1,19 +1,6 @@
 import { randomUUID } from 'node:crypto'
+import type { CustomFetch, CustomFetchResponse } from '@doist/todoist-sdk'
 import packageJson from '../../package.json' with { type: 'json' }
-
-type CustomFetchResponse = {
-    ok: boolean
-    status: number
-    statusText: string
-    headers: Record<string, string>
-    text(): Promise<string>
-    json(): Promise<unknown>
-}
-
-type CustomFetch = (
-    url: string,
-    options?: RequestInit & { timeout?: number },
-) => Promise<CustomFetchResponse>
 
 const CLI_NAME = 'todoist-cli'
 const CLI_VERSION = packageJson.version

--- a/src/lib/usage-tracking.ts
+++ b/src/lib/usage-tracking.ts
@@ -55,7 +55,7 @@ export function buildUsageTrackingHeaders(commandPath?: string): Record<string, 
         'doist-os': getDoistOs(),
         'X-TD-Request-Id': randomUUID(),
         'X-TD-Session-Id': SESSION_ID,
-        'X-Todoist-CLI-Command': normalizedCommandPath ?? 'unknown',
+        'X-TD-CLI-Command': normalizedCommandPath ?? 'unknown',
     }
 
     return headers

--- a/src/lib/usage-tracking.ts
+++ b/src/lib/usage-tracking.ts
@@ -17,46 +17,35 @@ type CustomFetch = (
 
 const CLI_NAME = 'todoist-cli'
 const CLI_VERSION = packageJson.version
-const INVOCATION_ID = randomUUID()
+const SESSION_ID = randomUUID()
 
 let activeCommandPath: string | undefined
 
-export function detectAiAgent(env: NodeJS.ProcessEnv = process.env): string | undefined {
-    // Best-effort analytics only. There is no cross-vendor standard for
-    // "which agent launched this process", and most of these environment
-    // variables are observable implementation details rather than documented
-    // public contracts. This list mirrors Stripe CLI's upstream detector:
-    // https://github.com/stripe/stripe-cli/blob/master/pkg/useragent/useragent.go
-    //
-    // When adding new entries, prefer a public upstream source that shows the
-    // variable being set or consumed.
-    if (env.ANTIGRAVITY_CLI_ALIAS) return 'antigravity'
-    if (env.CLAUDECODE) return 'claude_code'
-    if (env.CLINE_ACTIVE) return 'cline'
-    if (
-        env.CODEX_SANDBOX ||
-        env.CODEX_THREAD_ID ||
-        env.CODEX_SANDBOX_NETWORK_DISABLED ||
-        env.CODEX_CI
-    ) {
-        return 'codex_cli'
-    }
-    if (env.CURSOR_AGENT) return 'cursor'
-    if (env.GEMINI_CLI) return 'gemini_cli'
-    if (env.OPENCODE) return 'open_code'
-    if (env.OPENCLAW_SHELL) return 'openclaw'
-    return undefined
-}
-
 function getUserAgent(): string {
     return `${CLI_NAME}/${CLI_VERSION}`
+}
+
+function getDoistOs(
+    platform: NodeJS.Platform = process.platform,
+): 'macos' | 'linux' | 'windows' | 'unknown' {
+    switch (platform) {
+        case 'darwin':
+            return 'macos'
+        case 'linux':
+            return 'linux'
+        case 'win32':
+            return 'windows'
+        default:
+            return 'unknown'
+    }
 }
 
 export function normalizeCommandPath(commandPath: string): string {
     return commandPath
         .replace(/^td\s+/, '')
         .trim()
-        .replace(/\s+/g, '.')
+        .toLowerCase()
+        .replace(/\s+/g, ':')
 }
 
 export function setActiveCommandPath(commandPath: string | undefined): void {
@@ -67,24 +56,33 @@ export function getActiveCommandPath(): string | undefined {
     return activeCommandPath
 }
 
-export function buildUsageTrackingHeaders(): Record<string, string> {
+export function buildUsageTrackingHeaders(commandPath?: string): Record<string, string> {
+    const normalizedCommandPath = commandPath
+        ? normalizeCommandPath(commandPath)
+        : activeCommandPath
+
     const headers: Record<string, string> = {
         'User-Agent': getUserAgent(),
-        'X-Todoist-Client': CLI_NAME,
-        'X-Todoist-CLI-Version': CLI_VERSION,
-        'X-Todoist-CLI-Invocation-Id': INVOCATION_ID,
-    }
-
-    if (activeCommandPath) {
-        headers['X-Todoist-CLI-Command'] = activeCommandPath
-    }
-
-    const aiAgent = detectAiAgent()
-    if (aiAgent) {
-        headers['X-Todoist-CLI-AI-Agent'] = aiAgent
+        'doist-platform': 'cli',
+        'doist-version': CLI_VERSION,
+        'doist-os': getDoistOs(),
+        'X-TD-Request-Id': randomUUID(),
+        'X-TD-Session-Id': SESSION_ID,
+        'X-Todoist-CLI-Command': normalizedCommandPath ?? 'unknown',
     }
 
     return headers
+}
+
+function mergeTodoistHeaders(
+    headersInit?: HeadersInit,
+    commandPath?: string,
+): Record<string, string> {
+    const mergedHeaders = new Headers(headersInit)
+    for (const [key, value] of Object.entries(buildUsageTrackingHeaders(commandPath))) {
+        mergedHeaders.set(key, value)
+    }
+    return Object.fromEntries(mergedHeaders.entries())
 }
 
 function toCustomFetchResponse(response: Response): CustomFetchResponse {
@@ -101,16 +99,25 @@ function toCustomFetchResponse(response: Response): CustomFetchResponse {
 export function createTrackedFetch(baseFetch: typeof fetch = globalThis.fetch): CustomFetch {
     return async (url, options = {}) => {
         const { timeout: _timeout, headers, ...rest } = options
-        const mergedHeaders = new Headers(headers)
-        for (const [key, value] of Object.entries(buildUsageTrackingHeaders())) {
-            mergedHeaders.set(key, value)
-        }
         const response = await baseFetch(url, {
             ...rest,
-            headers: Object.fromEntries(mergedHeaders.entries()),
+            headers: mergeTodoistHeaders(headers),
         })
         return toCustomFetchResponse(response)
     }
+}
+
+export function fetchTodoist(
+    url: string | URL,
+    options: RequestInit = {},
+    fetchImpl: typeof fetch = globalThis.fetch,
+    commandPath?: string,
+): Promise<Response> {
+    const { headers, ...rest } = options
+    return fetchImpl(url, {
+        ...rest,
+        headers: mergeTodoistHeaders(headers, commandPath),
+    })
 }
 
 export function resetUsageTrackingForTests(): void {


### PR DESCRIPTION
## Summary

This PR makes Todoist CLI identify itself consistently to Todoist backend services.

Every Todoist-bound request now carries a shared header contract so backend logs can reliably recognize CLI traffic, attribute it to a low-cardinality command label, and correlate related requests from the same CLI process.

That coverage applies across the main SDK-backed API client as well as direct Todoist fetch paths such as OAuth and legacy auth migration, so the backend sees the same shape regardless of how the request was made.

## Why

Before this change, the CLI did not consistently describe itself across outbound requests to Todoist services.

This PR standardizes that request-level contract so backend tracking can happen from normal API logs instead of requiring a separate client-side telemetry system.

## What changed

- Introduced one shared request-metadata layer for Todoist-bound requests instead of piecemeal per-call headers.
- Standardized command attribution so backend logs receive a stable low-cardinality command label, including routed `td view ...` flows and internal non-Commander flows.
- Added tests around header generation and auth-related request paths, and documented the shared contract in the codebase.

## What every request now sends

All requests from the CLI to Todoist backend services now send the following headers:

- `User-Agent: todoist-cli/<version>`
  Identifies the binary and its version in the conventional user-agent slot.

- `doist-platform: cli`
  Explicit machine-readable platform marker for backend classification.

- `doist-version: <version>`
  Dedicated version field so backend consumers do not need to parse `User-Agent`.

- `doist-os: <normalized os>`
  Normalized operating-system label for environment-level usage analysis.

- `X-TD-Request-Id: <uuid>`
  A new UUID for every outbound request. This is request-scoped, not process-scoped.

- `X-TD-Session-Id: <uuid>`
  A stable UUID for the lifetime of the current CLI process. Multiple requests from the same run share this value.

- `X-TD-CLI-Command: <command label>`
  A low-cardinality, lower-case, colon-separated label describing the CLI action responsible for the request.
  Examples include `today`, `task:add`, `project:list`, `task:view`, and `postinstall:auth-migrate`.

A few details about `X-TD-CLI-Command`:
- Normal Commander-driven commands derive it automatically from the active command path.
- Routed `td view ...` flows override the top-level `view` label with the routed target command, so backend logs see the real action rather than just `view`.
- Internal flows that do not naturally run under Commander can provide an explicit low-cardinality override.
- If no specific command context is available, the fallback value is `unknown`, so the header is still present.