### PR TITLE
fix(task): add --no-labels flag to clear labels on update

### DIFF
--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -143,7 +143,7 @@ Choosing between `task add` and `task quickadd`:
 Useful task flags:
 - `--stdin` on `task add` reads the task description from stdin; on `task quickadd` (and the top-level `td add`) it reads the full natural-language text from stdin.
 - `--parent`, `--section`, `--project`, `--workspace`, `--assignee`, `--labels`, `--due`, `--deadline`, `--duration`, and `--priority` cover most task workflows.
-- `td task complete --forever` stops recurrence; `td task update --no-due` clears the due date and `--no-deadline` clears deadlines; `td task move --no-parent` and `--no-section` detach from hierarchy.
+- `td task complete --forever` stops recurrence; `td task update --no-due` clears the due date, `--no-deadline` clears deadlines, and `--no-labels` removes all labels; `td task move --no-parent` and `--no-section` detach from hierarchy.
 
 ### Projects And Workspaces
 ```bash

--- a/src/commands/task/index.ts
+++ b/src/commands/task/index.ts
@@ -190,6 +190,7 @@ Examples:
             ),
         )
         .option('--labels <a,b>', 'New labels (replaces existing)')
+        .option('--no-labels', 'Remove all labels')
         .option('--description <text>', 'New description')
         .option('--stdin', 'Read task description from stdin')
         .option('--assignee <ref>', 'Assign to user (name, email, id:xxx, or "me")')

--- a/src/commands/task/task.test.ts
+++ b/src/commands/task/task.test.ts
@@ -1671,6 +1671,35 @@ describe('task update --no-due', () => {
     })
 })
 
+describe('task update --no-labels', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+    })
+
+    it('removes all labels with --no-labels', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getTask.mockResolvedValue({
+            id: 'task-1',
+            content: 'Task',
+            labels: ['deep', 'quick'],
+        })
+        mockApi.updateTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
+
+        await program.parseAsync(['node', 'td', 'task', 'update', 'id:task-1', '--no-labels'])
+
+        expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', {
+            labels: [],
+        })
+        consoleSpy.mockRestore()
+    })
+})
+
 describe('task add/update --uncompletable', () => {
     let mockApi: MockApi
 

--- a/src/commands/task/task.test.ts
+++ b/src/commands/task/task.test.ts
@@ -1698,6 +1698,31 @@ describe('task update --no-labels', () => {
         })
         consoleSpy.mockRestore()
     })
+
+    it('previews --no-labels with --dry-run without calling API', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        mockApi.getTask.mockResolvedValue({
+            id: 'task-1',
+            content: 'Task',
+            labels: ['deep', 'quick'],
+        })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'task',
+            'update',
+            'id:task-1',
+            '--no-labels',
+            '--dry-run',
+        ])
+
+        expect(mockApi.updateTask).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('(remove all)'))
+        consoleSpy.mockRestore()
+    })
 })
 
 describe('task add/update --uncompletable', () => {

--- a/src/commands/task/update.ts
+++ b/src/commands/task/update.ts
@@ -13,7 +13,7 @@ export interface UpdateOptions {
     due?: string | false
     deadline?: string | false
     priority?: string
-    labels?: string
+    labels?: string | false
     description?: string
     stdin?: boolean
     assignee?: string
@@ -44,7 +44,11 @@ export async function updateTask(ref: string, options: UpdateOptions): Promise<v
         args.deadlineDate = options.deadline
     }
     if (options.priority) args.priority = parsePriority(options.priority)
-    if (options.labels) args.labels = options.labels.split(',').map((l) => l.trim())
+    if (options.labels === false) {
+        args.labels = []
+    } else if (options.labels) {
+        args.labels = options.labels.split(',').map((l) => l.trim())
+    }
 
     if (options.stdin && options.description !== undefined) {
         throw new CliError('CONFLICTING_OPTIONS', 'Cannot use both --description and --stdin')
@@ -89,7 +93,7 @@ export async function updateTask(ref: string, options: UpdateOptions): Promise<v
             Due: args.dueString ?? undefined,
             Deadline: args.deadlineDate ?? undefined,
             Priority: options.priority,
-            Labels: options.labels,
+            Labels: options.labels === false ? '(remove all)' : options.labels,
             Assignee: options.assignee,
             Unassign: options.unassign ? 'yes' : undefined,
             Duration: options.duration,

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -139,7 +139,7 @@ Choosing between \`task add\` and \`task quickadd\`:
 Useful task flags:
 - \`--stdin\` on \`task add\` reads the task description from stdin; on \`task quickadd\` (and the top-level \`td add\`) it reads the full natural-language text from stdin.
 - \`--parent\`, \`--section\`, \`--project\`, \`--workspace\`, \`--assignee\`, \`--labels\`, \`--due\`, \`--deadline\`, \`--duration\`, and \`--priority\` cover most task workflows.
-- \`td task complete --forever\` stops recurrence; \`td task update --no-due\` clears the due date and \`--no-deadline\` clears deadlines; \`td task move --no-parent\` and \`--no-section\` detach from hierarchy.
+- \`td task complete --forever\` stops recurrence; \`td task update --no-due\` clears the due date, \`--no-deadline\` clears deadlines, and \`--no-labels\` removes all labels; \`td task move --no-parent\` and \`--no-section\` detach from hierarchy.
 
 ### Projects And Workspaces
 \`\`\`bash


### PR DESCRIPTION
## Summary

- Fixes #326 — `td task update <ref> --labels ""` returned HTTP 400 because the truthy guard at `src/commands/task/update.ts:47` swallowed the empty string and the SDK posted an empty body `{}`.
- Adds `--no-labels` flag mirroring the existing `--no-due` / `--no-deadline` pattern; clearing now sends `{"labels": []}`, which the server already accepts.
- Updates the dry-run preview to show `(remove all)` when `--no-labels` is used.

## Test plan

- [x] `npm test` — 1548 tests pass, including new `task update --no-labels` test
- [x] `npm run check` — lint + format clean
- [x] `npm run type-check` — clean
- [ ] Manual smoke against real API:
  ```
  td task add "zzz-labels-test" --labels "deep,quick"
  td task update <id> --no-labels
  td task view <id> --json | jq '.labels'   # expect []
  ```
- [ ] `td task update <id> --no-labels --dry-run` shows `Labels: (remove all)`

## Audit

Scanned every `src/commands/*/update.ts` for the same truthy-guard-on-optional-string shape. Only `task --labels` was an actually-fixable CLI-side bug. `description` and `duration` use a similar guard but the SDK type does not currently accept `null` / clearing, so they are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)