### PR TITLE
fix: forward arrayBuffer on tracked-fetch wrapper for binary attachments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@doist/cli-core": "0.10.0",
-        "@doist/todoist-sdk": "10.1.3",
+        "@doist/todoist-sdk": "10.1.5",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@doist/todoist-sdk": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.1.3.tgz",
-      "integrity": "sha512-yFnNS5C7sXS+yWVmWF1zx+XZ0bMxyM8LMXWH6069Kjxnu/Nj2x4vrMCs2qSV/vfNThyCJ6Gw+4lc8r0CLsN/1Q==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.1.5.tgz",
+      "integrity": "sha512-32e1D4qMRaGsQJt0IPM/X2eTUpjMjQRRHXK/RDSIRVH2015pTo0oakzA+bUcoIRYy+BfWLGw0d9Gowg2oP+EkA==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "@doist/cli-core": "0.10.0",
-    "@doist/todoist-sdk": "10.1.3",
+    "@doist/todoist-sdk": "10.1.5",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",

--- a/src/lib/usage-tracking.test.ts
+++ b/src/lib/usage-tracking.test.ts
@@ -74,6 +74,30 @@ describe('usage tracking', () => {
         expect(response.ok).toBe(true)
     })
 
+    it('forwards arrayBuffer so binary attachments are not corrupted', async () => {
+        // PNG magic + a stretch of high bytes that would be replaced with
+        // U+FFFD by any UTF-8 text round-trip on the response body.
+        const binaryBytes = new Uint8Array([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0xff, 0xfe,
+            0xfd, 0x80,
+        ])
+        const trackedFetch = createTrackedFetch(
+            async () =>
+                new Response(binaryBytes, {
+                    status: 200,
+                    headers: { 'content-type': 'image/png' },
+                }),
+        )
+
+        const response = await trackedFetch('https://files.todoist.com/file.png')
+        const buffer = await response.arrayBuffer?.()
+
+        expect(buffer).toBeDefined()
+        if (buffer) {
+            expect(new Uint8Array(buffer)).toEqual(binaryBytes)
+        }
+    })
+
     it('maps sdk timeouts to abort signals', async () => {
         let captured: RequestInit | undefined
         const trackedFetch = createTrackedFetch(async (_url, options) => {

--- a/src/lib/usage-tracking.ts
+++ b/src/lib/usage-tracking.ts
@@ -101,6 +101,7 @@ function toCustomFetchResponse(response: Response): CustomFetchResponse {
         headers: Object.fromEntries(response.headers.entries()),
         text: () => response.text(),
         json: () => response.json(),
+        arrayBuffer: () => response.arrayBuffer(),
     }
 }
 


### PR DESCRIPTION
## Summary

- Bumps `@doist/todoist-sdk` to **10.1.5** ([Doist/todoist-sdk-typescript#602](https://github.com/Doist/todoist-sdk-typescript/pull/602)).
- Forwards `arrayBuffer()` from the tracked-fetch wrapper in `src/lib/usage-tracking.ts` so the SDK's binary endpoints (`viewAttachment`, `downloadBackup`) get a binary-safe response instead of falling back to the pre-10.1.5 lossy `text()` → `TextEncoder` round-trip.

## Bug

Same cooperating-pair as [Doist/todoist-ai#477](https://github.com/Doist/todoist-ai/pull/477) — the SDK's `UploadClient.viewAttachment` customFetch branch (pre-10.1.5) read the body via `response.text()` (UTF-8 decode with `errors=replace`) and re-encoded with `TextEncoder`, and `toCustomFetchResponse` here only forwarded `text/json/headers`, never giving the SDK a chance to read the body as bytes.

Effect: `td attachment view <png|jpeg|pdf>` returned base64 with every byte ≥ `0x80` replaced by `EF BF BD` (UTF-8 replacement char U+FFFD), corrupting every binary attachment.

## End-to-end verification

Ran `td attachment view https://files.todoist.com/user_upload/v2/2242232609/file.png --json` against a real 3.38 MB PNG attachment:

| Metric | Before | After |
| --- | --- | --- |
| Decoded length | inflated (~1.85×) | 3,382,996 B (exact match to source `fileSize`) |
| Magic bytes | `EF BF BD 50 4E 47 0D 0A …` | `89 50 4E 47 0D 0A 1A 0A` ✅ |
| `EF BF BD` count in payload | thousands | 0 ✅ |

## Test plan

- [x] `npm run type-check` — clean.
- [x] `npm test` — 1580/1580 pass.
- [x] `npm run check` — lint + format clean.
- [x] End-to-end: `td attachment view ... --json` against a real PNG, decoded base64, magic bytes match, no replacement chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)