### PR TITLE
fix(deps): bump @doist/todoist-sdk to 10.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@doist/todoist-sdk": "10.1.0",
+        "@doist/todoist-sdk": "10.1.1",
         "@napi-rs/keyring": "1.2.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@doist/todoist-sdk": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.1.0.tgz",
-      "integrity": "sha512-o4AM0YGcQLlNyHOZ126qCfa+FQHsgNOKWpfZCECtjm6a+7tsiU39E/em3Ihcaynh7nUkYRXEVC8RUQ0kkCkJXw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.1.1.tgz",
+      "integrity": "sha512-V60AjoJG5QjiJ2iYB8IIC4hLA4B5PLUybYysc1GU2qC3xjN7Zy3juRukKo8PO+O1VMXeb8EACMri5U/0GPnLkA==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@doist/todoist-sdk": "10.1.0",
+    "@doist/todoist-sdk": "10.1.1",
     "@napi-rs/keyring": "1.2.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",


### PR DESCRIPTION
## Summary

- Bump `@doist/todoist-sdk` from 10.1.0 to 10.1.1.
- Pulls in [Doist/todoist-sdk-typescript#596](https://github.com/Doist/todoist-sdk-typescript/pull/596), which fixes the sync `user` / `user_settings` schema mismatches that caused `td settings view` to throw a ZodError.

## Test plan

- [x] `npm install` clean
- [x] `npm run check` — lint + format clean
- [x] `npm run type-check` — clean
- [x] `npm test` — 1585 tests pass
- [x] `td settings view` — renders the settings table; no Zod error
- [x] `td settings view --json` — emits structured output

🤖 Generated with [Claude Code](https://claude.com/claude-code)