### PR TITLE
feat(auth): add `td auth token view` for script and agent use

### DIFF
--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -42,6 +42,8 @@ td auth login --read-only --additional-scopes=backups
 td auth login --additional-scopes=app-management,backups
 td auth token
 td auth status
+td auth print-token
+td auth print-token --user scott@doist.com
 td auth logout
 ```
 
@@ -53,6 +55,8 @@ Opt-in OAuth scopes are requested via `--additional-scopes=<list>` (comma-separa
 Combine freely with `--read-only` to keep data access read-only while still granting an opt-in scope (e.g. `td auth login --read-only --additional-scopes=backups`). When a command fails for lack of a scope, the error suggests a re-login command that preserves whichever flags were originally used.
 
 Tokens are stored in the OS credential manager when available, with fallback to `~/.config/todoist-cli/config.json`. `TODOIST_API_TOKEN` takes precedence over stored credentials.
+
+`td auth print-token` writes the stored token to stdout for use in scripts (e.g. `TOKEN=$(td auth print-token)`). Honors `--user <id|email>` for multi-account installs and refuses when `TODOIST_API_TOKEN` is set in the environment (the token is already available there).
 
 ## Multi-user
 

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -42,8 +42,8 @@ td auth login --read-only --additional-scopes=backups
 td auth login --additional-scopes=app-management,backups
 td auth token
 td auth status
-td auth print-token
-td auth print-token --user scott@doist.com
+TOKEN=$(td auth print-token)
+TOKEN=$(td auth print-token --user you@example.com)
 td auth logout
 ```
 
@@ -56,7 +56,7 @@ Combine freely with `--read-only` to keep data access read-only while still gran
 
 Tokens are stored in the OS credential manager when available, with fallback to `~/.config/todoist-cli/config.json`. `TODOIST_API_TOKEN` takes precedence over stored credentials.
 
-`td auth print-token` writes the stored token to stdout for use in scripts (e.g. `TOKEN=$(td auth print-token)`). Honors `--user <id|email>` for multi-account installs and refuses when `TODOIST_API_TOKEN` is set in the environment (the token is already available there).
+`td auth print-token` writes the stored token to stdout for use in scripts. **Always capture it into a shell variable** (e.g. `TOKEN=$(td auth print-token)`) — never invoke it bare in an agent transcript or piped to a shell that echoes its output, since that would leak the secret. Honors `--user <id|email>` for multi-account installs and refuses when `TODOIST_API_TOKEN` is set in the environment (the token is already available there).
 
 ## Multi-user
 

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -42,8 +42,8 @@ td auth login --read-only --additional-scopes=backups
 td auth login --additional-scopes=app-management,backups
 td auth token
 td auth status
-TOKEN=$(td auth print-token)
-TOKEN=$(td auth print-token --user you@example.com)
+TOKEN=$(td auth token view)
+TOKEN=$(td auth token view --user you@example.com)
 td auth logout
 ```
 
@@ -56,7 +56,7 @@ Combine freely with `--read-only` to keep data access read-only while still gran
 
 Tokens are stored in the OS credential manager when available, with fallback to `~/.config/todoist-cli/config.json`. `TODOIST_API_TOKEN` takes precedence over stored credentials.
 
-`td auth print-token` writes the stored token to stdout for use in scripts. **Always capture it into a shell variable** (e.g. `TOKEN=$(td auth print-token)`) — never invoke it bare in an agent transcript or piped to a shell that echoes its output, since that would leak the secret. Honors `--user <id|email>` for multi-account installs and refuses when `TODOIST_API_TOKEN` is set in the environment (the token is already available there).
+`td auth token view` writes the stored token to stdout for use in scripts. **Always capture it into a shell variable** (e.g. `TOKEN=$(td auth token view)`) — never invoke it bare in an agent transcript or piped to a shell that echoes its output, since that would leak the secret. Honors `--user <id|email>` for multi-account installs and refuses when `TODOIST_API_TOKEN` is set in the environment (the token is already available there).
 
 ## Multi-user
 

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -76,6 +76,7 @@ import {
     resolveActiveUser,
     upsertUser,
 } from '../../lib/auth.js'
+import { resetGlobalArgs } from '../../lib/global-args.js'
 import { startCallbackServer } from '../../lib/oauth-server.js'
 import { buildAuthorizationUrl, exchangeCodeForToken } from '../../lib/oauth.js'
 import { UserNotFoundError } from '../../lib/users.js'
@@ -562,9 +563,21 @@ describe('auth command', () => {
             const program = createProgram()
             mockResolveActiveUser.mockRejectedValue(new UserNotFoundError('missing@example.com'))
 
-            await expect(
-                program.parseAsync(['node', 'td', 'auth', 'print-token']),
-            ).rejects.toHaveProperty('code', 'USER_NOT_FOUND')
+            // `--user <ref>` is parsed from process.argv by the global-args
+            // layer (not commander) and stripped before commander sees the
+            // argv. Stub process.argv to mirror production wiring so the
+            // test exercises the same code path as a real invocation.
+            const originalArgv = process.argv
+            process.argv = ['node', 'td', 'auth', 'print-token', '--user', 'missing@example.com']
+            resetGlobalArgs()
+            try {
+                await expect(
+                    program.parseAsync(['node', 'td', 'auth', 'print-token']),
+                ).rejects.toHaveProperty('code', 'USER_NOT_FOUND')
+            } finally {
+                process.argv = originalArgv
+                resetGlobalArgs()
+            }
             expect(consoleSpy).not.toHaveBeenCalled()
         })
     })

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../lib/auth.js', async (importOriginal) => {
         getAuthMetadata: vi.fn(),
         listStoredUsers: vi.fn(),
         readConfig: vi.fn(),
+        resolveActiveUser: vi.fn(),
     }
 })
 
@@ -67,14 +68,17 @@ import open from 'open'
 import { createApiForToken, getApi } from '../../lib/api/core.js'
 import {
     NoTokenError,
+    TOKEN_ENV_VAR,
     clearApiToken,
     getAuthMetadata,
     listStoredUsers,
     readConfig,
+    resolveActiveUser,
     upsertUser,
 } from '../../lib/auth.js'
 import { startCallbackServer } from '../../lib/oauth-server.js'
 import { buildAuthorizationUrl, exchangeCodeForToken } from '../../lib/oauth.js'
+import { UserNotFoundError } from '../../lib/users.js'
 import { createMockApi } from '../../test-support/mock-api.js'
 import { registerAuthCommand } from './index.js'
 
@@ -85,6 +89,7 @@ const mockClearApiToken = vi.mocked(clearApiToken)
 const mockGetAuthMetadata = vi.mocked(getAuthMetadata)
 const mockListStoredUsers = vi.mocked(listStoredUsers)
 const mockReadConfig = vi.mocked(readConfig)
+const mockResolveActiveUser = vi.mocked(resolveActiveUser)
 const mockGetApi = vi.mocked(getApi)
 const mockCreateApiForToken = vi.mocked(createApiForToken)
 const mockStartCallbackServer = vi.mocked(startCallbackServer)
@@ -496,6 +501,71 @@ describe('auth command', () => {
 
             expect(mockClearApiToken).toHaveBeenCalled()
             expect(consoleSpy).toHaveBeenCalledWith('✓', 'Logged out')
+        })
+    })
+
+    describe('print-token subcommand', () => {
+        let originalEnvToken: string | undefined
+
+        beforeEach(() => {
+            originalEnvToken = process.env[TOKEN_ENV_VAR]
+            delete process.env[TOKEN_ENV_VAR]
+        })
+
+        afterEach(() => {
+            if (originalEnvToken === undefined) {
+                delete process.env[TOKEN_ENV_VAR]
+            } else {
+                process.env[TOKEN_ENV_VAR] = originalEnvToken
+            }
+        })
+
+        it('prints the bare token to stdout', async () => {
+            const program = createProgram()
+            mockResolveActiveUser.mockResolvedValue({
+                id: TEST_USER.id,
+                email: TEST_USER.email,
+                token: 'stored_token_abc123456',
+                authMode: 'read-write',
+                source: 'secure-store',
+            })
+
+            await program.parseAsync(['node', 'td', 'auth', 'print-token'])
+
+            expect(mockResolveActiveUser).toHaveBeenCalled()
+            expect(consoleSpy).toHaveBeenCalledTimes(1)
+            expect(consoleSpy).toHaveBeenCalledWith('stored_token_abc123456')
+        })
+
+        it('refuses when TODOIST_API_TOKEN is set', async () => {
+            const program = createProgram()
+            process.env[TOKEN_ENV_VAR] = 'env_token_value'
+
+            await expect(
+                program.parseAsync(['node', 'td', 'auth', 'print-token']),
+            ).rejects.toHaveProperty('code', 'TOKEN_FROM_ENV')
+            expect(mockResolveActiveUser).not.toHaveBeenCalled()
+            expect(consoleSpy).not.toHaveBeenCalled()
+        })
+
+        it('propagates NoTokenError when no users are stored', async () => {
+            const program = createProgram()
+            mockResolveActiveUser.mockRejectedValue(new NoTokenError())
+
+            await expect(
+                program.parseAsync(['node', 'td', 'auth', 'print-token']),
+            ).rejects.toHaveProperty('code', 'NO_TOKEN')
+            expect(consoleSpy).not.toHaveBeenCalled()
+        })
+
+        it('propagates UserNotFoundError when --user ref does not match', async () => {
+            const program = createProgram()
+            mockResolveActiveUser.mockRejectedValue(new UserNotFoundError('missing@example.com'))
+
+            await expect(
+                program.parseAsync(['node', 'td', 'auth', 'print-token']),
+            ).rejects.toHaveProperty('code', 'USER_NOT_FOUND')
+            expect(consoleSpy).not.toHaveBeenCalled()
         })
     })
 })

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -505,7 +505,7 @@ describe('auth command', () => {
         })
     })
 
-    describe('print-token subcommand', () => {
+    describe('token view subcommand', () => {
         let originalEnvToken: string | undefined
 
         beforeEach(() => {
@@ -531,7 +531,7 @@ describe('auth command', () => {
                 source: 'secure-store',
             })
 
-            await program.parseAsync(['node', 'td', 'auth', 'print-token'])
+            await program.parseAsync(['node', 'td', 'auth', 'token', 'view'])
 
             expect(mockResolveActiveUser).toHaveBeenCalled()
             expect(consoleSpy).toHaveBeenCalledTimes(1)
@@ -543,7 +543,7 @@ describe('auth command', () => {
             process.env[TOKEN_ENV_VAR] = 'env_token_value'
 
             await expect(
-                program.parseAsync(['node', 'td', 'auth', 'print-token']),
+                program.parseAsync(['node', 'td', 'auth', 'token', 'view']),
             ).rejects.toHaveProperty('code', 'TOKEN_FROM_ENV')
             expect(mockResolveActiveUser).not.toHaveBeenCalled()
             expect(consoleSpy).not.toHaveBeenCalled()
@@ -554,7 +554,7 @@ describe('auth command', () => {
             mockResolveActiveUser.mockRejectedValue(new NoTokenError())
 
             await expect(
-                program.parseAsync(['node', 'td', 'auth', 'print-token']),
+                program.parseAsync(['node', 'td', 'auth', 'token', 'view']),
             ).rejects.toHaveProperty('code', 'NO_TOKEN')
             expect(consoleSpy).not.toHaveBeenCalled()
         })
@@ -568,11 +568,11 @@ describe('auth command', () => {
             // argv. Stub process.argv to mirror production wiring so the
             // test exercises the same code path as a real invocation.
             const originalArgv = process.argv
-            process.argv = ['node', 'td', 'auth', 'print-token', '--user', 'missing@example.com']
+            process.argv = ['node', 'td', 'auth', 'token', 'view', '--user', 'missing@example.com']
             resetGlobalArgs()
             try {
                 await expect(
-                    program.parseAsync(['node', 'td', 'auth', 'print-token']),
+                    program.parseAsync(['node', 'td', 'auth', 'token', 'view']),
                 ).rejects.toHaveProperty('code', 'USER_NOT_FOUND')
             } finally {
                 process.argv = originalArgv

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 import { formatScopesHelp } from '../../lib/oauth-scopes.js'
 import { loginWithOAuth } from './login.js'
 import { logout } from './logout.js'
+import { printToken } from './print-token.js'
 import { showStatus } from './status.js'
 import { loginWithToken } from './token.js'
 
@@ -31,6 +32,12 @@ export function registerAuthCommand(program: Command): void {
         .description('Show current authentication status')
         .option('--json', 'Output as JSON')
         .action(showStatus)
+
+    auth.command('print-token')
+        .description(
+            'Print the stored API token for the active user (or --user <ref>) to stdout for use in scripts',
+        )
+        .action(printToken)
 
     auth.command('logout').description('Remove saved authentication token').action(logout)
 }

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -2,8 +2,8 @@ import { Command } from 'commander'
 import { formatScopesHelp } from '../../lib/oauth-scopes.js'
 import { loginWithOAuth } from './login.js'
 import { logout } from './logout.js'
-import { printToken } from './print-token.js'
 import { showStatus } from './status.js'
+import { viewToken } from './token-view.js'
 import { loginWithToken } from './token.js'
 
 export function registerAuthCommand(program: Command): void {
@@ -24,20 +24,28 @@ export function registerAuthCommand(program: Command): void {
         .addHelpText('after', formatScopesHelp())
         .action(loginWithOAuth)
 
-    auth.command('token [token]')
-        .description('Save API token for CLI authentication')
+    // `token` is a hybrid: it accepts a positional `[token]` (save) and also
+    // exposes subcommands (`view`). Commander matches subcommand names before
+    // falling through to the parent action, so `td auth token view` always
+    // dispatches to the `view` subcommand — `view` is never treated as a
+    // literal token value. Real Todoist tokens are 40-char hex strings, so
+    // this disambiguation is safe in practice.
+    const tokenCmd = auth
+        .command('token [token]')
+        .description('Save API token for CLI authentication (or use a subcommand: `view`)')
         .action(loginWithToken)
+
+    tokenCmd
+        .command('view')
+        .description(
+            'Print the stored API token for the active user (or --user <ref>) to stdout for use in scripts',
+        )
+        .action(viewToken)
 
     auth.command('status')
         .description('Show current authentication status')
         .option('--json', 'Output as JSON')
         .action(showStatus)
-
-    auth.command('print-token')
-        .description(
-            'Print the stored API token for the active user (or --user <ref>) to stdout for use in scripts',
-        )
-        .action(printToken)
 
     auth.command('logout').description('Remove saved authentication token').action(logout)
 }

--- a/src/commands/auth/print-token.ts
+++ b/src/commands/auth/print-token.ts
@@ -1,0 +1,18 @@
+import { resolveActiveUser, TOKEN_ENV_VAR } from '../../lib/auth.js'
+import { CliError } from '../../lib/errors.js'
+
+export async function printToken(): Promise<void> {
+    if (process.env[TOKEN_ENV_VAR]) {
+        throw new CliError(
+            'TOKEN_FROM_ENV',
+            `Refusing to print token: ${TOKEN_ENV_VAR} is set in the environment.`,
+            [
+                `The token is already available in your environment as $${TOKEN_ENV_VAR}.`,
+                `Unset ${TOKEN_ENV_VAR} to print the stored token instead.`,
+            ],
+        )
+    }
+
+    const resolved = await resolveActiveUser()
+    console.log(resolved.token)
+}

--- a/src/commands/auth/token-view.ts
+++ b/src/commands/auth/token-view.ts
@@ -1,7 +1,7 @@
 import { resolveActiveUser, TOKEN_ENV_VAR } from '../../lib/auth.js'
 import { CliError } from '../../lib/errors.js'
 
-export async function printToken(): Promise<void> {
+export async function viewToken(): Promise<void> {
     if (process.env[TOKEN_ENV_VAR]) {
         throw new CliError(
             'TOKEN_FROM_ENV',

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -10,6 +10,7 @@ export type ErrorCode =
     | 'INVALID_TOKEN'
     | 'NO_TOKEN'
     | 'READ_ONLY'
+    | 'TOKEN_FROM_ENV'
     // API & network
     | 'API_ERROR'
     | 'INTERNAL_ERROR'

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -38,8 +38,8 @@ td auth login --read-only --additional-scopes=backups
 td auth login --additional-scopes=app-management,backups
 td auth token
 td auth status
-td auth print-token
-td auth print-token --user scott@doist.com
+TOKEN=$(td auth print-token)
+TOKEN=$(td auth print-token --user you@example.com)
 td auth logout
 \`\`\`
 
@@ -52,7 +52,7 @@ Combine freely with \`--read-only\` to keep data access read-only while still gr
 
 Tokens are stored in the OS credential manager when available, with fallback to \`~/.config/todoist-cli/config.json\`. \`TODOIST_API_TOKEN\` takes precedence over stored credentials.
 
-\`td auth print-token\` writes the stored token to stdout for use in scripts (e.g. \`TOKEN=$(td auth print-token)\`). Honors \`--user <id|email>\` for multi-account installs and refuses when \`TODOIST_API_TOKEN\` is set in the environment (the token is already available there).
+\`td auth print-token\` writes the stored token to stdout for use in scripts. **Always capture it into a shell variable** (e.g. \`TOKEN=$(td auth print-token)\`) — never invoke it bare in an agent transcript or piped to a shell that echoes its output, since that would leak the secret. Honors \`--user <id|email>\` for multi-account installs and refuses when \`TODOIST_API_TOKEN\` is set in the environment (the token is already available there).
 
 ## Multi-user
 

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -38,6 +38,8 @@ td auth login --read-only --additional-scopes=backups
 td auth login --additional-scopes=app-management,backups
 td auth token
 td auth status
+td auth print-token
+td auth print-token --user scott@doist.com
 td auth logout
 \`\`\`
 
@@ -49,6 +51,8 @@ Opt-in OAuth scopes are requested via \`--additional-scopes=<list>\` (comma-sepa
 Combine freely with \`--read-only\` to keep data access read-only while still granting an opt-in scope (e.g. \`td auth login --read-only --additional-scopes=backups\`). When a command fails for lack of a scope, the error suggests a re-login command that preserves whichever flags were originally used.
 
 Tokens are stored in the OS credential manager when available, with fallback to \`~/.config/todoist-cli/config.json\`. \`TODOIST_API_TOKEN\` takes precedence over stored credentials.
+
+\`td auth print-token\` writes the stored token to stdout for use in scripts (e.g. \`TOKEN=$(td auth print-token)\`). Honors \`--user <id|email>\` for multi-account installs and refuses when \`TODOIST_API_TOKEN\` is set in the environment (the token is already available there).
 
 ## Multi-user
 

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -38,8 +38,8 @@ td auth login --read-only --additional-scopes=backups
 td auth login --additional-scopes=app-management,backups
 td auth token
 td auth status
-TOKEN=$(td auth print-token)
-TOKEN=$(td auth print-token --user you@example.com)
+TOKEN=$(td auth token view)
+TOKEN=$(td auth token view --user you@example.com)
 td auth logout
 \`\`\`
 
@@ -52,7 +52,7 @@ Combine freely with \`--read-only\` to keep data access read-only while still gr
 
 Tokens are stored in the OS credential manager when available, with fallback to \`~/.config/todoist-cli/config.json\`. \`TODOIST_API_TOKEN\` takes precedence over stored credentials.
 
-\`td auth print-token\` writes the stored token to stdout for use in scripts. **Always capture it into a shell variable** (e.g. \`TOKEN=$(td auth print-token)\`) — never invoke it bare in an agent transcript or piped to a shell that echoes its output, since that would leak the secret. Honors \`--user <id|email>\` for multi-account installs and refuses when \`TODOIST_API_TOKEN\` is set in the environment (the token is already available there).
+\`td auth token view\` writes the stored token to stdout for use in scripts. **Always capture it into a shell variable** (e.g. \`TOKEN=$(td auth token view)\`) — never invoke it bare in an agent transcript or piped to a shell that echoes its output, since that would leak the secret. Honors \`--user <id|email>\` for multi-account installs and refuses when \`TODOIST_API_TOKEN\` is set in the environment (the token is already available there).
 
 ## Multi-user
 


### PR DESCRIPTION
## Summary

- New `td auth token view` subcommand prints the stored API token for the active user (or `--user <ref>`) to stdout, so scripts can capture it via `TOKEN=$(td auth token view)` without ever surfacing the token in an agent's conversation context.
- Refuses when `TODOIST_API_TOKEN` is set in the environment — the token is already available there, and silently echoing it would mask multi-user `--user` requests when env happens to be set. New error code `TOKEN_FROM_ENV` with actionable hints.
- Wired as a nested subcommand of the existing `auth token` command. Commander matches subcommand names before falling through to the parent's `[token]` positional, so `view` is dispatched as a subcommand and never treated as a literal token value. `td auth token <real-token>` keeps working as before, since real Todoist tokens are 40-char hex strings.

## Test plan

- [x] `npm test -- src/commands/auth/auth.test.ts` — 24/24 pass (4 new: happy path, env refusal, `NoTokenError` propagation, `UserNotFoundError` propagation with `--user`)
- [x] `npm run check` — lint + format clean
- [x] `npm run check:skill-sync` — `skills/todoist-cli/SKILL.md` regenerated and in sync
- [x] `npm run type-check` — clean
- [ ] Manual: `TOKEN=$(td auth token view); echo "len=${#TOKEN}"`
- [ ] Manual: `td auth token view --user <other-email>` resolves the right account
- [ ] Manual: `TODOIST_API_TOKEN=fake td auth token view` exits non-zero with `TOKEN_FROM_ENV`
- [ ] Manual: `td auth token <some-token>` still saves (no regression on the parent action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)