### PR TITLE
refactor(auth): integrate @doist/cli-core 0.10.0 (logout + status)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@doist/cli-core": "0.9.0",
+        "@doist/cli-core": "0.10.0",
         "@doist/todoist-sdk": "10.1.3",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@doist/cli-core": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.9.0.tgz",
-      "integrity": "sha512-38uTt+DSFCMuuPkdWIl9Dm7XrjGlwG15eI0DrnaKEYm+AGizzP6tY7m1AZAT5aQXAJOCU6uYXAvqaqpni+PcLg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.10.0.tgz",
+      "integrity": "sha512-ya/+G0fJ8s+KJxIKsftKUAFGSHKFPGSPfNYJY961xoIuz1F+fm575vesPzWxaCRbmD6Z3vaiXUAxxG7SyfmgLQ==",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@doist/cli-core": "0.9.0",
+    "@doist/cli-core": "0.10.0",
     "@doist/todoist-sdk": "10.1.3",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -45,12 +45,14 @@ td auth login --json                         # emit the new account record as JS
 td auth login --ndjson                       # one-line newline-delimited JSON
 td auth token
 td auth status
+td auth status --json                        # full status payload as JSON (--ndjson also supported)
 TOKEN=$(td auth token view)
 TOKEN=$(td auth token view --user you@example.com)
 td auth logout
+td auth logout --json                        # emits `{"ok": true}` (--ndjson is silent)
 ```
 
-`td auth login` accepts `--callback-port <n>` (default `8765`, with a small fallback range when the port is busy) and the standard `--json` / `--ndjson` machine-output flags. Use `--json` / `--ndjson` to capture the newly stored account record (id, email, auth metadata) for scripts; warnings about keyring fallback are written to stderr so stdout stays parseable.
+`td auth login`, `td auth status`, and `td auth logout` all accept the standard `--json` / `--ndjson` machine-output flags. For `login` and `status` the body carries the account record (id, email, auth metadata, plus `storedUsers` and `source` from status); `logout` emits a `{"ok": true}` envelope under `--json` and stays silent under `--ndjson`. Across all three, keyring-fallback warnings are written to stderr so stdout stays parseable. `td auth login` additionally accepts `--callback-port <n>` (default `8765`, with a small fallback range when the port is busy).
 
 Opt-in OAuth scopes are requested via `--additional-scopes=<list>` (comma-separated). Run `td auth login --help` for the full list. Currently supported:
 

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -253,7 +253,7 @@ describe('auth command', () => {
 
             await program.parseAsync(['node', 'td', 'auth', 'status'])
 
-            expect(consoleSpy).toHaveBeenCalledWith('✓', 'Authenticated')
+            expect(consoleSpy).toHaveBeenCalledWith('✓ Authenticated')
             expect(consoleSpy).toHaveBeenCalledWith(`  Email: ${TEST_USER.email}`)
             expect(consoleSpy).toHaveBeenCalledWith(`  Name:  ${TEST_USER.fullName}`)
             expect(consoleSpy).toHaveBeenCalledWith('  Mode:  read-write')
@@ -271,7 +271,7 @@ describe('auth command', () => {
 
             await program.parseAsync(['node', 'td', 'auth', 'status'])
 
-            expect(consoleSpy).toHaveBeenCalledWith('✓', 'Authenticated (default)')
+            expect(consoleSpy).toHaveBeenCalledWith('✓ Authenticated (default)')
         })
 
         it('lists other stored accounts', async () => {
@@ -336,7 +336,7 @@ describe('auth command', () => {
             await program.parseAsync(['node', 'td', 'auth', 'logout'])
 
             expect(mockClearApiToken).toHaveBeenCalled()
-            expect(consoleSpy).toHaveBeenCalledWith('✓', 'Logged out')
+            expect(consoleSpy).toHaveBeenCalledWith('✓ Logged out')
         })
     })
 

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -51,6 +51,7 @@ vi.mock('node:readline', () => ({
 
 import { createInterface, type Interface } from 'node:readline'
 import { createApiForToken, getApi } from '../../lib/api/core.js'
+import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
 import {
     NoTokenError,
     TOKEN_ENV_VAR,
@@ -65,6 +66,7 @@ import { resetGlobalArgs } from '../../lib/global-args.js'
 import { UserNotFoundError } from '../../lib/users.js'
 import { createMockApi } from '../../test-support/mock-api.js'
 import { registerAuthCommand } from './index.js'
+import { attachTodoistStatusCommand } from './status.js'
 
 const mockCreateInterface = vi.mocked(createInterface)
 
@@ -321,14 +323,123 @@ describe('auth command', () => {
         it('throws NoTokenError when not authenticated', async () => {
             const program = createProgram()
             mockGetApi.mockRejectedValue(new NoTokenError())
+            // status now first calls `store.active()` (via cli-core) and, if a
+            // snapshot exists, takes the `createApiForToken(snapshot.token)`
+            // short-circuit in `fetchLive`. Make that path reject the same way
+            // so the test exercises both branches symmetrically.
+            mockCreateApiForToken.mockImplementation(() => {
+                throw new NoTokenError()
+            })
 
             await expect(
                 program.parseAsync(['node', 'td', 'auth', 'status']),
             ).rejects.toHaveProperty('code', 'NO_TOKEN')
         })
+
+        // The default tests above exercise the unauthenticated/`onNotAuthenticated`
+        // branch (real `store.active()` resolves to null in the test env because the
+        // keyring is unreachable). This block drives a controllable snapshot store
+        // directly into `attachTodoistStatusCommand` so the `fetchLive` →
+        // `renderText`/`renderJson` path is also covered.
+        describe('persisted-account snapshot path (fetchLive)', () => {
+            const SNAPSHOT_ACCOUNT: TodoistAccount = {
+                id: TEST_USER.id,
+                email: TEST_USER.email,
+                label: TEST_USER.email,
+                auth_mode: 'read-write',
+                auth_scope: 'data:read_write,data:delete,project:delete',
+            }
+
+            function programWithSnapshot(): Command {
+                const program = new Command()
+                program.exitOverride()
+                const auth = program.command('auth')
+                const snapshotStore: TodoistTokenStore = {
+                    async active() {
+                        return { token: 'snapshot_token', account: SNAPSHOT_ACCOUNT }
+                    },
+                    async set() {},
+                    async clear() {},
+                    getLastStorageResult: () => undefined,
+                    getLastClearResult: () => undefined,
+                }
+                attachTodoistStatusCommand(auth, snapshotStore)
+                return program
+            }
+
+            beforeEach(() => {
+                const liveApi = createMockApi({ getUser: vi.fn().mockResolvedValue(TEST_USER) })
+                mockCreateApiForToken.mockReturnValue(liveApi)
+                mockGetAuthMetadata.mockResolvedValue({
+                    authMode: 'read-write',
+                    authScope: 'data:read_write,data:delete,project:delete',
+                    source: 'secure-store',
+                })
+                mockListStoredUsers.mockResolvedValue([
+                    { id: TEST_USER.id, email: TEST_USER.email },
+                ])
+                mockReadConfig.mockResolvedValue({ user: { defaultUser: TEST_USER.id } })
+            })
+
+            it('renders text status from the snapshot (no --user override)', async () => {
+                await programWithSnapshot().parseAsync(['node', 'td', 'auth', 'status'])
+
+                expect(mockCreateApiForToken).toHaveBeenCalledWith('snapshot_token')
+                expect(consoleSpy).toHaveBeenCalledWith('✓ Authenticated (default)')
+                expect(consoleSpy).toHaveBeenCalledWith(`  Email: ${TEST_USER.email}`)
+                expect(consoleSpy).toHaveBeenCalledWith(`  Name:  ${TEST_USER.fullName}`)
+                expect(consoleSpy).toHaveBeenCalledWith('  Mode:  read-write')
+            })
+
+            it('emits the JSON envelope from the snapshot path', async () => {
+                await programWithSnapshot().parseAsync(['node', 'td', 'auth', 'status', '--json'])
+
+                const printed = consoleSpy.mock.calls[0][0] as string
+                const parsed = JSON.parse(printed)
+                expect(parsed).toMatchObject({
+                    id: TEST_USER.id,
+                    email: TEST_USER.email,
+                    fullName: TEST_USER.fullName,
+                    authMode: 'read-write',
+                    source: 'secure-store',
+                    isDefault: true,
+                })
+            })
+
+            it('falls back to getApi() when --user is set so the snapshot default is overridden', async () => {
+                // Stash --user in process.argv so global-args picks it up.
+                const overrideUser = { id: '99999', email: 'other@example.com', fullName: 'Other' }
+                const liveApi = createMockApi({
+                    getUser: vi.fn().mockResolvedValue(overrideUser),
+                })
+                mockGetApi.mockResolvedValue(liveApi)
+
+                const originalArgv = process.argv
+                process.argv = ['node', 'td', '--user', overrideUser.email, 'auth', 'status']
+                resetGlobalArgs()
+                try {
+                    await programWithSnapshot().parseAsync(['node', 'td', 'auth', 'status'])
+                } finally {
+                    process.argv = originalArgv
+                    resetGlobalArgs()
+                }
+
+                // With --user set, fetchLive must NOT call createApiForToken;
+                // it re-resolves via getApi() so the selector is honoured.
+                expect(mockCreateApiForToken).not.toHaveBeenCalled()
+                expect(mockGetApi).toHaveBeenCalled()
+                expect(consoleSpy).toHaveBeenCalledWith(`  Email: ${overrideUser.email}`)
+            })
+        })
     })
 
     describe('logout subcommand', () => {
+        const WARNING_RESULT = {
+            storage: 'config-file' as const,
+            warning:
+                'system credential manager unavailable; token cleared from plaintext config.json',
+        }
+
         it('clears the API token', async () => {
             const program = createProgram()
             mockClearApiToken.mockResolvedValue({ storage: 'secure-store' })
@@ -337,6 +448,39 @@ describe('auth command', () => {
 
             expect(mockClearApiToken).toHaveBeenCalled()
             expect(consoleSpy).toHaveBeenCalledWith('✓ Logged out')
+        })
+
+        it('surfaces keyring-fallback warning to stderr in plain mode', async () => {
+            const program = createProgram()
+            mockClearApiToken.mockResolvedValue(WARNING_RESULT)
+
+            await program.parseAsync(['node', 'td', 'auth', 'logout'])
+
+            expect(consoleSpy).toHaveBeenCalledWith('✓ Logged out')
+            expect(errorSpy).toHaveBeenCalledWith('Warning:', WARNING_RESULT.warning)
+        })
+
+        it('routes warning to stderr and emits JSON envelope on stdout in --json mode', async () => {
+            const program = createProgram()
+            mockClearApiToken.mockResolvedValue(WARNING_RESULT)
+
+            await program.parseAsync(['node', 'td', 'auth', 'logout', '--json'])
+
+            const stdoutLines = consoleSpy.mock.calls.map((c: unknown[]) => String(c[0]))
+            expect(stdoutLines).toEqual([JSON.stringify({ ok: true }, null, 2)])
+            // Plain "Stored token removed" confirmation must be suppressed under --json.
+            expect(stdoutLines.join('\n')).not.toContain('Stored token removed')
+            expect(errorSpy).toHaveBeenCalledWith('Warning:', WARNING_RESULT.warning)
+        })
+
+        it('routes warning to stderr and keeps stdout silent in --ndjson mode', async () => {
+            const program = createProgram()
+            mockClearApiToken.mockResolvedValue(WARNING_RESULT)
+
+            await program.parseAsync(['node', 'td', 'auth', 'logout', '--ndjson'])
+
+            expect(consoleSpy).not.toHaveBeenCalled()
+            expect(errorSpy).toHaveBeenCalledWith('Warning:', WARNING_RESULT.warning)
         })
     })
 

--- a/src/commands/auth/helpers.ts
+++ b/src/commands/auth/helpers.ts
@@ -24,11 +24,19 @@ export function promptHiddenInput(prompt: string): Promise<string> {
     })
 }
 
+/**
+ * Surface a `TokenStorageResult` from a save/clear operation: the
+ * human-readable confirmation goes to stdout, any keyring-fallback warning
+ * goes to stderr. Pass `isMachineOutput: true` when the command is in
+ * `--json` / `--ndjson` mode so the stdout confirmation is suppressed and
+ * the warning still reaches the operator on stderr.
+ */
 export function logTokenStorageResult(
     result: TokenStorageResult,
     secureStoreMessage: string,
+    isMachineOutput = false,
 ): void {
-    if (result.storage === 'secure-store') {
+    if (!isMachineOutput && result.storage === 'secure-store') {
         console.log(chalk.dim(secureStoreMessage))
     }
 

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -1,14 +1,23 @@
 import type { Command } from 'commander'
+import { createTodoistTokenStore } from '../../lib/auth-store.js'
 import { attachTodoistLoginCommand } from './login.js'
-import { logout } from './logout.js'
-import { showStatus } from './status.js'
+import { attachTodoistLogoutCommand } from './logout.js'
+import { attachTodoistStatusCommand } from './status.js'
 import { viewToken } from './token-view.js'
 import { loginWithToken } from './token.js'
 
 export function registerAuthCommand(program: Command): void {
     const auth = program.command('auth').description('Manage authentication')
 
-    attachTodoistLoginCommand(auth)
+    // Shared store instance: login stashes the post-`set` storage result for
+    // its success handler, logout reads the post-`clear` result for the same
+    // keyring-fallback warning surface. Status uses `active()` as the
+    // authenticated-snapshot gate.
+    const store = createTodoistTokenStore()
+
+    attachTodoistLoginCommand(auth, store)
+    attachTodoistLogoutCommand(auth, store)
+    attachTodoistStatusCommand(auth, store)
 
     // `token` is a hybrid: it accepts a positional `[token]` (save) and also
     // exposes subcommands (`view`). Commander matches subcommand names before
@@ -16,6 +25,10 @@ export function registerAuthCommand(program: Command): void {
     // dispatches to the `view` subcommand — `view` is never treated as a
     // literal token value. Real Todoist tokens are 40-char hex strings, so
     // this disambiguation is safe in practice.
+    //
+    // `token view` stays hand-rolled (not migrated to `attachTokenViewCommand`)
+    // because it depends on the `--user <ref>` selector + env precedence rules
+    // that the `TokenStore` adapter intentionally drops from `active()`.
     const tokenCmd = auth
         .command('token [token]')
         .description('Save API token for CLI authentication (or use a subcommand: `view`)')
@@ -27,11 +40,4 @@ export function registerAuthCommand(program: Command): void {
             'Print the stored API token for the active user (or --user <ref>) to stdout for use in scripts',
         )
         .action(viewToken)
-
-    auth.command('status')
-        .description('Show current authentication status')
-        .option('--json', 'Output as JSON')
-        .action(showStatus)
-
-    auth.command('logout').description('Remove saved authentication token').action(logout)
 }

--- a/src/commands/auth/login.test.ts
+++ b/src/commands/auth/login.test.ts
@@ -37,6 +37,7 @@ vi.mock('@doist/cli-core/auth', async (importOriginal) => {
     }
 })
 
+import { createTodoistTokenStore } from '../../lib/auth-store.js'
 import { attachTodoistLoginCommand } from './login.js'
 
 type AttachOptions = {
@@ -53,22 +54,7 @@ function attachAndCapture(): AttachOptions {
     capturedAttachOptions.length = 0
     const program = new Command()
     program.exitOverride()
-    // Stub `TodoistTokenStore` — the login attacher just forwards the store to
-    // cli-core, which is mocked here. The tests only exercise the local
-    // resolveScopes / onSuccess callbacks.
-    const stubStore = {
-        async active() {
-            return null
-        },
-        async set() {},
-        async clear() {},
-        getLastStorageResult: () => undefined,
-        getLastClearResult: () => undefined,
-    }
-    attachTodoistLoginCommand(
-        program,
-        stubStore as unknown as Parameters<typeof attachTodoistLoginCommand>[1],
-    )
+    attachTodoistLoginCommand(program, createTodoistTokenStore())
     return capturedAttachOptions[capturedAttachOptions.length - 1].options as AttachOptions
 }
 

--- a/src/commands/auth/login.test.ts
+++ b/src/commands/auth/login.test.ts
@@ -53,7 +53,22 @@ function attachAndCapture(): AttachOptions {
     capturedAttachOptions.length = 0
     const program = new Command()
     program.exitOverride()
-    attachTodoistLoginCommand(program)
+    // Stub `TodoistTokenStore` — the login attacher just forwards the store to
+    // cli-core, which is mocked here. The tests only exercise the local
+    // resolveScopes / onSuccess callbacks.
+    const stubStore = {
+        async active() {
+            return null
+        },
+        async set() {},
+        async clear() {},
+        getLastStorageResult: () => undefined,
+        getLastClearResult: () => undefined,
+    }
+    attachTodoistLoginCommand(
+        program,
+        stubStore as unknown as Parameters<typeof attachTodoistLoginCommand>[1],
+    )
     return capturedAttachOptions[capturedAttachOptions.length - 1].options as AttachOptions
 }
 

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -63,16 +63,11 @@ export function attachTodoistLoginCommand(auth: Command, store: TodoistTokenStor
             // `--json` / `--ndjson` stdout envelope clean; the human "stored
             // securely" confirmation is suppressed in machine-output mode.
             if (storage) {
-                if (view.json || view.ndjson) {
-                    if (storage.warning) {
-                        console.error(chalk.yellow('Warning:'), storage.warning)
-                    }
-                } else {
-                    logTokenStorageResult(
-                        storage,
-                        'Token stored securely in the system credential manager',
-                    )
-                }
+                logTokenStorageResult(
+                    storage,
+                    'Token stored securely in the system credential manager',
+                    view.json || view.ndjson,
+                )
             }
         },
     })

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -5,7 +5,7 @@ import type { Command } from 'commander'
 import open from 'open'
 import { renderAuthErrorPage, renderAuthSuccessPage } from '../../lib/auth-html.js'
 import { createTodoistAuthProvider } from '../../lib/auth-provider.js'
-import { createTodoistTokenStore, type TodoistAccount } from '../../lib/auth-store.js'
+import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
 import {
     extractAdditionalScopes,
     formatScopesHelp,
@@ -27,9 +27,7 @@ const TODOIST_CALLBACK_PORT_FALLBACK = 5
  * the same Commander view; cli-core surfaces it through the `flags` argument
  * to `resolveScopes`.
  */
-export function attachTodoistLoginCommand(auth: Command): Command {
-    const store = createTodoistTokenStore()
-
+export function attachTodoistLoginCommand(auth: Command, store: TodoistTokenStore): Command {
     const login = attachLoginCommand<TodoistAccount>(auth, {
         provider: createTodoistAuthProvider(),
         store,

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -1,9 +1,30 @@
+import { attachLogoutCommand } from '@doist/cli-core/auth'
 import chalk from 'chalk'
-import { clearApiToken } from '../../lib/auth.js'
+import type { Command } from 'commander'
+import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
 import { logTokenStorageResult } from './helpers.js'
 
-export async function logout(): Promise<void> {
-    const result = await clearApiToken()
-    console.log(chalk.green('✓'), 'Logged out')
-    logTokenStorageResult(result, 'Stored token removed from the system credential manager')
+/**
+ * Attach `td auth logout` via cli-core's generic `attachLogoutCommand`. The
+ * registrar emits the success line (`✓ Logged out` / `{ok:true}` / silent
+ * ndjson); `onCleared` only surfaces the keyring-fallback warning carried by
+ * `TokenStorageResult` — cli-core's `TokenStore.clear: void` contract can't
+ * expose it directly, so we stash it on the adapter (`getLastClearResult`).
+ */
+export function attachTodoistLogoutCommand(auth: Command, store: TodoistTokenStore): Command {
+    return attachLogoutCommand<TodoistAccount>(auth, {
+        store,
+        onCleared: ({ view }) => {
+            const result = store.getLastClearResult()
+            if (!result) return
+            if (view.json || view.ndjson) {
+                if (result.warning) console.error(chalk.yellow('Warning:'), result.warning)
+            } else {
+                logTokenStorageResult(
+                    result,
+                    'Stored token removed from the system credential manager',
+                )
+            }
+        },
+    })
 }

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -1,5 +1,4 @@
 import { attachLogoutCommand } from '@doist/cli-core/auth'
-import chalk from 'chalk'
 import type { Command } from 'commander'
 import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
 import { logTokenStorageResult } from './helpers.js'
@@ -17,14 +16,11 @@ export function attachTodoistLogoutCommand(auth: Command, store: TodoistTokenSto
         onCleared: ({ view }) => {
             const result = store.getLastClearResult()
             if (!result) return
-            if (view.json || view.ndjson) {
-                if (result.warning) console.error(chalk.yellow('Warning:'), result.warning)
-            } else {
-                logTokenStorageResult(
-                    result,
-                    'Stored token removed from the system credential manager',
-                )
-            }
+            logTokenStorageResult(
+                result,
+                'Stored token removed from the system credential manager',
+                view.json || view.ndjson,
+            )
         },
     })
 }

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -1,7 +1,25 @@
+import { formatJson, formatNdjson } from '@doist/cli-core'
+import { attachStatusCommand } from '@doist/cli-core/auth'
 import chalk from 'chalk'
+import type { Command } from 'commander'
 import { getApi } from '../../lib/api/core.js'
-import { type AuthMode, getAuthMetadata, listStoredUsers, readConfig } from '../../lib/auth.js'
+import { type TodoistAccount, type TodoistTokenStore } from '../../lib/auth-store.js'
+import {
+    type AuthMetadata,
+    type AuthMode,
+    getAuthMetadata,
+    listStoredUsers,
+    readConfig,
+    type StoredUser,
+} from '../../lib/auth.js'
 import { getDefaultUserId } from '../../lib/users.js'
+
+type StatusData = {
+    user: { id: string; email: string; fullName: string }
+    metadata: AuthMetadata
+    storedUsers: StoredUser[]
+    defaultUserId: string | undefined
+}
 
 function formatAuthMode(authMode: AuthMode, authScope?: string): string {
     if (authMode === 'read-only') {
@@ -13,39 +31,20 @@ function formatAuthMode(authMode: AuthMode, authScope?: string): string {
     return 'unknown (manual token or env var; assuming write access)'
 }
 
-export async function showStatus(options: { json?: boolean }): Promise<void> {
+async function gatherStatusData(): Promise<StatusData> {
     const api = await getApi()
-    const user = await api.getUser()
-    const metadata = await getAuthMetadata()
-    const config = await readConfig()
-    const storedUsers = await listStoredUsers()
-    const defaultUserId = getDefaultUserId(config)
-    const modeLabel = formatAuthMode(metadata.authMode, metadata.authScope)
+    const [user, metadata, storedUsers, config] = await Promise.all([
+        api.getUser(),
+        getAuthMetadata(),
+        listStoredUsers(),
+        readConfig(),
+    ])
+    return { user, metadata, storedUsers, defaultUserId: getDefaultUserId(config) }
+}
 
-    if (options.json) {
-        console.log(
-            JSON.stringify(
-                {
-                    id: user.id,
-                    email: user.email,
-                    fullName: user.fullName,
-                    authMode: metadata.authMode,
-                    authScope: metadata.authScope,
-                    authFlags: metadata.authFlags,
-                    source: metadata.source,
-                    isDefault: defaultUserId === user.id,
-                    storedUsers: storedUsers.map((u) => ({
-                        id: u.id,
-                        email: u.email,
-                        isDefault: defaultUserId === u.id,
-                    })),
-                },
-                null,
-                2,
-            ),
-        )
-        return
-    }
+function buildStatusText(data: StatusData): readonly string[] {
+    const { user, metadata, storedUsers, defaultUserId } = data
+    const modeLabel = formatAuthMode(metadata.authMode, metadata.authScope)
 
     // env source wins over default: when running with TODOIST_API_TOKEN,
     // showing `(default)` would hide the more important "this is an env
@@ -56,23 +55,101 @@ export async function showStatus(options: { json?: boolean }): Promise<void> {
             : defaultUserId === user.id
               ? ' (default)'
               : ''
-    console.log(chalk.green('✓'), `Authenticated${defaultMarker}`)
-    console.log(`  Email: ${user.email}`)
-    console.log(`  Name:  ${user.fullName}`)
-    console.log(`  Mode:  ${modeLabel}`)
+
+    const lines: string[] = [
+        `${chalk.green('✓')} Authenticated${defaultMarker}`,
+        `  Email: ${user.email}`,
+        `  Name:  ${user.fullName}`,
+        `  Mode:  ${modeLabel}`,
+    ]
 
     const others = storedUsers.filter((u) => u.id !== user.id)
     if (others.length > 0) {
-        console.log()
-        console.log(chalk.dim(`Other stored accounts (${others.length}):`))
+        lines.push('')
+        lines.push(chalk.dim(`Other stored accounts (${others.length}):`))
         for (const other of others) {
             const marker = other.id === defaultUserId ? chalk.dim(' (default)') : ''
-            console.log(`  ${other.email} ${chalk.dim(`(id:${other.id})`)}${marker}`)
+            lines.push(`  ${other.email} ${chalk.dim(`(id:${other.id})`)}${marker}`)
         }
-        console.log(
+        lines.push(
             chalk.dim(
                 'Use `td user use <id|email>` to switch default, or `--user <ref>` per command.',
             ),
         )
     }
+    return lines
+}
+
+function buildStatusJson(data: StatusData): unknown {
+    const { user, metadata, storedUsers, defaultUserId } = data
+    return {
+        id: user.id,
+        email: user.email,
+        fullName: user.fullName,
+        authMode: metadata.authMode,
+        authScope: metadata.authScope,
+        authFlags: metadata.authFlags,
+        source: metadata.source,
+        isDefault: defaultUserId === user.id,
+        storedUsers: storedUsers.map((u) => ({
+            id: u.id,
+            email: u.email,
+            isDefault: defaultUserId === u.id,
+        })),
+    }
+}
+
+/**
+ * Attach `td auth status` via cli-core's generic `attachStatusCommand`.
+ *
+ * `TodoistTokenStore.active()` returns `null` for env-token mode + when no
+ * default user is stored (per the adapter's documented contract — see
+ * `auth-store.ts`). To preserve the existing UX for those cases we route the
+ * full status fetch through `onNotAuthenticated`; when `active()` does return
+ * a snapshot, `fetchLive` covers the same gather so renderText/renderJson can
+ * read from a single closure-captured `StatusData` regardless of which path
+ * we took. The same gather (`gatherStatusData`) is reused so output is
+ * byte-for-byte identical between paths.
+ */
+export function attachTodoistStatusCommand(auth: Command, store: TodoistTokenStore): Command {
+    let data: StatusData | null = null
+
+    return attachStatusCommand<TodoistAccount>(auth, {
+        store,
+        description: 'Show current authentication status',
+        fetchLive: async ({ account }) => {
+            data = await gatherStatusData()
+            return {
+                ...account,
+                email: data.user.email,
+                auth_mode: data.metadata.authMode,
+                auth_scope: data.metadata.authScope,
+                auth_flags: data.metadata.authFlags,
+            }
+        },
+        renderText: () => {
+            if (!data) throw new Error('status renderText called before fetchLive')
+            return buildStatusText(data)
+        },
+        renderJson: () => {
+            if (!data) throw new Error('status renderJson called before fetchLive')
+            return buildStatusJson(data)
+        },
+        onNotAuthenticated: async ({ view }) => {
+            // active() returned null — either env-token mode, --user selector,
+            // or no default. Drive the legacy resolver (getApi) so all three
+            // paths render identically; getApi throws NoTokenError /
+            // UserNotFoundError when nothing resolves, matching prior UX.
+            data = await gatherStatusData()
+            if (view.json) {
+                console.log(formatJson(buildStatusJson(data)))
+                return
+            }
+            if (view.ndjson) {
+                console.log(formatNdjson([buildStatusJson(data)]))
+                return
+            }
+            for (const line of buildStatusText(data)) console.log(line)
+        },
+    })
 }

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -2,8 +2,12 @@ import { formatJson, formatNdjson } from '@doist/cli-core'
 import { attachStatusCommand } from '@doist/cli-core/auth'
 import chalk from 'chalk'
 import type { Command } from 'commander'
-import { getApi } from '../../lib/api/core.js'
-import { type TodoistAccount, type TodoistTokenStore } from '../../lib/auth-store.js'
+import { createApiForToken, getApi } from '../../lib/api/core.js'
+import {
+    toTodoistAccount,
+    type TodoistAccount,
+    type TodoistTokenStore,
+} from '../../lib/auth-store.js'
 import {
     type AuthMetadata,
     type AuthMode,
@@ -12,6 +16,7 @@ import {
     readConfig,
     type StoredUser,
 } from '../../lib/auth.js'
+import { getRequestedUserRef } from '../../lib/global-args.js'
 import { getDefaultUserId } from '../../lib/users.js'
 
 type StatusData = {
@@ -31,8 +36,14 @@ function formatAuthMode(authMode: AuthMode, authScope?: string): string {
     return 'unknown (manual token or env var; assuming write access)'
 }
 
-async function gatherStatusData(): Promise<StatusData> {
-    const api = await getApi()
+/**
+ * `token` shortcut: when the caller already has a resolved token (e.g. from
+ * the cli-core `store.active()` snapshot, and no `--user <ref>` override is
+ * in play), pass it through to skip the redundant keyring round-trip
+ * `getApi()` would do via `resolveActiveUser`.
+ */
+async function gatherStatusData(token?: string): Promise<StatusData> {
+    const api = token ? createApiForToken(token) : await getApi()
     const [user, metadata, storedUsers, config] = await Promise.all([
         api.getUser(),
         getAuthMetadata(),
@@ -108,8 +119,10 @@ function buildStatusJson(data: StatusData): unknown {
  * full status fetch through `onNotAuthenticated`; when `active()` does return
  * a snapshot, `fetchLive` covers the same gather so renderText/renderJson can
  * read from a single closure-captured `StatusData` regardless of which path
- * we took. The same gather (`gatherStatusData`) is reused so output is
- * byte-for-byte identical between paths.
+ * we took. The snapshot path also short-circuits one credential resolve via
+ * `gatherStatusData(token)` when no `--user <ref>` is in play; when `--user`
+ * is set we re-resolve through `getApi()` so the displayed account matches
+ * the selector instead of the snapshot's default.
  */
 export function attachTodoistStatusCommand(auth: Command, store: TodoistTokenStore): Command {
     let data: StatusData | null = null
@@ -117,15 +130,19 @@ export function attachTodoistStatusCommand(auth: Command, store: TodoistTokenSto
     return attachStatusCommand<TodoistAccount>(auth, {
         store,
         description: 'Show current authentication status',
-        fetchLive: async ({ account }) => {
-            data = await gatherStatusData()
-            return {
-                ...account,
+        fetchLive: async ({ token }) => {
+            // Snapshot's token only matches `--user` when no selector is set.
+            // Re-resolve via getApi when --user is present so the displayed
+            // account is the requested one, not the snapshot's default.
+            const userOverride = getRequestedUserRef() !== undefined
+            data = await gatherStatusData(userOverride ? undefined : token)
+            return toTodoistAccount({
+                id: data.user.id,
                 email: data.user.email,
-                auth_mode: data.metadata.authMode,
-                auth_scope: data.metadata.authScope,
-                auth_flags: data.metadata.authFlags,
-            }
+                authMode: data.metadata.authMode,
+                authScope: data.metadata.authScope,
+                authFlags: data.metadata.authFlags,
+            })
         },
         renderText: () => {
             if (!data) throw new Error('status renderText called before fetchLive')
@@ -136,10 +153,11 @@ export function attachTodoistStatusCommand(auth: Command, store: TodoistTokenSto
             return buildStatusJson(data)
         },
         onNotAuthenticated: async ({ view }) => {
-            // active() returned null — either env-token mode, --user selector,
-            // or no default. Drive the legacy resolver (getApi) so all three
-            // paths render identically; getApi throws NoTokenError /
-            // UserNotFoundError when nothing resolves, matching prior UX.
+            // active() returned null — either env-token mode, --user selector
+            // without a snapshot match, or no default. Drive the legacy
+            // resolver (getApi) so all three paths render identically; getApi
+            // throws NoTokenError / UserNotFoundError when nothing resolves,
+            // matching prior UX.
             data = await gatherStatusData()
             if (view.json) {
                 console.log(formatJson(buildStatusJson(data)))

--- a/src/lib/auth-store.ts
+++ b/src/lib/auth-store.ts
@@ -86,10 +86,12 @@ function storedUserToAccount(user: StoredUser): TodoistAccount {
  */
 export type TodoistTokenStore = TokenStore<TodoistAccount> & {
     getLastStorageResult(): TokenStorageResult | undefined
+    getLastClearResult(): TokenStorageResult | undefined
 }
 
 export function createTodoistTokenStore(): TodoistTokenStore {
     let lastStorageResult: TokenStorageResult | undefined
+    let lastClearResult: TokenStorageResult | undefined
 
     return {
         /**
@@ -133,11 +135,15 @@ export function createTodoistTokenStore(): TodoistTokenStore {
         },
 
         async clear() {
-            await clearApiToken()
+            lastClearResult = await clearApiToken()
         },
 
         getLastStorageResult() {
             return lastStorageResult
+        },
+
+        getLastClearResult() {
+            return lastClearResult
         },
     }
 }

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -41,12 +41,14 @@ td auth login --json                         # emit the new account record as JS
 td auth login --ndjson                       # one-line newline-delimited JSON
 td auth token
 td auth status
+td auth status --json                        # full status payload as JSON (--ndjson also supported)
 TOKEN=$(td auth token view)
 TOKEN=$(td auth token view --user you@example.com)
 td auth logout
+td auth logout --json                        # emits \`{"ok": true}\` (--ndjson is silent)
 \`\`\`
 
-\`td auth login\` accepts \`--callback-port <n>\` (default \`8765\`, with a small fallback range when the port is busy) and the standard \`--json\` / \`--ndjson\` machine-output flags. Use \`--json\` / \`--ndjson\` to capture the newly stored account record (id, email, auth metadata) for scripts; warnings about keyring fallback are written to stderr so stdout stays parseable.
+\`td auth login\`, \`td auth status\`, and \`td auth logout\` all accept the standard \`--json\` / \`--ndjson\` machine-output flags. For \`login\` and \`status\` the body carries the account record (id, email, auth metadata, plus \`storedUsers\` and \`source\` from status); \`logout\` emits a \`{"ok": true}\` envelope under \`--json\` and stays silent under \`--ndjson\`. Across all three, keyring-fallback warnings are written to stderr so stdout stays parseable. \`td auth login\` additionally accepts \`--callback-port <n>\` (default \`8765\`, with a small fallback range when the port is busy).
 
 Opt-in OAuth scopes are requested via \`--additional-scopes=<list>\` (comma-separated). Run \`td auth login --help\` for the full list. Currently supported:
 


### PR DESCRIPTION
## Summary

Bumps `@doist/cli-core` to **0.10.0** and migrates `td auth logout` + `td auth status` onto the new `attachLogoutCommand` / `attachStatusCommand` registrars that ship alongside the existing `attachLoginCommand` ([cli-core#16](https://github.com/Doist/cli-core/pull/16)).

- `TodoistTokenStore` gains `getLastClearResult()` so the logout `onCleared` callback can surface keyring-fallback warnings — cli-core's `TokenStore.clear: void` contract can't carry the `TokenStorageResult` directly.
- `auth/index.ts` now creates a single shared `TodoistTokenStore` instance used by login, logout, and status (login's wrapper takes the store as a parameter instead of constructing its own).
- `attachTodoistStatusCommand` routes both the active-snapshot path (`fetchLive`) and the unauthenticated path (`onNotAuthenticated`) through one `gatherStatusData` helper so env-token mode and `--user <ref>` (both return `null` from `TokenStore.active()` by the adapter's documented contract) render byte-for-byte identically to the persisted-default-user path.
- `auth logout` and `auth status` now accept `--ndjson` for free (framework-registered) on top of `--json`. `auth status` previously only had `--json`.
- `td auth token view` stays hand-rolled — its `--user <ref>` selector depends on multi-user state the `TokenStore` adapter intentionally drops from `active()`. cli-core PR #16 explicitly carves this out as a scope note pending a multi-user store contract.

## Test plan

- [x] `npm run check` (oxlint + oxfmt) clean
- [x] `npm run type-check` clean
- [x] `npm test` — 1574/1574 across 60 files
- [x] `npm run build` clean
- [x] Smoke: `HOME=$(mktemp -d) td auth status` prints the legacy "No API token found." CliError envelope
- [x] Smoke: `td auth {login,logout,status} --help` show framework-registered `--json` / `--ndjson` flags
- [ ] Manual: full OAuth login → `td auth status` → `td auth status --json` → `td auth logout` round-trip against a real account
- [ ] Manual: `TODOIST_API_TOKEN=… td auth status` shows `✓ Authenticated (TODOIST_API_TOKEN)` env-mode branch
- [ ] Manual: multi-user setup shows the "Other stored accounts" enumeration

🤖 Generated with [Claude Code](https://claude.com/claude-code)