### PR TITLE
ci: auto-open PR to sync next with main

### DIFF
--- a/.github/workflows/sync-next-with-main.yml
+++ b/.github/workflows/sync-next-with-main.yml
@@ -1,0 +1,143 @@
+name: Sync next with main
+
+on:
+    push:
+        branches:
+            - main
+    schedule:
+        # Daily at 09:00 UTC. Catches release commits (`[skip ci]`) that don't
+        # trigger workflows via push, and any drift the push trigger missed.
+        - cron: '0 9 * * *'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: false
+
+jobs:
+    sync:
+        name: Sync
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+
+        steps:
+            - name: Generate bot token
+              id: generate_token
+              uses: actions/create-github-app-token@v3
+              with:
+                  app-id: ${{ secrets.DOIST_RELEASE_BOT_ID }}
+                  private-key: ${{ secrets.DOIST_RELEASE_BOT_PRIVATE_KEY }}
+                  permission-contents: write
+                  permission-pull-requests: write
+
+            - name: Checkout next
+              uses: actions/checkout@v4
+              with:
+                  ref: next
+                  token: ${{ steps.generate_token.outputs.token }}
+                  fetch-depth: 0
+
+            - name: Configure git
+              run: |
+                  git config user.name "${{ steps.generate_token.outputs.app-slug }}[bot]"
+                  git config user.email "${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
+            - name: Check if main is ahead of next
+              id: divergence
+              run: |
+                  git fetch origin main
+                  ahead=$(git rev-list --count next..origin/main)
+                  echo "ahead=$ahead" >> "$GITHUB_OUTPUT"
+                  if [ "$ahead" -eq 0 ]; then
+                      echo "next is up to date with main; nothing to do"
+                  else
+                      echo "main is $ahead commit(s) ahead of next"
+                  fi
+
+            - name: Create sync branch
+              if: steps.divergence.outputs.ahead != '0'
+              run: git checkout -B chore/sync-main-into-next
+
+            - name: Attempt merge
+              if: steps.divergence.outputs.ahead != '0'
+              id: merge
+              run: |
+                  if git merge --no-ff origin/main -m "chore: merge main into next"; then
+                      echo "status=clean" >> "$GITHUB_OUTPUT"
+                      {
+                          echo "conflicts<<EOF"
+                          echo "EOF"
+                      } >> "$GITHUB_OUTPUT"
+                  else
+                      conflicts=$(git diff --name-only --diff-filter=U | sed 's/^/- `/; s/$/`/')
+                      git add -A
+                      git commit -m "chore: merge main into next (conflicts to resolve)"
+                      echo "status=conflicts" >> "$GITHUB_OUTPUT"
+                      {
+                          echo "conflicts<<EOF"
+                          echo "$conflicts"
+                          echo "EOF"
+                      } >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Push sync branch
+              if: steps.divergence.outputs.ahead != '0'
+              run: git push --force origin chore/sync-main-into-next
+
+            - name: Open or update PR
+              if: steps.divergence.outputs.ahead != '0'
+              env:
+                  GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+                  MERGE_STATUS: ${{ steps.merge.outputs.status }}
+                  CONFLICTS: ${{ steps.merge.outputs.conflicts }}
+              run: |
+                  if [ "$MERGE_STATUS" = "clean" ]; then
+                      cat > /tmp/pr-body.md <<'EOF'
+                  Automated sync of `main` into `next`.
+
+                  The merge applied cleanly. Standard CI (Tests, Lint, Skill Sync) will validate against the merged tree.
+
+                  Once green and reviewed, merge this to publish a new `…-next.N` prerelease.
+                  EOF
+                  else
+                      cat > /tmp/pr-body.md <<EOF
+                  Automated sync of \`main\` into \`next\`.
+
+                  ⚠️ **Conflicts detected** — the branch was pushed with conflict markers and needs manual resolution.
+
+                  ### Conflicting files
+
+                  ${CONFLICTS}
+
+                  ### How to resolve
+
+                  \`\`\`bash
+                  git fetch origin
+                  git checkout chore/sync-main-into-next
+                  # resolve conflicts in the files above
+                  git add -A
+                  git commit --amend --no-edit
+                  git push --force-with-lease
+                  \`\`\`
+                  EOF
+                  fi
+
+                  existing=$(gh pr list \
+                      --base next \
+                      --head chore/sync-main-into-next \
+                      --state open \
+                      --json number \
+                      --jq '.[0].number')
+
+                  if [ -n "$existing" ]; then
+                      gh pr edit "$existing" --body-file /tmp/pr-body.md
+                  else
+                      gh pr create \
+                          --base next \
+                          --head chore/sync-main-into-next \
+                          --title "chore: merge main into next" \
+                          --body-file /tmp/pr-body.md
+                  fi

--- a/.github/workflows/sync-next-with-main.yml
+++ b/.github/workflows/sync-next-with-main.yml
@@ -15,7 +15,11 @@ permissions:
 
 concurrency:
     group: ${{ github.workflow }}
-    cancel-in-progress: false
+    cancel-in-progress: true
+
+env:
+    SYNC_BRANCH: chore/sync-main-into-next
+    SYNC_PR_TITLE: 'chore: merge main into next'
 
 jobs:
     sync:
@@ -33,6 +37,18 @@ jobs:
                   permission-contents: write
                   permission-pull-requests: write
 
+            - name: Get bot user ID
+              id: bot_user
+              run: |
+                  user_id=$(gh api "/users/${{ steps.generate_token.outputs.app-slug }}[bot]" --jq .id)
+                  if [ -z "$user_id" ]; then
+                      echo "Failed to get bot user ID" >&2
+                      exit 1
+                  fi
+                  echo "id=$user_id" >> "$GITHUB_OUTPUT"
+              env:
+                  GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
             - name: Checkout next
               uses: actions/checkout@v4
               with:
@@ -43,12 +59,11 @@ jobs:
             - name: Configure git
               run: |
                   git config user.name "${{ steps.generate_token.outputs.app-slug }}[bot]"
-                  git config user.email "${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com"
+                  git config user.email "${{ steps.bot_user.outputs.id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
             - name: Check if main is ahead of next
               id: divergence
               run: |
-                  git fetch origin main
                   ahead=$(git rev-list --count next..origin/main)
                   echo "ahead=$ahead" >> "$GITHUB_OUTPUT"
                   if [ "$ahead" -eq 0 ]; then
@@ -57,15 +72,50 @@ jobs:
                       echo "main is $ahead commit(s) ahead of next"
                   fi
 
-            - name: Create sync branch
+            - name: Check existing sync branch
+              id: existing_sync
               if: steps.divergence.outputs.ahead != '0'
-              run: git checkout -B chore/sync-main-into-next
+              run: |
+                  next_sha=$(git rev-parse origin/next)
+                  main_sha=$(git rev-parse origin/main)
+                  expected_email="${{ steps.bot_user.outputs.id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
+                  if ! git ls-remote --exit-code --heads origin "$SYNC_BRANCH" >/dev/null; then
+                      echo "No existing $SYNC_BRANCH on origin; will create."
+                      echo "should_sync=true" >> "$GITHUB_OUTPUT"
+                      exit 0
+                  fi
+
+                  git fetch --no-tags origin "$SYNC_BRANCH:refs/remotes/origin/$SYNC_BRANCH"
+                  head_sha=$(git rev-parse "refs/remotes/origin/$SYNC_BRANCH")
+                  p1=$(git rev-parse "$head_sha^1" 2>/dev/null || echo "")
+                  p2=$(git rev-parse "$head_sha^2" 2>/dev/null || echo "")
+                  head_email=$(git log -1 --format='%ae' "$head_sha")
+
+                  if [ "$p1" = "$next_sha" ] && [ "$p2" = "$main_sha" ]; then
+                      echo "$SYNC_BRANCH already merges current next and main; nothing to do."
+                      echo "should_sync=false" >> "$GITHUB_OUTPUT"
+                      exit 0
+                  fi
+
+                  if [ "$head_email" != "$expected_email" ]; then
+                      echo "$SYNC_BRANCH HEAD authored by $head_email (not the bot); refusing to overwrite."
+                      echo "should_sync=false" >> "$GITHUB_OUTPUT"
+                      exit 0
+                  fi
+
+                  echo "$SYNC_BRANCH is bot-owned but stale; will refresh."
+                  echo "should_sync=true" >> "$GITHUB_OUTPUT"
+
+            - name: Create sync branch
+              if: steps.existing_sync.outputs.should_sync == 'true'
+              run: git checkout -B "$SYNC_BRANCH"
 
             - name: Attempt merge
-              if: steps.divergence.outputs.ahead != '0'
+              if: steps.existing_sync.outputs.should_sync == 'true'
               id: merge
               run: |
-                  if git merge --no-ff origin/main -m "chore: merge main into next"; then
+                  if git merge --no-ff origin/main -m "$SYNC_PR_TITLE"; then
                       echo "status=clean" >> "$GITHUB_OUTPUT"
                       {
                           echo "conflicts<<EOF"
@@ -74,7 +124,7 @@ jobs:
                   else
                       conflicts=$(git diff --name-only --diff-filter=U | sed 's/^/- `/; s/$/`/')
                       git add -A
-                      git commit -m "chore: merge main into next (conflicts to resolve)"
+                      git commit -m "$SYNC_PR_TITLE (conflicts to resolve)"
                       echo "status=conflicts" >> "$GITHUB_OUTPUT"
                       {
                           echo "conflicts<<EOF"
@@ -84,11 +134,11 @@ jobs:
                   fi
 
             - name: Push sync branch
-              if: steps.divergence.outputs.ahead != '0'
-              run: git push --force origin chore/sync-main-into-next
+              if: steps.existing_sync.outputs.should_sync == 'true'
+              run: git push --force origin "$SYNC_BRANCH"
 
             - name: Open or update PR
-              if: steps.divergence.outputs.ahead != '0'
+              if: steps.existing_sync.outputs.should_sync == 'true'
               env:
                   GH_TOKEN: ${{ steps.generate_token.outputs.token }}
                   MERGE_STATUS: ${{ steps.merge.outputs.status }}
@@ -116,7 +166,7 @@ jobs:
 
                   \`\`\`bash
                   git fetch origin
-                  git checkout chore/sync-main-into-next
+                  git checkout ${SYNC_BRANCH}
                   # resolve conflicts in the files above
                   git add -A
                   git commit --amend --no-edit
@@ -127,17 +177,17 @@ jobs:
 
                   existing=$(gh pr list \
                       --base next \
-                      --head chore/sync-main-into-next \
+                      --head "$SYNC_BRANCH" \
                       --state open \
                       --json number \
-                      --jq '.[0].number')
+                      --jq '.[0].number // empty')
 
                   if [ -n "$existing" ]; then
                       gh pr edit "$existing" --body-file /tmp/pr-body.md
                   else
                       gh pr create \
                           --base next \
-                          --head chore/sync-main-into-next \
-                          --title "chore: merge main into next" \
+                          --head "$SYNC_BRANCH" \
+                          --title "$SYNC_PR_TITLE" \
                           --body-file /tmp/pr-body.md
                   fi

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -22,7 +22,8 @@ eslint/prettier) · semantic-release on merge to `main`.
 ├─ skills/todoist-cli/    # Generated SKILL.md (from src/lib/skills/content.ts)
 ├─ .github/workflows/     # test.yml, lint.yml, release.yml, check-skill-sync.yml,
 │                         # check-semantic-pull-request.yml, update-todoist-sdk.yml,
-│                         # issue-automation.yml, request-reviews.yml
+│                         # issue-automation.yml, request-reviews.yml,
+│                         # sync-next-with-main.yml
 ├─ AGENTS.md              # Prescriptive rules (build cmds, skill-sync, JSON flag)
 ├─ CODEBASE.md            # This file — descriptive map
 ├─ CLAUDE.md              # One-liner forward to AGENTS.md
@@ -246,6 +247,14 @@ opt-in: `--read-only` for a read-only token,
 - **Release:** semantic-release on merge to `main` (`.github/workflows/release.yml`).
   Commits must follow Conventional Commits — enforced by
   `check-semantic-pull-request.yml`.
+- **Prerelease sync:** `sync-next-with-main.yml` opens (or updates) a
+  `chore: merge main into next` PR whenever `main` is ahead of `next`. Runs
+  on push to `main`, daily at 09:00 UTC, and `workflow_dispatch`. Clean
+  merges go through the standard PR CI; conflicts are committed with
+  markers and surfaced in the PR body for manual resolution. Idempotent —
+  skips reruns when the existing sync branch already merges the current
+  `main`/`next` tips, and refuses to overwrite branches whose HEAD was not
+  authored by the bot.
 
 ## Skill content flow
 


### PR DESCRIPTION
## Summary

PR #331 was a manual `chore: merge main into next`. This automates that work.

A new `Sync next with main` workflow fires on push to `main`, daily at 09:00 UTC, and `workflow_dispatch`. When `main` is ahead of `next`, it force-pushes a stable `chore/sync-main-into-next` branch and opens (or updates) the PR — so reruns don't pile up duplicates.

### Clean merges
Pushes the merged tree and lets the existing `Tests`, `Lint`, and `check-skill-sync` workflows validate against it. Once green and reviewed, merging the PR triggers the next prerelease publish.

### Conflicts
Commits the conflict markers so the branch is checkout-able, lists the conflicting files in the PR body, and includes a copy-paste `git fetch / checkout / resolve / commit --amend / push --force-with-lease` snippet. The conflict-resolution judgment (e.g. keeping `@doist/todoist-sdk@…-next.N` while taking other deps from main, or the regex relaxation in [src/lib/migrate-auth.test.ts](src/lib/migrate-auth.test.ts) that #331 needed) still happens by hand — the workflow just opens the PR for you.

### Trigger redundancy
- `push: main` covers human merges.
- `schedule: '0 9 * * *'` covers release commits where `[skip ci]` skips workflows on push.
- `workflow_dispatch` covers everything else.

The same `doist-release-bot` App used by [release.yml](.github/workflows/release.yml) authors the merge commit and the PR — no new secrets.

## Test plan

- [ ] Merge this PR, then verify the workflow runs on the next push to `main` (or trigger it manually) and opens `chore: merge main into next`.
- [ ] If the merge is clean, confirm `Tests` / `Lint` / `check-skill-sync` run on the sync PR.
- [ ] If a future sync hits conflicts, confirm the PR body lists the conflicting files and the resolve-in-place flow works.