### PR TITLE
fix(hc): resolve www.todoist.com marketing article URLs

### DIFF
--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -247,9 +247,10 @@ td reminder location get id:456
 td hc
 td hc --help
 td hc locale --set-default pt-br
+td hc view https://www.todoist.com/help/articles/introduction-to-filters-V98wIH
 ```
 
-`td hc` queries the Todoist online Help Center. Run `td hc --help` for locale discovery, article search, and article viewing details. `td hc locale --set-default <locale>` persists a preferred locale in `~/.config/todoist-cli/config.json` under `hc.defaultLocale`; the `--locale` flag on individual subcommands still overrides it.
+`td hc` queries the Todoist online Help Center. Run `td hc --help` for locale discovery, article search, and article viewing details. `td hc locale --set-default <locale>` persists a preferred locale in `~/.config/todoist-cli/config.json` under `hc.defaultLocale`; the `--locale` flag on individual subcommands still overrides it. `td hc view` accepts `id:N`, raw numeric article IDs, `get.todoist.help` URLs, and public `www.todoist.com/help/articles/...` marketing URLs (resolved to the underlying Zendesk article via slug search).
 
 ### Templates
 ```bash

--- a/src/commands/hc/hc.test.ts
+++ b/src/commands/hc/hc.test.ts
@@ -259,6 +259,104 @@ describe('hc command', () => {
         expect(fetchSpy).not.toHaveBeenCalled()
     })
 
+    it('opens the marketing URL directly in --browser mode without resolving', async () => {
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'td',
+            'hc',
+            'view',
+            'https://www.todoist.com/help/articles/introduction-to-filters-V98wIH',
+            '--browser',
+        ])
+
+        expect(openInBrowser).toHaveBeenCalledWith(
+            'https://www.todoist.com/help/articles/introduction-to-filters-V98wIH',
+        )
+        expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('resolves a www.todoist.com marketing URL via search and fetches the article', async () => {
+        fetchSpy
+            .mockResolvedValueOnce(
+                createJsonResponse({
+                    count: 2,
+                    results: [
+                        {
+                            id: 26646901023644,
+                            title: 'Todoist glossary',
+                            html_url:
+                                'https://get.todoist.help/hc/en-us/articles/26646901023644-Todoist-glossary',
+                        },
+                        {
+                            id: 205248842,
+                            title: 'Introduction to filters',
+                            html_url:
+                                'https://get.todoist.help/hc/en-us/articles/205248842-Introduction-to-filters',
+                        },
+                    ],
+                }),
+            )
+            .mockResolvedValueOnce(
+                createJsonResponse({
+                    article: {
+                        id: 205248842,
+                        title: 'Introduction to filters',
+                        html_url:
+                            'https://get.todoist.help/hc/en-us/articles/205248842-Introduction-to-filters',
+                        body: '<p>Filters help you...</p>',
+                    },
+                }),
+            )
+
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'td',
+            'hc',
+            'view',
+            'https://www.todoist.com/help/articles/introduction-to-filters-V98wIH',
+        ])
+
+        expect(fetchSpy).toHaveBeenCalledTimes(2)
+        expect(String(fetchSpy.mock.calls[0][0])).toContain(
+            '/api/v2/help_center/articles/search?query=introduction-to-filters-V98wIH&locale=en-us&per_page=10',
+        )
+        expect(fetchSpy.mock.calls[1][0]).toBe(
+            'https://todoist.zendesk.com/api/v2/help_center/en-us/articles/205248842',
+        )
+
+        const output = consoleSpy.mock.calls[0][0] as string
+        expect(output).toContain('# Introduction to filters')
+        expect(output).toContain('Filters help you')
+    })
+
+    it('errors when the marketing URL slug cannot be matched', async () => {
+        fetchSpy.mockResolvedValueOnce(
+            createJsonResponse({
+                count: 1,
+                results: [
+                    {
+                        id: 999,
+                        title: 'Something else',
+                        html_url: 'https://get.todoist.help/hc/en-us/articles/999-Something-else',
+                    },
+                ],
+            }),
+        )
+
+        const program = createProgram()
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'hc',
+                'view',
+                'https://www.todoist.com/help/articles/introduction-to-filters-V98wIH',
+            ]),
+        ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    })
+
     it('outputs the raw HTML body with --html', async () => {
         const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
         fetchSpy.mockResolvedValue(

--- a/src/commands/hc/hc.test.ts
+++ b/src/commands/hc/hc.test.ts
@@ -331,6 +331,82 @@ describe('hc command', () => {
         expect(output).toContain('Filters help you')
     })
 
+    it('searches in en-us when an English marketing URL is pasted with a non-English default locale', async () => {
+        mockReadConfig.mockResolvedValue({ hc: { defaultLocale: 'pt-br' } })
+        fetchSpy
+            .mockResolvedValueOnce(
+                createJsonResponse({
+                    count: 1,
+                    results: [
+                        {
+                            id: 205248842,
+                            title: 'Introduction to filters',
+                            html_url:
+                                'https://get.todoist.help/hc/en-us/articles/205248842-Introduction-to-filters',
+                        },
+                    ],
+                }),
+            )
+            .mockResolvedValueOnce(
+                createJsonResponse({
+                    article: {
+                        id: 205248842,
+                        title: 'Introdução aos filtros',
+                        html_url:
+                            'https://get.todoist.help/hc/pt-br/articles/205248842-Introducao-aos-filtros',
+                        body: '<p>Filtros</p>',
+                    },
+                }),
+            )
+
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'td',
+            'hc',
+            'view',
+            'https://www.todoist.com/help/articles/introduction-to-filters-V98wIH',
+        ])
+
+        expect(String(fetchSpy.mock.calls[0][0])).toContain('locale=en-us')
+        expect(fetchSpy.mock.calls[1][0]).toBe(
+            'https://todoist.zendesk.com/api/v2/help_center/pt-br/articles/205248842',
+        )
+    })
+
+    it('opens the resolved zendesk URL once when --browser is combined with --locale on a marketing URL', async () => {
+        fetchSpy.mockResolvedValueOnce(
+            createJsonResponse({
+                count: 1,
+                results: [
+                    {
+                        id: 205248842,
+                        title: 'Introduction to filters',
+                        html_url:
+                            'https://get.todoist.help/hc/en-us/articles/205248842-Introduction-to-filters',
+                    },
+                ],
+            }),
+        )
+
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'td',
+            'hc',
+            'view',
+            'https://www.todoist.com/help/articles/introduction-to-filters-V98wIH',
+            '--browser',
+            '--locale',
+            'fr',
+        ])
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1)
+        expect(openInBrowser).toHaveBeenCalledWith(
+            'https://get.todoist.help/hc/en-us/articles/205248842-Introduction-to-filters',
+        )
+    })
+
     it('errors when the marketing URL slug cannot be matched', async () => {
         fetchSpy.mockResolvedValueOnce(
             createJsonResponse({

--- a/src/commands/hc/index.ts
+++ b/src/commands/hc/index.ts
@@ -22,10 +22,11 @@ Examples:
   td hc view id:360000269065
   td hc view 360000269065
   td hc view https://get.todoist.help/hc/en-us/articles/360000269065
+  td hc view https://www.todoist.com/help/articles/introduction-to-filters-V98wIH
 
 Notes:
   search prints real Help Center article IDs
-  view accepts id:N, raw article IDs, and Help Center URLs`,
+  view accepts id:N, raw article IDs, get.todoist.help URLs, and www.todoist.com/help/articles/... URLs`,
         )
 
     hc.command('locales')

--- a/src/commands/hc/view.ts
+++ b/src/commands/hc/view.ts
@@ -41,20 +41,21 @@ export async function viewHelpCenterArticle(
         return
     }
 
-    let articleId = resolved.articleId
-    if (!articleId) {
-        if (!resolved.marketingSlug) {
-            throw new CliError(
-                'INVALID_REF',
-                'Help Center reference could not be resolved to an article ID.',
-            )
-        }
-        const marketingSlug = resolved.marketingSlug
+    let articleId: string
+    if (resolved.kind === 'marketing') {
+        const { marketingSlug, urlLocale } = resolved
         const resolvedMarketing = await withSpinner(
             { text: 'Resolving Help Center article...', color: 'blue' },
-            () => resolveMarketingArticleId(marketingSlug, resolved.locale),
+            () => resolveMarketingArticleId(marketingSlug, urlLocale),
         )
         articleId = resolvedMarketing.articleId
+
+        if (options.browser) {
+            await openInBrowser(resolvedMarketing.htmlUrl)
+            return
+        }
+    } else {
+        articleId = resolved.articleId
     }
 
     const article = await withSpinner(

--- a/src/commands/hc/view.ts
+++ b/src/commands/hc/view.ts
@@ -5,6 +5,7 @@ import {
     formatHelpCenterArticleMarkdown,
     getHelpCenterArticle,
     resolveHelpCenterRef,
+    resolveMarketingArticleId,
 } from '../../lib/help-center.js'
 import { renderMarkdown } from '../../lib/markdown.js'
 import { withSpinner } from '../../lib/spinner.js'
@@ -40,9 +41,25 @@ export async function viewHelpCenterArticle(
         return
     }
 
+    let articleId = resolved.articleId
+    if (!articleId) {
+        if (!resolved.marketingSlug) {
+            throw new CliError(
+                'INVALID_REF',
+                'Help Center reference could not be resolved to an article ID.',
+            )
+        }
+        const marketingSlug = resolved.marketingSlug
+        const resolvedMarketing = await withSpinner(
+            { text: 'Resolving Help Center article...', color: 'blue' },
+            () => resolveMarketingArticleId(marketingSlug, resolved.locale),
+        )
+        articleId = resolvedMarketing.articleId
+    }
+
     const article = await withSpinner(
         { text: 'Loading Help Center article...', color: 'blue' },
-        () => getHelpCenterArticle(resolved.articleId, { locale: resolved.locale }),
+        () => getHelpCenterArticle(articleId, { locale: resolved.locale }),
     )
 
     if (options.browser) {

--- a/src/lib/help-center.test.ts
+++ b/src/lib/help-center.test.ts
@@ -66,4 +66,30 @@ describe('help center helpers', () => {
             'Invalid Help Center reference "notifications".',
         )
     })
+
+    it('flags a www.todoist.com marketing URL for slug resolution', () => {
+        expect(
+            resolveHelpCenterRef(
+                'https://www.todoist.com/help/articles/introduction-to-filters-V98wIH',
+            ),
+        ).toEqual({
+            marketingSlug: 'introduction-to-filters-V98wIH',
+            locale: 'en-us',
+            htmlUrl: 'https://www.todoist.com/help/articles/introduction-to-filters-V98wIH',
+            source: 'url',
+        })
+    })
+
+    it('honours an explicit locale on a marketing URL', () => {
+        expect(
+            resolveHelpCenterRef(
+                'https://www.todoist.com/help/articles/introduction-to-filters-V98wIH',
+                { locale: 'pt-br' },
+            ),
+        ).toMatchObject({
+            marketingSlug: 'introduction-to-filters-V98wIH',
+            locale: 'pt-br',
+            source: 'url',
+        })
+    })
 })

--- a/src/lib/help-center.test.ts
+++ b/src/lib/help-center.test.ts
@@ -33,6 +33,7 @@ describe('help center helpers', () => {
 
     it('resolves an explicit id: ref', () => {
         expect(resolveHelpCenterRef('id:360000269065')).toEqual({
+            kind: 'article',
             articleId: '360000269065',
             locale: 'en-us',
             source: 'id',
@@ -41,6 +42,7 @@ describe('help center helpers', () => {
 
     it('resolves a raw numeric article id', () => {
         expect(resolveHelpCenterRef('205348301')).toEqual({
+            kind: 'article',
             articleId: '205348301',
             locale: 'en-us',
             source: 'id',
@@ -53,6 +55,7 @@ describe('help center helpers', () => {
                 'https://get.todoist.help/hc/en-us/articles/360000269065-manage-your-notifications',
             ),
         ).toEqual({
+            kind: 'article',
             articleId: '360000269065',
             htmlUrl:
                 'https://get.todoist.help/hc/en-us/articles/360000269065-manage-your-notifications',
@@ -73,23 +76,38 @@ describe('help center helpers', () => {
                 'https://www.todoist.com/help/articles/introduction-to-filters-V98wIH',
             ),
         ).toEqual({
+            kind: 'marketing',
             marketingSlug: 'introduction-to-filters-V98wIH',
+            urlLocale: 'en-us',
             locale: 'en-us',
             htmlUrl: 'https://www.todoist.com/help/articles/introduction-to-filters-V98wIH',
             source: 'url',
         })
     })
 
-    it('honours an explicit locale on a marketing URL', () => {
+    it('extracts the URL locale from a localized marketing URL', () => {
+        expect(
+            resolveHelpCenterRef(
+                'https://www.todoist.com/de/help/articles/einfuehrung-in-filter-V98wIH',
+            ),
+        ).toMatchObject({
+            kind: 'marketing',
+            urlLocale: 'de',
+            locale: 'en-us',
+        })
+    })
+
+    it('honours an explicit locale on a marketing URL while preserving the URL locale', () => {
         expect(
             resolveHelpCenterRef(
                 'https://www.todoist.com/help/articles/introduction-to-filters-V98wIH',
                 { locale: 'pt-br' },
             ),
         ).toMatchObject({
+            kind: 'marketing',
             marketingSlug: 'introduction-to-filters-V98wIH',
+            urlLocale: 'en-us',
             locale: 'pt-br',
-            source: 'url',
         })
     })
 })

--- a/src/lib/help-center.ts
+++ b/src/lib/help-center.ts
@@ -83,13 +83,22 @@ export interface ResolveHelpCenterRefOptions {
     fallbackLocale?: string
 }
 
-export interface ResolvedHelpCenterRef {
-    articleId?: string
-    marketingSlug?: string
-    locale: string
-    htmlUrl?: string
-    source: 'id' | 'url'
-}
+export type ResolvedHelpCenterRef =
+    | {
+          kind: 'article'
+          articleId: string
+          locale: string
+          htmlUrl?: string
+          source: 'id' | 'url'
+      }
+    | {
+          kind: 'marketing'
+          marketingSlug: string
+          urlLocale: string
+          locale: string
+          htmlUrl: string
+          source: 'url'
+      }
 
 const NAMED_HTML_ENTITIES: Record<string, string> = {
     amp: '&',
@@ -479,7 +488,9 @@ export function parseHelpCenterArticleUrl(
     return null
 }
 
-export function parseMarketingHelpCenterUrl(ref: string): { slug: string; htmlUrl: string } | null {
+export function parseMarketingHelpCenterUrl(
+    ref: string,
+): { slug: string; locale: string; htmlUrl: string } | null {
     let url: URL
     try {
         url = new URL(ref)
@@ -492,50 +503,52 @@ export function parseMarketingHelpCenterUrl(ref: string): { slug: string; htmlUr
         return null
     }
 
-    const match = url.pathname.match(/^\/help\/articles\/([A-Za-z0-9][A-Za-z0-9-]*)\/?$/)
+    const match = url.pathname.match(
+        /^(?:\/([a-z]{2}(?:-[a-z]{2})?))?\/help\/articles\/([A-Za-z0-9][A-Za-z0-9-]*)\/?$/i,
+    )
     if (!match) {
         return null
     }
 
-    return { slug: match[1], htmlUrl: url.toString() }
+    return {
+        slug: match[2],
+        locale: match[1] ? match[1].toLowerCase() : DEFAULT_HELP_CENTER_LOCALE,
+        htmlUrl: url.toString(),
+    }
 }
 
-function stripMarketingShortId(slug: string): string {
-    // Marketing slugs have the form `title-slug-{shortId}`, where shortId is a
-    // 6–12 char alphanumeric token containing at least one uppercase letter
-    // (title slugs themselves are all-lowercase, so the case requirement
-    // distinguishes the short ID from genuine slug words).
-    return slug.replace(/-(?=[A-Za-z0-9]*[A-Z])[A-Za-z0-9]{6,12}$/, '').toLowerCase()
+function stripMarketingShortId(slug: string): string | null {
+    // Marketing slugs have the form `title-slug-{shortId}` where shortId is a
+    // 6–12 char alphanumeric token. Returns the title-slug with the trailing
+    // short ID removed, or null if the slug doesn't end with a strippable token.
+    const match = slug.match(/^(.+)-([A-Za-z0-9]{6,12})$/)
+    return match ? match[1].toLowerCase() : null
+}
+
+function findArticleBySlug(
+    results: HelpCenterSearchResult[],
+    targetSlug: string,
+): HelpCenterSearchResult | undefined {
+    return results.find((result) => {
+        const slugMatch = result.htmlUrl.match(/\/articles\/\d+-(.+?)\/?$/)
+        return slugMatch ? slugMatch[1].toLowerCase() === targetSlug : false
+    })
 }
 
 export async function resolveMarketingArticleId(
     slug: string,
     locale: string,
 ): Promise<{ articleId: string; htmlUrl: string }> {
+    const results = await searchHelpCenter(slug, { locale, limit: 10 })
+
     const titleSlug = stripMarketingShortId(slug)
-    const url = new URL(HELP_CENTER_SEARCH_URL)
-    url.searchParams.set('query', slug)
-    url.searchParams.set('locale', locale)
-    url.searchParams.set('per_page', '10')
-
-    const { response, data } = await fetchHelpCenterJson<RawHelpCenterSearchResponse>(
-        url.toString(),
-    )
-    if (!response.ok) {
-        throw new CliError(
-            'FETCH_FAILED',
-            `Failed to resolve Help Center URL: ${response.status} ${response.statusText}`,
-        )
+    if (titleSlug) {
+        const match = findArticleBySlug(results, titleSlug)
+        if (match) return { articleId: match.id, htmlUrl: match.htmlUrl }
     }
 
-    for (const result of data.results ?? []) {
-        if (result.id === undefined || result.id === null || !result.html_url) continue
-        const slugMatch = result.html_url.match(/\/articles\/\d+-(.+?)\/?$/)
-        if (!slugMatch) continue
-        if (slugMatch[1].toLowerCase() === titleSlug) {
-            return { articleId: String(result.id), htmlUrl: result.html_url }
-        }
-    }
+    const fullMatch = findArticleBySlug(results, slug.toLowerCase())
+    if (fullMatch) return { articleId: fullMatch.id, htmlUrl: fullMatch.htmlUrl }
 
     throw new CliError('NOT_FOUND', `Could not resolve Help Center URL slug "${slug}".`, [
         'Open the article on get.todoist.help and pass that URL or the numeric article ID instead.',
@@ -674,6 +687,7 @@ export function resolveHelpCenterRef(
     const urlRef = parseHelpCenterArticleUrl(trimmed)
     if (urlRef) {
         return {
+            kind: 'article',
             articleId: urlRef.articleId,
             locale: explicitLocale ?? urlRef.locale ?? normalizedFallback(),
             htmlUrl: urlRef.htmlUrl,
@@ -684,7 +698,9 @@ export function resolveHelpCenterRef(
     const marketingRef = parseMarketingHelpCenterUrl(trimmed)
     if (marketingRef) {
         return {
+            kind: 'marketing',
             marketingSlug: marketingRef.slug,
+            urlLocale: marketingRef.locale,
             locale: explicitLocale ?? normalizedFallback(),
             htmlUrl: marketingRef.htmlUrl,
             source: 'url',
@@ -694,6 +710,7 @@ export function resolveHelpCenterRef(
     if (trimmed.startsWith('id:')) {
         const articleId = normalizeArticleId(trimmed.slice(3))
         return {
+            kind: 'article',
             articleId,
             locale: explicitLocale ?? normalizedFallback(),
             source: 'id',
@@ -702,6 +719,7 @@ export function resolveHelpCenterRef(
 
     if (/^[1-9]\d*$/.test(trimmed)) {
         return {
+            kind: 'article',
             articleId: trimmed,
             locale: explicitLocale ?? normalizedFallback(),
             source: 'id',

--- a/src/lib/help-center.ts
+++ b/src/lib/help-center.ts
@@ -84,7 +84,8 @@ export interface ResolveHelpCenterRefOptions {
 }
 
 export interface ResolvedHelpCenterRef {
-    articleId: string
+    articleId?: string
+    marketingSlug?: string
     locale: string
     htmlUrl?: string
     source: 'id' | 'url'
@@ -478,6 +479,69 @@ export function parseHelpCenterArticleUrl(
     return null
 }
 
+export function parseMarketingHelpCenterUrl(ref: string): { slug: string; htmlUrl: string } | null {
+    let url: URL
+    try {
+        url = new URL(ref)
+    } catch {
+        return null
+    }
+
+    const hostname = url.hostname.toLowerCase()
+    if (hostname !== 'www.todoist.com' && hostname !== 'todoist.com') {
+        return null
+    }
+
+    const match = url.pathname.match(/^\/help\/articles\/([A-Za-z0-9][A-Za-z0-9-]*)\/?$/)
+    if (!match) {
+        return null
+    }
+
+    return { slug: match[1], htmlUrl: url.toString() }
+}
+
+function stripMarketingShortId(slug: string): string {
+    // Marketing slugs have the form `title-slug-{shortId}`, where shortId is a
+    // 6–12 char alphanumeric token containing at least one uppercase letter
+    // (title slugs themselves are all-lowercase, so the case requirement
+    // distinguishes the short ID from genuine slug words).
+    return slug.replace(/-(?=[A-Za-z0-9]*[A-Z])[A-Za-z0-9]{6,12}$/, '').toLowerCase()
+}
+
+export async function resolveMarketingArticleId(
+    slug: string,
+    locale: string,
+): Promise<{ articleId: string; htmlUrl: string }> {
+    const titleSlug = stripMarketingShortId(slug)
+    const url = new URL(HELP_CENTER_SEARCH_URL)
+    url.searchParams.set('query', slug)
+    url.searchParams.set('locale', locale)
+    url.searchParams.set('per_page', '10')
+
+    const { response, data } = await fetchHelpCenterJson<RawHelpCenterSearchResponse>(
+        url.toString(),
+    )
+    if (!response.ok) {
+        throw new CliError(
+            'FETCH_FAILED',
+            `Failed to resolve Help Center URL: ${response.status} ${response.statusText}`,
+        )
+    }
+
+    for (const result of data.results ?? []) {
+        if (result.id === undefined || result.id === null || !result.html_url) continue
+        const slugMatch = result.html_url.match(/\/articles\/\d+-(.+?)\/?$/)
+        if (!slugMatch) continue
+        if (slugMatch[1].toLowerCase() === titleSlug) {
+            return { articleId: String(result.id), htmlUrl: result.html_url }
+        }
+    }
+
+    throw new CliError('NOT_FOUND', `Could not resolve Help Center URL slug "${slug}".`, [
+        'Open the article on get.todoist.help and pass that URL or the numeric article ID instead.',
+    ])
+}
+
 export async function searchHelpCenter(
     query: string,
     options: { locale?: string; limit?: number | string } = {},
@@ -613,6 +677,16 @@ export function resolveHelpCenterRef(
             articleId: urlRef.articleId,
             locale: explicitLocale ?? urlRef.locale ?? normalizedFallback(),
             htmlUrl: urlRef.htmlUrl,
+            source: 'url',
+        }
+    }
+
+    const marketingRef = parseMarketingHelpCenterUrl(trimmed)
+    if (marketingRef) {
+        return {
+            marketingSlug: marketingRef.slug,
+            locale: explicitLocale ?? normalizedFallback(),
+            htmlUrl: marketingRef.htmlUrl,
             source: 'url',
         }
     }

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -243,9 +243,10 @@ td reminder location get id:456
 td hc
 td hc --help
 td hc locale --set-default pt-br
+td hc view https://www.todoist.com/help/articles/introduction-to-filters-V98wIH
 \`\`\`
 
-\`td hc\` queries the Todoist online Help Center. Run \`td hc --help\` for locale discovery, article search, and article viewing details. \`td hc locale --set-default <locale>\` persists a preferred locale in \`~/.config/todoist-cli/config.json\` under \`hc.defaultLocale\`; the \`--locale\` flag on individual subcommands still overrides it.
+\`td hc\` queries the Todoist online Help Center. Run \`td hc --help\` for locale discovery, article search, and article viewing details. \`td hc locale --set-default <locale>\` persists a preferred locale in \`~/.config/todoist-cli/config.json\` under \`hc.defaultLocale\`; the \`--locale\` flag on individual subcommands still overrides it. \`td hc view\` accepts \`id:N\`, raw numeric article IDs, \`get.todoist.help\` URLs, and public \`www.todoist.com/help/articles/...\` marketing URLs (resolved to the underlying Zendesk article via slug search).
 
 ### Templates
 \`\`\`bash


### PR DESCRIPTION
## Summary

- `td hc view https://www.todoist.com/help/articles/<slug>-<shortId>` previously failed with `INVALID_REF`. The marketing host was not recognized and the trailing short ID (e.g. `V98wIH`) is not a valid Zendesk article identifier.
- New `parseMarketingHelpCenterUrl` recognizes `www.todoist.com/help/articles/...` URLs. `resolveMarketingArticleId` searches the Zendesk Help Center using the full slug and validates the top hit by comparing the marketing slug (with the trailing short ID stripped) against the Zendesk `html_url` slug. This is reliable because Zendesk URLs end in `{numericId}-{Title-Slug}`.
- `--browser` short-circuits to the marketing URL without making an extra API call.

## Test plan

- [x] `npm test` (1582 passing, including new help-center + hc.command coverage for marketing URLs)
- [x] `npm run type-check`
- [x] `npm run check`
- [x] Manual: `td hc view https://www.todoist.com/help/articles/introduction-to-filters-V98wIH` resolves to article `205248842` and renders the article body.
- [x] Manual: `td hc view https://www.todoist.com/help/articles/introduction-to-filters-V98wIH --browser` opens the marketing URL directly with no extra fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)