### PR TITLE
fix: honour HTTP_PROXY on the customFetch path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@doist/todoist-sdk": "10.0.0",
+        "@doist/todoist-sdk": "10.1.0",
         "@napi-rs/keyring": "1.2.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@doist/todoist-sdk": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.0.0.tgz",
-      "integrity": "sha512-NAL04+mR6XJitfF8HAZ8N095Zo6LY79Kh4gSIGMu7QlrBqjVr+NCXHnCn5SqcSERyGKwUeAi2C7b8VU9mmKrGQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.1.0.tgz",
+      "integrity": "sha512-o4AM0YGcQLlNyHOZ126qCfa+FQHsgNOKWpfZCECtjm6a+7tsiU39E/em3Ihcaynh7nUkYRXEVC8RUQ0kkCkJXw==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@doist/todoist-sdk": "10.0.0",
+    "@doist/todoist-sdk": "10.1.0",
     "@napi-rs/keyring": "1.2.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",

--- a/src/lib/usage-tracking.test.ts
+++ b/src/lib/usage-tracking.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import { getDefaultDispatcher } from '@doist/todoist-sdk'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
     buildUsageTrackingHeaders,
     createTrackedFetch,
@@ -7,6 +8,16 @@ import {
     resetUsageTrackingForTests,
     setActiveCommandPath,
 } from './usage-tracking.js'
+
+vi.mock('@doist/todoist-sdk', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@doist/todoist-sdk')>()
+    return {
+        ...actual,
+        getDefaultDispatcher: vi.fn(() => Promise.resolve(undefined)),
+    }
+})
+
+const getDefaultDispatcherMock = vi.mocked(getDefaultDispatcher)
 
 describe('usage tracking', () => {
     it('normalizes commander command paths into header-friendly values', () => {
@@ -111,6 +122,111 @@ describe('usage tracking', () => {
         abortController.abort()
 
         expect(captured?.signal?.aborted).toBe(true)
+    })
+
+    describe('proxy dispatcher injection', () => {
+        afterEach(() => {
+            getDefaultDispatcherMock.mockReset()
+            getDefaultDispatcherMock.mockResolvedValue(undefined)
+        })
+
+        it('attaches the env proxy dispatcher when createTrackedFetch uses native fetch', async () => {
+            const fakeDispatcher = { kind: 'env-http-proxy-agent' } as unknown as NonNullable<
+                Awaited<ReturnType<typeof getDefaultDispatcher>>
+            >
+            getDefaultDispatcherMock.mockResolvedValue(fakeDispatcher)
+
+            let captured: RequestInit | undefined
+            const originalFetch = globalThis.fetch
+            globalThis.fetch = (async (_url: RequestInfo | URL, options?: RequestInit) => {
+                captured = options
+                return new Response('{}', {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                })
+            }) as typeof fetch
+
+            try {
+                const trackedFetch = createTrackedFetch()
+                await trackedFetch('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
+            } finally {
+                globalThis.fetch = originalFetch
+            }
+
+            expect(getDefaultDispatcherMock).toHaveBeenCalled()
+            expect(captured).toBeTruthy()
+            // dispatcher is a Node fetch extension not present in RequestInit types
+            expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBe(
+                fakeDispatcher,
+            )
+        })
+
+        it('does not attach a dispatcher when createTrackedFetch is given a stub', async () => {
+            let captured: RequestInit | undefined
+            const trackedFetch = createTrackedFetch(async (_url, options) => {
+                captured = options
+                return new Response('{}', {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                })
+            })
+
+            await trackedFetch('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
+
+            expect(getDefaultDispatcherMock).not.toHaveBeenCalled()
+            expect(captured).toBeTruthy()
+            expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBeUndefined()
+        })
+
+        it('attaches the env proxy dispatcher when fetchTodoist uses native fetch', async () => {
+            const fakeDispatcher = { kind: 'env-http-proxy-agent' } as unknown as NonNullable<
+                Awaited<ReturnType<typeof getDefaultDispatcher>>
+            >
+            getDefaultDispatcherMock.mockResolvedValue(fakeDispatcher)
+
+            let captured: RequestInit | undefined
+            const originalFetch = globalThis.fetch
+            globalThis.fetch = (async (_url: RequestInfo | URL, options?: RequestInit) => {
+                captured = options
+                return new Response('{}', {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                })
+            }) as typeof fetch
+
+            try {
+                await fetchTodoist('https://api.todoist.com/api/v1/user', {
+                    headers: { Authorization: 'Bearer token' },
+                })
+            } finally {
+                globalThis.fetch = originalFetch
+            }
+
+            expect(getDefaultDispatcherMock).toHaveBeenCalled()
+            expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBe(
+                fakeDispatcher,
+            )
+        })
+
+        it('does not attach a dispatcher when fetchTodoist is given a stub', async () => {
+            let captured: RequestInit | undefined
+            const fetchImpl: typeof fetch = async (_url, options) => {
+                captured = options
+                return new Response('{}', {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                })
+            }
+
+            await fetchTodoist(
+                'https://api.todoist.com/api/v1/user',
+                { headers: { Authorization: 'Bearer token' } },
+                fetchImpl,
+            )
+
+            expect(getDefaultDispatcherMock).not.toHaveBeenCalled()
+            expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBeUndefined()
+        })
     })
 
     it('supports explicit command overrides for non-command direct fetches', async () => {

--- a/src/lib/usage-tracking.test.ts
+++ b/src/lib/usage-tracking.test.ts
@@ -125,38 +125,41 @@ describe('usage tracking', () => {
     })
 
     describe('proxy dispatcher injection', () => {
+        const fakeDispatcher = { kind: 'env-http-proxy-agent' } as unknown as NonNullable<
+            Awaited<ReturnType<typeof getDefaultDispatcher>>
+        >
+
         afterEach(() => {
+            vi.restoreAllMocks()
             getDefaultDispatcherMock.mockReset()
             getDefaultDispatcherMock.mockResolvedValue(undefined)
         })
 
-        it('attaches the env proxy dispatcher when createTrackedFetch uses native fetch', async () => {
-            const fakeDispatcher = { kind: 'env-http-proxy-agent' } as unknown as NonNullable<
-                Awaited<ReturnType<typeof getDefaultDispatcher>>
-            >
-            getDefaultDispatcherMock.mockResolvedValue(fakeDispatcher)
-
+        function spyOnNativeFetch(): () => RequestInit | undefined {
             let captured: RequestInit | undefined
-            const originalFetch = globalThis.fetch
-            globalThis.fetch = (async (_url: RequestInfo | URL, options?: RequestInit) => {
+            vi.spyOn(globalThis, 'fetch').mockImplementation((async (
+                _url: RequestInfo | URL,
+                options?: RequestInit,
+            ) => {
                 captured = options
                 return new Response('{}', {
                     status: 200,
                     headers: { 'content-type': 'application/json' },
                 })
-            }) as typeof fetch
+            }) as typeof fetch)
+            return () => captured
+        }
 
-            try {
-                const trackedFetch = createTrackedFetch()
-                await trackedFetch('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
-            } finally {
-                globalThis.fetch = originalFetch
-            }
+        it('attaches the env proxy dispatcher when createTrackedFetch uses native fetch', async () => {
+            getDefaultDispatcherMock.mockResolvedValue(fakeDispatcher)
+            const getCaptured = spyOnNativeFetch()
+
+            const trackedFetch = createTrackedFetch()
+            await trackedFetch('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
 
             expect(getDefaultDispatcherMock).toHaveBeenCalled()
-            expect(captured).toBeTruthy()
             // dispatcher is a Node fetch extension not present in RequestInit types
-            expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBe(
+            expect((getCaptured() as unknown as { dispatcher?: unknown }).dispatcher).toBe(
                 fakeDispatcher,
             )
         })
@@ -179,31 +182,15 @@ describe('usage tracking', () => {
         })
 
         it('attaches the env proxy dispatcher when fetchTodoist uses native fetch', async () => {
-            const fakeDispatcher = { kind: 'env-http-proxy-agent' } as unknown as NonNullable<
-                Awaited<ReturnType<typeof getDefaultDispatcher>>
-            >
             getDefaultDispatcherMock.mockResolvedValue(fakeDispatcher)
+            const getCaptured = spyOnNativeFetch()
 
-            let captured: RequestInit | undefined
-            const originalFetch = globalThis.fetch
-            globalThis.fetch = (async (_url: RequestInfo | URL, options?: RequestInit) => {
-                captured = options
-                return new Response('{}', {
-                    status: 200,
-                    headers: { 'content-type': 'application/json' },
-                })
-            }) as typeof fetch
-
-            try {
-                await fetchTodoist('https://api.todoist.com/api/v1/user', {
-                    headers: { Authorization: 'Bearer token' },
-                })
-            } finally {
-                globalThis.fetch = originalFetch
-            }
+            await fetchTodoist('https://api.todoist.com/api/v1/user', {
+                headers: { Authorization: 'Bearer token' },
+            })
 
             expect(getDefaultDispatcherMock).toHaveBeenCalled()
-            expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBe(
+            expect((getCaptured() as unknown as { dispatcher?: unknown }).dispatcher).toBe(
                 fakeDispatcher,
             )
         })

--- a/src/lib/usage-tracking.ts
+++ b/src/lib/usage-tracking.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from 'node:crypto'
-import type { CustomFetch, CustomFetchResponse } from '@doist/todoist-sdk'
+import {
+    type CustomFetch,
+    type CustomFetchResponse,
+    getDefaultDispatcher,
+} from '@doist/todoist-sdk'
 import packageJson from '../../package.json' with { type: 'json' }
 
 const CLI_NAME = 'todoist-cli'
@@ -72,6 +76,14 @@ function mergeTodoistHeaders(
     return Object.fromEntries(mergedHeaders.entries())
 }
 
+async function attachDispatcher(options: RequestInit): Promise<void> {
+    const dispatcher = await getDefaultDispatcher()
+    if (dispatcher !== undefined) {
+        // @ts-expect-error - dispatcher is a valid option for Node's fetch but not in the TS types
+        options.dispatcher = dispatcher
+    }
+}
+
 function toCustomFetchResponse(response: Response): CustomFetchResponse {
     return {
         ok: response.ok,
@@ -84,6 +96,10 @@ function toCustomFetchResponse(response: Response): CustomFetchResponse {
 }
 
 export function createTrackedFetch(baseFetch: typeof fetch = globalThis.fetch): CustomFetch {
+    // Only attach the EnvHttpProxyAgent dispatcher when running through the
+    // real native fetch. Test stubs pass an explicit `baseFetch` and don't
+    // need (or understand) the dispatcher option.
+    const useDispatcher = baseFetch === globalThis.fetch
     return async (url, options = {}) => {
         const { timeout: timeoutMs, headers, signal, ...rest } = options
 
@@ -93,26 +109,35 @@ export function createTrackedFetch(baseFetch: typeof fetch = globalThis.fetch): 
             abortSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
         }
 
-        const response = await baseFetch(url, {
+        const fetchOptions: RequestInit = {
             ...rest,
             signal: abortSignal,
             headers: mergeTodoistHeaders(headers),
-        })
+        }
+        if (useDispatcher) {
+            await attachDispatcher(fetchOptions)
+        }
+
+        const response = await baseFetch(url, fetchOptions)
         return toCustomFetchResponse(response)
     }
 }
 
-export function fetchTodoist(
+export async function fetchTodoist(
     url: string | URL,
     options: RequestInit = {},
     fetchImpl: typeof fetch = globalThis.fetch,
     commandPath?: string,
 ): Promise<Response> {
     const { headers, ...rest } = options
-    return fetchImpl(url, {
+    const fetchOptions: RequestInit = {
         ...rest,
         headers: mergeTodoistHeaders(headers, commandPath),
-    })
+    }
+    if (fetchImpl === globalThis.fetch) {
+        await attachDispatcher(fetchOptions)
+    }
+    return fetchImpl(url, fetchOptions)
 }
 
 export function resetUsageTrackingForTests(): void {

--- a/src/lib/usage-tracking.ts
+++ b/src/lib/usage-tracking.ts
@@ -76,7 +76,16 @@ function mergeTodoistHeaders(
     return Object.fromEntries(mergedHeaders.entries())
 }
 
-async function attachDispatcher(options: RequestInit): Promise<void> {
+async function attachDispatcherIfNative(
+    fetchImpl: typeof fetch,
+    options: RequestInit,
+): Promise<void> {
+    // Test stubs pass their own `fetchImpl`; they don't need (or understand)
+    // the dispatcher option. Only the real native fetch path needs it for
+    // HTTP_PROXY / HTTPS_PROXY / NO_PROXY support.
+    if (fetchImpl !== globalThis.fetch) return
+    // Don't clobber a dispatcher the caller already chose.
+    if ('dispatcher' in options) return
     const dispatcher = await getDefaultDispatcher()
     if (dispatcher !== undefined) {
         // @ts-expect-error - dispatcher is a valid option for Node's fetch but not in the TS types
@@ -96,10 +105,6 @@ function toCustomFetchResponse(response: Response): CustomFetchResponse {
 }
 
 export function createTrackedFetch(baseFetch: typeof fetch = globalThis.fetch): CustomFetch {
-    // Only attach the EnvHttpProxyAgent dispatcher when running through the
-    // real native fetch. Test stubs pass an explicit `baseFetch` and don't
-    // need (or understand) the dispatcher option.
-    const useDispatcher = baseFetch === globalThis.fetch
     return async (url, options = {}) => {
         const { timeout: timeoutMs, headers, signal, ...rest } = options
 
@@ -114,9 +119,7 @@ export function createTrackedFetch(baseFetch: typeof fetch = globalThis.fetch): 
             signal: abortSignal,
             headers: mergeTodoistHeaders(headers),
         }
-        if (useDispatcher) {
-            await attachDispatcher(fetchOptions)
-        }
+        await attachDispatcherIfNative(baseFetch, fetchOptions)
 
         const response = await baseFetch(url, fetchOptions)
         return toCustomFetchResponse(response)
@@ -134,9 +137,7 @@ export async function fetchTodoist(
         ...rest,
         headers: mergeTodoistHeaders(headers, commandPath),
     }
-    if (fetchImpl === globalThis.fetch) {
-        await attachDispatcher(fetchOptions)
-    }
+    await attachDispatcherIfNative(fetchImpl, fetchOptions)
     return fetchImpl(url, fetchOptions)
 }
 


### PR DESCRIPTION
## Summary

- Bumps `@doist/todoist-sdk` to `10.1.0` (which now publicly exports `getDefaultDispatcher`).
- In `createTrackedFetch` and `fetchTodoist`, attach the SDK's shared `EnvHttpProxyAgent` dispatcher whenever the underlying fetch is the real native one — restoring `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` support on the `customFetch` path.
- Test stubs continue to skip the dispatcher so their captured options stay clean.

Fixes #304.

## Why

#302 (1.60.0) routed every Todoist-bound request through a `customFetch` so we could attach the usage-tracking headers. The SDK's `transport/fetch-with-retry.ts` only attaches the proxy dispatcher on its **native-fetch** branch — once a `customFetch` is supplied, that branch is skipped, so the proxy env vars were silently dropped. This regressed every corporate-proxy user from 1.60.0 onwards.

The SDK fix landed in [Doist/todoist-sdk-typescript#594](https://github.com/Doist/todoist-sdk-typescript/pull/594), shipped as 10.1.0. This PR consumes that and wires it into our two outbound paths.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run check` clean (lint + format)
- [x] `npm test` — 1577 passing (4 new dispatcher cases added)
- [ ] Manual proxy check: `HTTPS_PROXY=http://localhost:8888 td today` transits the proxy
- [ ] Manual NO_PROXY check: `HTTPS_PROXY=http://localhost:8888 NO_PROXY=api.todoist.com td today` bypasses the proxy
- [ ] Manual OAuth check: `HTTPS_PROXY=http://localhost:8888 td auth login` token exchange transits the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)