### PR TITLE
feat: GitHub Copilot Skill Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Install skills for your coding agent:
 ```bash
 td skill install claude-code
 td skill install codex
+td skill install copilot
 td skill install cursor
 td skill install gemini
 td skill install pi

--- a/src/commands/skill/skill.test.ts
+++ b/src/commands/skill/skill.test.ts
@@ -42,6 +42,7 @@ describe('skill command', () => {
             expect(consoleSpy).toHaveBeenCalledWith('Available agents:')
             expect(consoleSpy).toHaveBeenCalledWith('  claude-code')
             expect(consoleSpy).toHaveBeenCalledWith('  codex')
+            expect(consoleSpy).toHaveBeenCalledWith('  copilot')
             expect(consoleSpy).toHaveBeenCalledWith('  cursor')
             expect(consoleSpy).toHaveBeenCalledWith('  gemini')
             expect(consoleSpy).toHaveBeenCalledWith('  pi')
@@ -141,6 +142,12 @@ describe('skills registry', () => {
         expect(installer?.name).toBe('codex')
     })
 
+    it('returns copilot installer', () => {
+        const installer = getInstaller('copilot')
+        expect(installer).toBeDefined()
+        expect(installer?.name).toBe('copilot')
+    })
+
     it('returns cursor installer', () => {
         const installer = getInstaller('cursor')
         expect(installer).toBeDefined()
@@ -174,6 +181,7 @@ describe('skills registry', () => {
         const agents = listAgents()
         expect(agents).toContain('claude-code')
         expect(agents).toContain('codex')
+        expect(agents).toContain('copilot')
         expect(agents).toContain('cursor')
         expect(agents).toContain('gemini')
         expect(agents).toContain('pi')
@@ -185,6 +193,7 @@ describe('installer paths', () => {
     const cases = [
         { agent: 'claude-code', dir: '.claude', desc: 'Claude Code skill for Todoist CLI' },
         { agent: 'codex', dir: '.codex', desc: 'Codex skill for Todoist CLI' },
+        { agent: 'copilot', dir: '.copilot', desc: 'GitHub Copilot skill for Todoist CLI' },
         { agent: 'cursor', dir: '.cursor', desc: 'Cursor skill for Todoist CLI' },
         { agent: 'gemini', dir: '.gemini', desc: 'Gemini CLI skill for Todoist CLI' },
         { agent: 'pi', dir: '.pi', desc: 'Pi skill for Todoist CLI' },

--- a/src/lib/skills/index.ts
+++ b/src/lib/skills/index.ts
@@ -12,6 +12,11 @@ export const skillInstallers: Record<string, SkillInstaller> = {
         description: 'Codex skill for Todoist CLI',
         dirName: '.codex',
     }),
+    copilot: createInstaller({
+        name: 'copilot',
+        description: 'GitHub Copilot skill for Todoist CLI',
+        dirName: '.copilot',
+    }),
     cursor: createInstaller({
         name: 'cursor',
         description: 'Cursor skill for Todoist CLI',


### PR DESCRIPTION
This pull request adds support for the GitHub Copilot skill to the project. The main changes ensure that Copilot is now available as an installable skill, is included in the list of available agents, and is fully covered by tests.

**Copilot skill integration:**

* Added a new Copilot skill entry to the `skillInstallers` registry in `src/lib/skills/index.ts`, making it available for installation.
* Updated the CLI installation instructions in `README.md` to include `td skill install copilot`.
