### PR TITLE
refactor: drop X-TD header prefix

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -164,8 +164,8 @@ New subcommand? Copy a sibling in the target group, wire it in that group's
 - **`permissions.ts`** — collaborator permission parsing
 - **`help-center.ts`** — Help Center article search/fetch
 - **`progress.ts`** — `--progress-jsonl` JSONL event writer
-- **`usage-tracking.ts`** — request markers (`User-Agent`, `doist-*`,
-  `request-id`, `session-id`, `cli-command`), session/request ids, command path
+- **`usage-tracking.ts`** — request/session metadata headers, CLI command
+  attribution, tracked fetch wrappers
 - **`browser.ts` / `stdin.ts` / `update.ts`** — small single-purpose helpers
 - **`skills/content.ts`** — `SKILL_NAME`, `SKILL_DESCRIPTION`, `SKILL_CONTENT`
 

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -165,7 +165,7 @@ New subcommand? Copy a sibling in the target group, wire it in that group's
 - **`help-center.ts`** — Help Center article search/fetch
 - **`progress.ts`** — `--progress-jsonl` JSONL event writer
 - **`usage-tracking.ts`** — request markers (`User-Agent`, `doist-*`,
-  `X-TD-*`, including `X-TD-CLI-Command`), session/request ids, command path
+  `request-id`, `session-id`, `cli-command`), session/request ids, command path
 - **`browser.ts` / `stdin.ts` / `update.ts`** — small single-purpose helpers
 - **`skills/content.ts`** — `SKILL_NAME`, `SKILL_DESCRIPTION`, `SKILL_CONTENT`
 

--- a/src/lib/migrate-auth.test.ts
+++ b/src/lib/migrate-auth.test.ts
@@ -145,9 +145,9 @@ describe('migrateLegacyAuth', () => {
                     authorization: 'Bearer legacy-1234567',
                     'doist-platform': 'cli',
                     'doist-version': expect.stringMatching(/^\d+\.\d+\.\d+$/),
-                    'x-td-request-id': expect.any(String),
-                    'x-td-session-id': expect.any(String),
-                    'x-td-cli-command': 'postinstall:auth-migrate',
+                    'request-id': expect.any(String),
+                    'session-id': expect.any(String),
+                    'cli-command': 'postinstall:auth-migrate',
                 }),
             }),
         )

--- a/src/lib/usage-tracking.test.ts
+++ b/src/lib/usage-tracking.test.ts
@@ -35,9 +35,9 @@ describe('usage tracking', () => {
         expect(headers['doist-platform']).toBe('cli')
         expect(headers['doist-version']).toMatch(/^\d+\.\d+\.\d+$/)
         expect(headers['doist-os']).toMatch(/^(macos|linux|windows|unknown)$/)
-        expect(headers['X-TD-Request-Id']).toBeTruthy()
-        expect(headers['X-TD-Session-Id']).toBeTruthy()
-        expect(headers['X-TD-CLI-Command']).toBe('task:view')
+        expect(headers['request-id']).toBeTruthy()
+        expect(headers['session-id']).toBeTruthy()
+        expect(headers['cli-command']).toBe('task:view')
     })
 
     it('injects tracking headers into sdk custom fetch requests', async () => {
@@ -68,9 +68,9 @@ describe('usage tracking', () => {
         expect(firstHeaders.authorization).toBe('Bearer token')
         expect(firstHeaders['doist-platform']).toBe('cli')
         expect(firstHeaders['doist-version']).toMatch(/^\d+\.\d+\.\d+$/)
-        expect(firstHeaders['x-td-cli-command']).toBe('today')
-        expect(firstHeaders['x-td-session-id']).toBe(secondHeaders['x-td-session-id'])
-        expect(firstHeaders['x-td-request-id']).not.toBe(secondHeaders['x-td-request-id'])
+        expect(firstHeaders['cli-command']).toBe('today')
+        expect(firstHeaders['session-id']).toBe(secondHeaders['session-id'])
+        expect(firstHeaders['request-id']).not.toBe(secondHeaders['request-id'])
         expect(response.ok).toBe(true)
     })
 
@@ -240,6 +240,6 @@ describe('usage tracking', () => {
         if (!captured) throw new Error('direct fetch did not capture request options')
         const headers = captured.headers as Record<string, string>
         expect(headers.authorization).toBe('Bearer token')
-        expect(headers['x-td-cli-command']).toBe('postinstall:auth-migrate')
+        expect(headers['cli-command']).toBe('postinstall:auth-migrate')
     })
 })

--- a/src/lib/usage-tracking.ts
+++ b/src/lib/usage-tracking.ts
@@ -57,9 +57,9 @@ export function buildUsageTrackingHeaders(commandPath?: string): Record<string, 
         'doist-platform': 'cli',
         'doist-version': CLI_VERSION,
         'doist-os': getDoistOs(),
-        'X-TD-Request-Id': randomUUID(),
-        'X-TD-Session-Id': SESSION_ID,
-        'X-TD-CLI-Command': normalizedCommandPath ?? 'unknown',
+        'request-id': randomUUID(),
+        'session-id': SESSION_ID,
+        'cli-command': normalizedCommandPath ?? 'unknown',
     }
 
     return headers


### PR DESCRIPTION
## Summary

- Rename CLI request metadata headers to `request-id`, `session-id`, and `cli-command`.
- Update usage tracking tests and codebase docs for the new header contract.

Follow-up to #302.

These headers are newly added and not actively consumed yet, so this is a relatively safe time to rename them.

## Reasoning

- On dropping `X-`, [RFC 6648](https://www.rfc-editor.org/rfc/rfc6648) published in 2012, actively discourages `X-` prefixes, reverting previous guidance, for reasons explained in the RFC.
- On dropping `TD-`, it's for a similar reason, this is generic request metadata rather than Todoist-specific fields. That said, this one is more nuanced, and I'm happy to revert this part. More subjective.
- On lowercasing, because header names are already case insensitive, HTTP/2 effectively requires lowercase header names on the wire, and many fetch/headers implementations normalize to lowercase anyway. 