### PR TITLE
refactor(spinner): delegate to @doist/cli-core 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@doist/cli-core": "0.2.0",
+        "@doist/cli-core": "0.3.0",
         "@doist/todoist-sdk": "10.1.1",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
@@ -19,8 +19,7 @@
         "date-fns": "4.1.0",
         "marked": "18.0.3",
         "marked-terminal-renderer": "2.2.0",
-        "open": "11.0.0",
-        "yocto-spinner": "1.1.0"
+        "open": "11.0.0"
       },
       "bin": {
         "td": "dist/index.js"
@@ -137,10 +136,14 @@
       }
     },
     "node_modules/@doist/cli-core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.2.0.tgz",
-      "integrity": "sha512-4sZJgUIWnvQIsjIAFUS9voSqEiT8gqjOG33AfAFuLNs7pFrPVij5eXdOtFUdET9oopQRvEADNarsR6LNlEE2WQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.3.0.tgz",
+      "integrity": "sha512-vQHY/cYCzWBJsYeFvX6n8WXLV1h/wW+NyuWxCZhxU6kPynPmc0ILf2+iSg/fGAkFtBYgXP4eJr8LdrK4hA5YrA==",
       "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "yocto-spinner": "1.1.0"
+      },
       "engines": {
         "node": ">=20.18.1"
       }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@doist/cli-core": "0.2.0",
+    "@doist/cli-core": "0.3.0",
     "@doist/todoist-sdk": "10.1.1",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",
@@ -60,8 +60,7 @@
     "date-fns": "4.1.0",
     "marked": "18.0.3",
     "marked-terminal-renderer": "2.2.0",
-    "open": "11.0.0",
-    "yocto-spinner": "1.1.0"
+    "open": "11.0.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "6.0.3",

--- a/src/lib/spinner.test.ts
+++ b/src/lib/spinner.test.ts
@@ -40,4 +40,30 @@ describe('spinner wrapper', () => {
         const s = new LoadingSpinner()
         expect(s.start({ text: 'noop', noSpinner: true })).toBe(s)
     })
+
+    it('forwards shouldDisableSpinner to cli-core (TD_SPINNER=false suppresses the spinner)', () => {
+        // shouldDisableSpinner is the wrapper's only CLI-specific hook.
+        // Force an interactive, non-CI context so the *only* thing left
+        // gating the spinner is shouldDisableSpinner reading TD_SPINNER.
+        const stdout = process.stdout as unknown as { isTTY?: boolean }
+        const originalIsTTY = stdout.isTTY
+        stdout.isTTY = true
+        const originalCI = process.env.CI
+        delete process.env.CI
+        process.env.TD_SPINNER = 'false'
+
+        const writeBefore = process.stdout.write
+        try {
+            startEarlySpinner()
+            // If the wiring is intact, cli-core saw isDisabled() === true
+            // and never installed its stdout interceptor.
+            expect(process.stdout.write).toBe(writeBefore)
+        } finally {
+            stdout.isTTY = originalIsTTY
+            if (originalCI === undefined) delete process.env.CI
+            else process.env.CI = originalCI
+            delete process.env.TD_SPINNER
+            stopEarlySpinner()
+        }
+    })
 })

--- a/src/lib/spinner.test.ts
+++ b/src/lib/spinner.test.ts
@@ -1,6 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import yoctoSpinnerFactory from 'yocto-spinner'
-import { resetGlobalArgs } from './global-args.js'
+import { describe, expect, it } from 'vitest'
+
 import {
     LoadingSpinner,
     resetEarlySpinner,
@@ -9,346 +8,36 @@ import {
     withSpinner,
 } from './spinner.js'
 
-// Mock yocto-spinner
-const mockSpinnerInstance = {
-    start: vi.fn().mockReturnThis(),
-    success: vi.fn(),
-    error: vi.fn(),
-    stop: vi.fn(),
-    text: '',
-}
+// Smoke tests for the local wrapper. The detailed spinner behaviour
+// (early-spinner adoption, colour palette, ✓/✗ rendering, etc.) is
+// covered exhaustively in @doist/cli-core's own spinner suite — this
+// file only verifies that we wire it up correctly and surface the
+// expected public API.
 
-vi.mock('yocto-spinner', () => ({
-    default: vi.fn(() => mockSpinnerInstance),
-}))
-
-// Mock chalk to avoid colors in tests
-vi.mock('chalk')
-
-describe('withSpinner', () => {
-    beforeEach(() => {
-        vi.clearAllMocks()
-        resetEarlySpinner()
-        // Reset environment variables
-        delete process.env.TD_SPINNER
-        delete process.env.CI
-        // Mock TTY as true by default
-        Object.defineProperty(process.stdout, 'isTTY', {
-            value: true,
-            configurable: true,
-        })
-        // Clear process.argv and global args cache
-        process.argv = ['node', 'td']
-        resetGlobalArgs()
+describe('spinner wrapper', () => {
+    it('re-exports the kit produced by createSpinner', () => {
+        expect(typeof LoadingSpinner).toBe('function') // class constructor
+        expect(typeof withSpinner).toBe('function')
+        expect(typeof startEarlySpinner).toBe('function')
+        expect(typeof stopEarlySpinner).toBe('function')
+        expect(typeof resetEarlySpinner).toBe('function')
     })
 
-    afterEach(() => {
-        vi.clearAllMocks()
-        resetEarlySpinner()
+    it('withSpinner returns the operation result', async () => {
+        const result = await withSpinner({ text: 'noop', noSpinner: true }, async () => 42)
+        expect(result).toBe(42)
     })
 
-    it('should handle successful operations', async () => {
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue' },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).toHaveBeenCalled()
-        expect(mockSpinnerInstance.stop).toHaveBeenCalled()
-        expect(mockSpinnerInstance.error).not.toHaveBeenCalled()
-    })
-
-    it('should handle failed operations', async () => {
+    it('withSpinner rethrows operation errors', async () => {
         await expect(
-            withSpinner({ text: 'Testing...', color: 'blue' }, async () => {
-                throw new Error('test error')
+            withSpinner({ text: 'noop', noSpinner: true }, async () => {
+                throw new Error('boom')
             }),
-        ).rejects.toThrow('test error')
-
-        expect(mockSpinnerInstance.start).toHaveBeenCalled()
-        expect(mockSpinnerInstance.error).toHaveBeenCalled()
-        expect(mockSpinnerInstance.stop).not.toHaveBeenCalled()
+        ).rejects.toThrow('boom')
     })
 
-    it('should not show spinner when noSpinner option is true', async () => {
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue', noSpinner: true },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-    })
-
-    it('should not show spinner when TD_SPINNER=false', async () => {
-        process.env.TD_SPINNER = 'false'
-
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue' },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-    })
-
-    it('should not show spinner in CI environment', async () => {
-        process.env.CI = 'true'
-
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue' },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-    })
-
-    it('should not show spinner when not in TTY', async () => {
-        Object.defineProperty(process.stdout, 'isTTY', {
-            value: false,
-            configurable: true,
-        })
-
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue' },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-    })
-
-    it.each([
-        ['--json', ['node', 'td', 'auth', 'status', '--json']],
-        ['--ndjson', ['node', 'td', 'auth', 'status', '--ndjson']],
-        ['--no-spinner', ['node', 'td', 'auth', 'status', '--no-spinner']],
-        ['--progress-jsonl', ['node', 'td', 'today', '--progress-jsonl']],
-        ['--progress-jsonl=path', ['node', 'td', 'today', '--progress-jsonl=/tmp/progress.jsonl']],
-    ])('should not show spinner with %s flag', async (_flagName, argv) => {
-        process.argv = argv
-        resetGlobalArgs()
-
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue' },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-    })
-})
-
-describe('LoadingSpinner', () => {
-    beforeEach(() => {
-        vi.clearAllMocks()
-        resetEarlySpinner()
-        // Reset environment variables
-        delete process.env.TD_SPINNER
-        delete process.env.CI
-        // Mock TTY as true by default
-        Object.defineProperty(process.stdout, 'isTTY', {
-            value: true,
-            configurable: true,
-        })
-        // Clear process.argv and global args cache
-        process.argv = ['node', 'td']
-        resetGlobalArgs()
-    })
-
-    afterEach(() => {
-        vi.clearAllMocks()
-        resetEarlySpinner()
-    })
-
-    it('should start and stop spinner', () => {
-        const spinner = new LoadingSpinner()
-        spinner.start({ text: 'Testing...', color: 'blue' })
-        expect(mockSpinnerInstance.start).toHaveBeenCalled()
-
-        spinner.stop()
-        expect(mockSpinnerInstance.stop).toHaveBeenCalled()
-    })
-
-    it('should show success message', () => {
-        const spinner = new LoadingSpinner()
-        spinner.start({ text: 'Testing...', color: 'blue' })
-        spinner.succeed('Operation completed')
-        expect(mockSpinnerInstance.success).toHaveBeenCalledWith('✓ Operation completed')
-    })
-
-    it('should show failure message', () => {
-        const spinner = new LoadingSpinner()
-        spinner.start({ text: 'Testing...', color: 'blue' })
-        spinner.fail('Operation failed')
-        expect(mockSpinnerInstance.error).toHaveBeenCalledWith('✗ Operation failed')
-    })
-
-    it('should handle multiple calls to stop gracefully', () => {
-        const spinner = new LoadingSpinner()
-        spinner.start({ text: 'Testing...', color: 'blue' })
-        spinner.stop()
-        spinner.stop() // Should not throw
-
-        expect(mockSpinnerInstance.stop).toHaveBeenCalledTimes(1)
-    })
-
-    it('should handle succeed/fail without starting', () => {
-        const spinner = new LoadingSpinner()
-        spinner.succeed('Test') // Should not throw
-        spinner.fail('Test') // Should not throw
-
-        expect(mockSpinnerInstance.success).not.toHaveBeenCalled()
-        expect(mockSpinnerInstance.error).not.toHaveBeenCalled()
-    })
-})
-
-describe('early spinner', () => {
-    const yoctoSpinner = vi.mocked(yoctoSpinnerFactory)
-
-    beforeEach(() => {
-        vi.clearAllMocks()
-        resetEarlySpinner()
-        mockSpinnerInstance.text = ''
-        // Reset environment variables
-        delete process.env.TD_SPINNER
-        delete process.env.CI
-        // Mock TTY as true by default
-        Object.defineProperty(process.stdout, 'isTTY', {
-            value: true,
-            configurable: true,
-        })
-        // Clear process.argv and global args cache
-        process.argv = ['node', 'td']
-        resetGlobalArgs()
-    })
-
-    afterEach(() => {
-        vi.clearAllMocks()
-        resetEarlySpinner()
-    })
-
-    it('should start and stop early spinner', () => {
-        startEarlySpinner()
-
-        expect(yoctoSpinner).toHaveBeenCalledWith({ text: 'Loading...' })
-        expect(mockSpinnerInstance.start).toHaveBeenCalled()
-
-        stopEarlySpinner()
-        expect(mockSpinnerInstance.stop).toHaveBeenCalled()
-    })
-
-    it('should not start early spinner when not in TTY', () => {
-        Object.defineProperty(process.stdout, 'isTTY', {
-            value: false,
-            configurable: true,
-        })
-
-        startEarlySpinner()
-        expect(yoctoSpinner).not.toHaveBeenCalled()
-    })
-
-    it.each([
-        ['--json', ['node', 'td', 'today', '--json']],
-        ['--ndjson', ['node', 'td', 'today', '--ndjson']],
-        ['--no-spinner', ['node', 'td', 'today', '--no-spinner']],
-    ])('should not start early spinner with %s flag', (_flagName, argv) => {
-        process.argv = argv
-        resetGlobalArgs()
-
-        startEarlySpinner()
-        expect(yoctoSpinner).not.toHaveBeenCalled()
-    })
-
-    it('should not start early spinner in CI environment', () => {
-        process.env.CI = 'true'
-
-        startEarlySpinner()
-        expect(yoctoSpinner).not.toHaveBeenCalled()
-    })
-
-    it('should not start early spinner when TD_SPINNER=false', () => {
-        process.env.TD_SPINNER = 'false'
-
-        startEarlySpinner()
-        expect(yoctoSpinner).not.toHaveBeenCalled()
-    })
-
-    it('should be adopted by LoadingSpinner.start() — reuses instance and updates text', () => {
-        startEarlySpinner()
-        vi.clearAllMocks()
-
-        const spinner = new LoadingSpinner()
-        spinner.start({ text: 'Loading tasks...', color: 'blue' })
-
-        // Should NOT have created a new yocto-spinner
-        expect(yoctoSpinner).not.toHaveBeenCalled()
-        // Should NOT have called .start() again (already running)
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-        // Should have updated the text
-        expect(mockSpinnerInstance.text).toBe('Loading tasks...')
-    })
-
-    it('should release back on stop — available for re-adoption by next API call', () => {
-        startEarlySpinner()
-        vi.clearAllMocks()
-
-        // First LoadingSpinner adopts the early spinner
-        const spinner1 = new LoadingSpinner()
-        spinner1.start({ text: 'Loading tasks...', color: 'blue' })
-        expect(yoctoSpinner).not.toHaveBeenCalled()
-
-        // stop() releases it back instead of actually stopping
-        spinner1.stop()
-        expect(mockSpinnerInstance.stop).not.toHaveBeenCalled()
-
-        // Second LoadingSpinner re-adopts the same instance
-        const spinner2 = new LoadingSpinner()
-        spinner2.start({ text: 'Checking authentication...', color: 'blue' })
-        expect(yoctoSpinner).not.toHaveBeenCalled()
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-        expect(mockSpinnerInstance.text).toBe('Checking authentication...')
-
-        // Final cleanup via stopEarlySpinner actually stops it
-        spinner2.stop()
-        stopEarlySpinner()
-        expect(mockSpinnerInstance.stop).toHaveBeenCalledTimes(1)
-    })
-
-    it('should actually stop on fail even if adopted', () => {
-        startEarlySpinner()
-        vi.clearAllMocks()
-
-        const spinner = new LoadingSpinner()
-        spinner.start({ text: 'Loading tasks...', color: 'blue' })
-        spinner.fail('Request failed')
-
-        expect(mockSpinnerInstance.error).toHaveBeenCalled()
-        // Should not be released back — error terminates the spinner
-        stopEarlySpinner()
-        expect(mockSpinnerInstance.stop).not.toHaveBeenCalled()
-    })
-
-    it('should auto-stop when stdout is written to', () => {
-        startEarlySpinner()
-        expect(mockSpinnerInstance.start).toHaveBeenCalled()
-
-        // Simulate command output — spinner should auto-clear
-        process.stdout.write('output\n')
-        expect(mockSpinnerInstance.stop).toHaveBeenCalled()
-    })
-
-    it('should be cleaned up by stopEarlySpinner if never adopted', () => {
-        startEarlySpinner()
-        expect(mockSpinnerInstance.start).toHaveBeenCalled()
-
-        stopEarlySpinner()
-        expect(mockSpinnerInstance.stop).toHaveBeenCalled()
-
-        // Subsequent stop should be a no-op
-        vi.clearAllMocks()
-        stopEarlySpinner()
-        expect(mockSpinnerInstance.stop).not.toHaveBeenCalled()
+    it('LoadingSpinner.start returns the spinner instance for chaining', () => {
+        const s = new LoadingSpinner()
+        expect(s.start({ text: 'noop', noSpinner: true })).toBe(s)
     })
 })

--- a/src/lib/spinner.ts
+++ b/src/lib/spinner.ts
@@ -1,143 +1,16 @@
-import { isStdoutTTY } from '@doist/cli-core'
-import chalk from 'chalk'
-import yoctoSpinner from 'yocto-spinner'
+import { createSpinner } from '@doist/cli-core'
 import { shouldDisableSpinner } from './global-args.js'
 
-interface SpinnerOptions {
-    text: string
-    color?: 'green' | 'yellow' | 'blue' | 'red' | 'gray' | 'cyan' | 'magenta'
-    noSpinner?: boolean // Allow overriding spinner display
-}
-
-// Early spinner singleton — shown instantly before command modules load.
-// Stays running through all API calls (via release-back on stop) and is
-// auto-cleared the moment stdout is written to (command output starting).
-let earlySpinnerInstance: ReturnType<typeof yoctoSpinner> | null = null
-let originalStdoutWrite: typeof process.stdout.write | null = null
-
-export function startEarlySpinner(): void {
-    if (!isStdoutTTY() || shouldDisableSpinner()) {
-        return
-    }
-
-    earlySpinnerInstance = yoctoSpinner({ text: chalk.blue('Loading...') })
-    earlySpinnerInstance.start()
-
-    // Intercept stdout so the spinner is cleared before any command output
-    const savedWrite = process.stdout.write.bind(process.stdout) as typeof process.stdout.write
-    originalStdoutWrite = savedWrite
-    process.stdout.write = function (
-        this: typeof process.stdout,
-        ...args: Parameters<typeof process.stdout.write>
-    ) {
-        stopEarlySpinner()
-        return savedWrite.apply(this, args)
-    } as typeof process.stdout.write
-}
-
-export function stopEarlySpinner(): void {
-    if (originalStdoutWrite) {
-        process.stdout.write = originalStdoutWrite
-        originalStdoutWrite = null
-    }
-    if (earlySpinnerInstance) {
-        earlySpinnerInstance.stop()
-        earlySpinnerInstance = null
-    }
-}
-
-export function resetEarlySpinner(): void {
-    earlySpinnerInstance = null
-    if (originalStdoutWrite) {
-        process.stdout.write = originalStdoutWrite
-        originalStdoutWrite = null
-    }
-}
-
-class LoadingSpinner {
-    private spinnerInstance: ReturnType<typeof yoctoSpinner> | null = null
-    private adopted = false
-
-    start(options: SpinnerOptions) {
-        // Don't show spinner in non-interactive environments, when disabled via options, or when JSON output is expected
-        if (!isStdoutTTY() || options.noSpinner || shouldDisableSpinner()) {
-            return this
-        }
-
-        // If an early spinner is running, adopt it instead of creating a new one
-        if (earlySpinnerInstance) {
-            this.spinnerInstance = earlySpinnerInstance
-            this.adopted = true
-            earlySpinnerInstance = null
-            const colorFn = chalk[options.color || 'blue']
-            this.spinnerInstance.text = colorFn(options.text)
-            return this
-        }
-
-        const colorFn = chalk[options.color || 'blue']
-        this.spinnerInstance = yoctoSpinner({
-            text: colorFn(options.text),
-            // yocto-spinner uses dots spinner by default which matches NPM's braille pattern
-        })
-        this.spinnerInstance.start()
-        return this
-    }
-
-    succeed(text?: string) {
-        if (this.spinnerInstance) {
-            if (this.adopted) {
-                // Release back so subsequent API calls can re-adopt
-                earlySpinnerInstance = this.spinnerInstance
-                this.spinnerInstance = null
-                this.adopted = false
-                return
-            }
-            this.spinnerInstance.success(text ? chalk.green(`✓ ${text}`) : undefined)
-            this.spinnerInstance = null
-        }
-    }
-
-    fail(text?: string) {
-        if (this.spinnerInstance) {
-            this.spinnerInstance.error(text ? chalk.red(`✗ ${text}`) : undefined)
-            this.spinnerInstance = null
-            this.adopted = false
-        }
-    }
-
-    stop() {
-        if (this.spinnerInstance) {
-            if (this.adopted) {
-                // Release back so subsequent API calls can re-adopt
-                earlySpinnerInstance = this.spinnerInstance
-                this.spinnerInstance = null
-                this.adopted = false
-                return
-            }
-            this.spinnerInstance.stop()
-            this.spinnerInstance = null
-        }
-    }
-}
+export type { SpinnerOptions } from '@doist/cli-core'
 
 /**
- * High-level wrapper function for running async operations with a loading spinner.
- * Automatically handles success/failure states and cleanup.
+ * Todoist spinner kit. The CLI-specific bit is `shouldDisableSpinner` —
+ * everything else (early-spinner singleton, adoption, withSpinner, the
+ * LoadingSpinner class) lives in cli-core.
  */
-export async function withSpinner<T>(
-    options: SpinnerOptions,
-    asyncOperation: () => Promise<T>,
-): Promise<T> {
-    const loadingSpinner = new LoadingSpinner().start(options)
+const spinner = createSpinner({ isDisabled: shouldDisableSpinner })
 
-    try {
-        const result = await asyncOperation()
-        loadingSpinner.stop() // Don't show success message by default - let the command handle its own output
-        return result
-    } catch (error) {
-        loadingSpinner.fail()
-        throw error
-    }
-}
+export const { LoadingSpinner, withSpinner, startEarlySpinner, stopEarlySpinner } = spinner
 
-export { LoadingSpinner, type SpinnerOptions }
+/** @internal Test-only — exposed so the existing spinner test suite can fully reset state. */
+export const resetEarlySpinner = spinner.resetEarlySpinner


### PR DESCRIPTION
## Summary

Replaces the local spinner module with `createSpinner` from `@doist/cli-core` 0.3.0.

```ts
const spinner = createSpinner({ isDisabled: shouldDisableSpinner })

export const {
    LoadingSpinner,
    withSpinner,
    startEarlySpinner,
    stopEarlySpinner,
} = spinner
```

cli-core owns the whole module — early-spinner singleton with stdout interception, adopt/release semantics for chained API calls, the `LoadingSpinner` class, the `withSpinner` wrapper, the colour palette. The only CLI-specific bit is `shouldDisableSpinner` (the `TD_SPINNER` env var + global-args fan-out for `--json` / `--ndjson` / `--no-spinner` / etc.), which we wire in as `isDisabled`.

## Behaviour change worth flagging

`yocto-spinner.success()` and `.error()` already prepend their own `✔` / `✖` glyphs. The old code added a manual `✓ ` / `✗ ` on top, which produced doubled symbols in real terminals (e.g. `✔ ✓ Done`). cli-core 0.3 drops the manual prefixes and tests confirm the bare text is forwarded — so the success/fail line now renders as a single `✔ Done` instead of `✔ ✓ Done`. Surfaced during the cli-core review.

## Other changes

- Bumps `@doist/cli-core` 0.2.0 → 0.3.0.
- Drops `yocto-spinner` from direct dependencies; it's now reached transitively through cli-core.
- Trims `spinner.test.ts` to 4 smoke tests covering the wrapper's public API plus `withSpinner`'s happy + error paths. Deep behaviour (adoption, glyph rendering, stdout-interceptor lifecycle, `--json`-style gating) is exhaustively covered in cli-core's own `spinner.test.ts`.

## Test plan

- [x] `npm run type-check`
- [x] `npm run check`
- [x] `npm test` — 1570 / 1570 pass against the published `@doist/cli-core@0.3.0`
- [ ] Manually run a long command (`td today`, `td auth login`) to confirm spinner UX still feels right and the glyph isn't doubled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
