### PR TITLE
feat(auth): adopt cli-core 0.12.0 multi-user TokenStore contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@doist/cli-core": "0.10.0",
+        "@doist/cli-core": "0.12.0",
         "@doist/todoist-sdk": "10.1.5",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
@@ -136,13 +136,13 @@
       }
     },
     "node_modules/@doist/cli-core": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.10.0.tgz",
-      "integrity": "sha512-ya/+G0fJ8s+KJxIKsftKUAFGSHKFPGSPfNYJY961xoIuz1F+fm575vesPzWxaCRbmD6Z3vaiXUAxxG7SyfmgLQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.12.0.tgz",
+      "integrity": "sha512-6dk9mL+HMmkfijcO9t+AtXO+2vxV6Gj5thD91sExNJfInnmQzFhMSYOJ/8u/k5gzpD9wyVAxL+q+bzt8s9eeQw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
-        "yocto-spinner": "1.1.0"
+        "yocto-spinner": "1.2.0"
       },
       "engines": {
         "node": ">=20.18.1"
@@ -10973,9 +10973,9 @@
       }
     },
     "node_modules/yocto-spinner": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.1.0.tgz",
-      "integrity": "sha512-/BY0AUXnS7IKO354uLLA2eRcWiqDifEbd6unXCsOxkFDAkhgUL3PH9X2bFoaU0YchnDXsF+iKleeTLJGckbXfA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.2.0.tgz",
+      "integrity": "sha512-Yw0hUB6UA3o4YUgKy3oSe9a4cxoaZ9sBfYDw+JSxo6Id0KoJGoxzPA24qqUXYKBWABs/zDSGTz9kww7t3F0XGw==",
       "license": "MIT",
       "dependencies": {
         "yoctocolors": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@doist/cli-core": "0.10.0",
+    "@doist/cli-core": "0.12.0",
     "@doist/todoist-sdk": "10.1.5",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -360,6 +360,10 @@ describe('auth command', () => {
                     },
                     async set() {},
                     async clear() {},
+                    async list() {
+                        return [{ account: SNAPSHOT_ACCOUNT, isDefault: true }]
+                    },
+                    async setDefault() {},
                     getLastStorageResult: () => undefined,
                     getLastClearResult: () => undefined,
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,10 @@
 #!/usr/bin/env node
 
+import { stripUserFlag } from '@doist/cli-core'
 import { type Command, program } from 'commander'
 import packageJson from '../package.json' with { type: 'json' }
 import { BaseCliError, CliError } from './lib/errors.js'
-import {
-    getRequestedUserRef,
-    isJsonMode,
-    isNdjsonMode,
-    isRawMode,
-    stripUserFlag,
-} from './lib/global-args.js'
+import { getRequestedUserRef, isJsonMode, isNdjsonMode, isRawMode } from './lib/global-args.js'
 import { initializeLogger } from './lib/logger.js'
 import { preloadMarkdown } from './lib/markdown.js'
 import { formatError, formatErrorJson } from './lib/output.js'

--- a/src/lib/auth-store.test.ts
+++ b/src/lib/auth-store.test.ts
@@ -7,6 +7,7 @@ vi.mock('./auth.js', async (importOriginal) => {
         loadTokenForStoredUser: vi.fn(),
         upsertUser: vi.fn(),
         clearApiToken: vi.fn(),
+        setDefaultUserId: vi.fn(),
     }
 })
 
@@ -28,16 +29,19 @@ import {
     clearApiToken,
     loadTokenForStoredUser,
     NoTokenError,
+    setDefaultUserId,
     TOKEN_ENV_VAR,
     upsertUser,
 } from './auth.js'
 import { readConfig } from './config.js'
 import { SecureStoreUnavailableError } from './secure-store.js'
+import { UserNotFoundError } from './users.js'
 
 const mockReadConfig = vi.mocked(readConfig)
 const mockLoadToken = vi.mocked(loadTokenForStoredUser)
 const mockUpsertUser = vi.mocked(upsertUser)
 const mockClearApiToken = vi.mocked(clearApiToken)
+const mockSetDefaultUserId = vi.mocked(setDefaultUserId)
 
 const USER_A = {
     id: '111',
@@ -60,6 +64,15 @@ const ACCOUNT_A: TodoistAccount = {
     auth_mode: USER_A.auth_mode,
     auth_scope: USER_A.auth_scope,
     auth_flags: undefined,
+}
+
+const ACCOUNT_B: TodoistAccount = {
+    id: USER_B.id,
+    email: USER_B.email,
+    label: USER_B.email,
+    auth_mode: USER_B.auth_mode,
+    auth_scope: USER_B.auth_scope,
+    auth_flags: ['read-only'],
 }
 
 describe('TodoistAccount mappers', () => {
@@ -143,10 +156,48 @@ describe('createTodoistTokenStore', () => {
         it.each([
             ['NoTokenError', new NoTokenError()],
             ['SecureStoreUnavailableError', new SecureStoreUnavailableError('offline')],
-        ])('returns null when token load throws %s', async (_label, error) => {
-            mockReadConfig.mockResolvedValue({ users: [USER_A] })
-            mockLoadToken.mockRejectedValue(error)
-            expect(await createTodoistTokenStore().active()).toBeNull()
+        ])(
+            'propagates %s when token load fails for a matched user (does not collapse to null)',
+            async (_label, error) => {
+                // Pre cli-core 0.12.0 these were swallowed to null, but `null`
+                // is now reserved for "ref miss" — see TokenStore contract.
+                mockReadConfig.mockResolvedValue({ users: [USER_A] })
+                mockLoadToken.mockRejectedValue(error)
+                await expect(createTodoistTokenStore().active()).rejects.toBe(error)
+            },
+        )
+
+        describe('with --user ref', () => {
+            it('returns the matched account when ref hits a stored id', async () => {
+                mockReadConfig.mockResolvedValue({ users: [USER_A, USER_B] })
+                mockLoadToken.mockResolvedValue({ token: 'tok_b', source: 'secure-store' })
+
+                const result = await createTodoistTokenStore().active(USER_B.id)
+                expect(mockLoadToken).toHaveBeenCalledWith(USER_B)
+                expect(result?.account.id).toBe(USER_B.id)
+            })
+
+            it('returns the matched account when ref hits a stored email', async () => {
+                mockReadConfig.mockResolvedValue({ users: [USER_A, USER_B] })
+                mockLoadToken.mockResolvedValue({ token: 'tok_a', source: 'secure-store' })
+
+                const result = await createTodoistTokenStore().active(USER_A.email)
+                expect(mockLoadToken).toHaveBeenCalledWith(USER_A)
+                expect(result?.account.email).toBe(USER_A.email)
+            })
+
+            it('returns null when ref does not match any stored account', async () => {
+                mockReadConfig.mockResolvedValue({ users: [USER_A] })
+                expect(await createTodoistTokenStore().active('nobody@example.com')).toBeNull()
+                expect(mockLoadToken).not.toHaveBeenCalled()
+            })
+
+            it('propagates keyring errors when ref matches but token load fails', async () => {
+                mockReadConfig.mockResolvedValue({ users: [USER_A, USER_B] })
+                const error = new SecureStoreUnavailableError('offline')
+                mockLoadToken.mockRejectedValue(error)
+                await expect(createTodoistTokenStore().active(USER_B.id)).rejects.toBe(error)
+            })
         })
     })
 
@@ -174,10 +225,64 @@ describe('createTodoistTokenStore', () => {
     })
 
     describe('clear()', () => {
-        it('delegates to clearApiToken', async () => {
+        it('delegates to clearApiToken with no ref', async () => {
             mockClearApiToken.mockResolvedValue({ storage: 'secure-store' })
             await createTodoistTokenStore().clear()
-            expect(mockClearApiToken).toHaveBeenCalled()
+            expect(mockClearApiToken).toHaveBeenCalledWith({ ref: undefined })
+        })
+
+        it('forwards a ref to clearApiToken', async () => {
+            mockClearApiToken.mockResolvedValue({ storage: 'secure-store' })
+            await createTodoistTokenStore().clear(USER_B.email)
+            expect(mockClearApiToken).toHaveBeenCalledWith({ ref: USER_B.email })
+        })
+    })
+
+    describe('list()', () => {
+        it('returns an empty array when nothing is stored', async () => {
+            mockReadConfig.mockResolvedValue({ users: [] })
+            expect(await createTodoistTokenStore().list()).toEqual([])
+        })
+
+        it('marks the only stored user as the default (implicit single-user fallback)', async () => {
+            mockReadConfig.mockResolvedValue({ users: [USER_A] })
+            expect(await createTodoistTokenStore().list()).toEqual([
+                { account: ACCOUNT_A, isDefault: true },
+            ])
+        })
+
+        it('marks the explicit defaultUser when multiple are stored', async () => {
+            mockReadConfig.mockResolvedValue({
+                users: [USER_A, USER_B],
+                user: { defaultUser: USER_B.id },
+            })
+            expect(await createTodoistTokenStore().list()).toEqual([
+                { account: ACCOUNT_A, isDefault: false },
+                { account: ACCOUNT_B, isDefault: true },
+            ])
+        })
+
+        it('marks none as default when multiple users are stored without an explicit default', async () => {
+            mockReadConfig.mockResolvedValue({ users: [USER_A, USER_B] })
+            expect(await createTodoistTokenStore().list()).toEqual([
+                { account: ACCOUNT_A, isDefault: false },
+                { account: ACCOUNT_B, isDefault: false },
+            ])
+        })
+    })
+
+    describe('setDefault()', () => {
+        it('delegates to setDefaultUserId', async () => {
+            await createTodoistTokenStore().setDefault(USER_B.email)
+            expect(mockSetDefaultUserId).toHaveBeenCalledWith(USER_B.email)
+        })
+
+        it('propagates UserNotFoundError when the ref does not match', async () => {
+            const error = new UserNotFoundError('nobody@example.com')
+            mockSetDefaultUserId.mockRejectedValueOnce(error)
+            await expect(createTodoistTokenStore().setDefault('nobody@example.com')).rejects.toBe(
+                error,
+            )
         })
     })
 })

--- a/src/lib/auth-store.ts
+++ b/src/lib/auth-store.ts
@@ -1,8 +1,9 @@
-import type { AuthAccount, TokenStore } from '@doist/cli-core/auth'
+import type { AccountRef, AuthAccount, TokenStore } from '@doist/cli-core/auth'
 import {
     clearApiToken,
     loadTokenForStoredUser,
     NoTokenError,
+    setDefaultUserId,
     type TokenStorageResult,
     TOKEN_ENV_VAR,
     upsertUser,
@@ -10,7 +11,7 @@ import {
 } from './auth.js'
 import { type AuthFlag, type AuthMode, readConfig, type StoredUser } from './config.js'
 import { SecureStoreUnavailableError } from './secure-store.js'
-import { getDefaultUser, getStoredUsers } from './users.js'
+import { findUserByRef, getDefaultUser, getStoredUsers } from './users.js'
 
 /**
  * Account shape stored by todoist-cli. Extends cli-core's `AuthAccount` with
@@ -95,23 +96,27 @@ export function createTodoistTokenStore(): TodoistTokenStore {
 
     return {
         /**
-         * Pure view of persisted state. Deliberately ignores the global
-         * `--user` selector (a CLI-invocation concern, not storage) and
-         * returns `null` when `TODOIST_API_TOKEN` is in play (env tokens
-         * don't represent a persisted account). When multiple accounts
-         * are stored without a default, returns `null` rather than
-         * throwing a selection error — the runtime caller can react to
-         * "no active persisted account" but shouldn't see CLI-arg errors
-         * leaking out of a store read.
+         * Pure view of persisted state. Returns `null` when `TODOIST_API_TOKEN`
+         * is in play (env tokens don't represent a persisted account). With
+         * `ref`, returns that specific stored account; without, returns the
+         * default-or-only account. A `ref` that does not match any stored
+         * account returns `null` so cli-core's resolver layer can translate
+         * the miss into a typed error without storage reads leaking CLI-arg
+         * errors.
          */
-        async active() {
+        async active(ref?: AccountRef) {
             if (process.env[TOKEN_ENV_VAR]) return null
 
             const config = await readConfig()
             const users = getStoredUsers(config)
             if (users.length === 0) return null
 
-            const target = getDefaultUser(config) ?? (users.length === 1 ? users[0] : null)
+            let target: StoredUser | null
+            if (ref !== undefined) {
+                target = findUserByRef(config, ref)?.user ?? null
+            } else {
+                target = getDefaultUser(config) ?? (users.length === 1 ? users[0] : null)
+            }
             if (!target) return null
 
             try {
@@ -134,8 +139,27 @@ export function createTodoistTokenStore(): TodoistTokenStore {
             lastStorageResult = result
         },
 
-        async clear() {
-            lastClearResult = await clearApiToken()
+        async clear(ref?: AccountRef) {
+            lastClearResult = await clearApiToken({ ref })
+        },
+
+        async list() {
+            const config = await readConfig()
+            const users = getStoredUsers(config)
+            if (users.length === 0) return []
+            const defaultUser = getDefaultUser(config)
+            const defaultId = defaultUser?.id ?? (users.length === 1 ? users[0].id : undefined)
+            return users.map((user) => ({
+                account: storedUserToAccount(user),
+                isDefault: user.id === defaultId,
+            }))
+        },
+
+        async setDefault(ref: AccountRef) {
+            // `setDefaultUserId` accepts any ref (id or email) and throws
+            // `UserNotFoundError` (a `CliError` with code `USER_NOT_FOUND`)
+            // when the ref does not match any stored account.
+            await setDefaultUserId(ref)
         },
 
         getLastStorageResult() {

--- a/src/lib/auth-store.ts
+++ b/src/lib/auth-store.ts
@@ -2,7 +2,6 @@ import type { AccountRef, AuthAccount, TokenStore } from '@doist/cli-core/auth'
 import {
     clearApiToken,
     loadTokenForStoredUser,
-    NoTokenError,
     setDefaultUserId,
     type TokenStorageResult,
     TOKEN_ENV_VAR,
@@ -10,8 +9,7 @@ import {
     type UpsertUserInput,
 } from './auth.js'
 import { type AuthFlag, type AuthMode, readConfig, type StoredUser } from './config.js'
-import { SecureStoreUnavailableError } from './secure-store.js'
-import { findUserByRef, getDefaultUser, getStoredUsers } from './users.js'
+import { findUserByRef, getEffectiveDefaultUser, getStoredUsers } from './users.js'
 
 /**
  * Account shape stored by todoist-cli. Extends cli-core's `AuthAccount` with
@@ -97,39 +95,28 @@ export function createTodoistTokenStore(): TodoistTokenStore {
     return {
         /**
          * Pure view of persisted state. Returns `null` when `TODOIST_API_TOKEN`
-         * is in play (env tokens don't represent a persisted account). With
-         * `ref`, returns that specific stored account; without, returns the
-         * default-or-only account. A `ref` that does not match any stored
-         * account returns `null` so cli-core's resolver layer can translate
-         * the miss into a typed error without storage reads leaking CLI-arg
-         * errors.
+         * is in play (env tokens don't represent a persisted account), when
+         * nothing is stored, or when `ref` does not match any stored account
+         * — cli-core's resolver layer translates the miss into a typed error.
+         * With `ref`, returns that specific stored account; without, returns
+         * the default-or-only account.
+         *
+         * Token-load failures (broken keyring, missing secret) propagate as
+         * typed errors once a user was matched — collapsing them to `null`
+         * would make a real account look like an unknown `ref` to cli-core.
          */
         async active(ref?: AccountRef) {
             if (process.env[TOKEN_ENV_VAR]) return null
 
             const config = await readConfig()
-            const users = getStoredUsers(config)
-            if (users.length === 0) return null
-
-            let target: StoredUser | null
-            if (ref !== undefined) {
-                target = findUserByRef(config, ref)?.user ?? null
-            } else {
-                target = getDefaultUser(config) ?? (users.length === 1 ? users[0] : null)
-            }
+            const target =
+                ref !== undefined
+                    ? (findUserByRef(config, ref)?.user ?? null)
+                    : getEffectiveDefaultUser(config)
             if (!target) return null
 
-            try {
-                const { token } = await loadTokenForStoredUser(target)
-                return { token, account: storedUserToAccount(target) }
-            } catch (error) {
-                // Token unreachable (no secret, keyring offline) — surface as
-                // "no active persisted account" so a `set()` retry can recover
-                // without a runtime caller having to special-case storage errors.
-                if (error instanceof NoTokenError) return null
-                if (error instanceof SecureStoreUnavailableError) return null
-                throw error
-            }
+            const { token } = await loadTokenForStoredUser(target)
+            return { token, account: storedUserToAccount(target) }
         },
 
         async set(account, token) {
@@ -147,8 +134,7 @@ export function createTodoistTokenStore(): TodoistTokenStore {
             const config = await readConfig()
             const users = getStoredUsers(config)
             if (users.length === 0) return []
-            const defaultUser = getDefaultUser(config)
-            const defaultId = defaultUser?.id ?? (users.length === 1 ? users[0].id : undefined)
+            const defaultId = getEffectiveDefaultUser(config)?.id
             return users.map((user) => ({
                 account: storedUserToAccount(user),
                 isDefault: user.id === defaultId,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -306,12 +306,18 @@ export async function clearApiToken(opts: { ref?: string } = {}): Promise<TokenS
     // No users stored yet — fall through to legacy logout only on a v1-shaped
     // config (no `users` key at all). Empty `users: []` is an already-clean
     // v2 install; treat it as a no-op rather than poking the legacy keyring.
+    //
+    // A `requestedRef` always wins over the legacy fallback: a caller asking
+    // for a specific account on a legacy install should see `USER_NOT_FOUND`,
+    // not have their legacy token silently wiped (matches `resolveActiveUser`
+    // above and prevents `td auth logout --user missing@x` from clearing the
+    // wrong credential).
     if (users.length === 0) {
-        if (!Array.isArray(config.users)) {
-            return clearLegacyToken(config)
-        }
         if (requestedRef) {
             throw new UserNotFoundError(requestedRef)
+        }
+        if (!Array.isArray(config.users)) {
+            return clearLegacyToken(config)
         }
         throw new NoTokenError()
     }

--- a/src/lib/global-args.test.ts
+++ b/src/lib/global-args.test.ts
@@ -11,7 +11,6 @@ import {
     parseGlobalArgs,
     resetGlobalArgs,
     shouldDisableSpinner,
-    stripUserFlag,
 } from './global-args.js'
 
 describe('parseGlobalArgs', () => {
@@ -82,37 +81,6 @@ describe('parseGlobalArgs', () => {
         })
         it('leaves --user at end of argv as undefined', () => {
             expect(parseGlobalArgs(['task', 'list', '--user']).user).toBeUndefined()
-        })
-    })
-
-    describe('stripUserFlag', () => {
-        it('removes --user <value>', () => {
-            expect(stripUserFlag(['task', 'list', '--user', 'a@b.c', '--json'])).toEqual([
-                'task',
-                'list',
-                '--json',
-            ])
-        })
-        it('removes --user=<value>', () => {
-            expect(stripUserFlag(['--user=12345', 'today'])).toEqual(['today'])
-        })
-        it('does not strip the next arg when it looks like a flag', () => {
-            // Mirrors parseGlobalArgs: keep --json intact so commander can
-            // surface a usage error on the bare --user.
-            expect(stripUserFlag(['--user', '--json', 'auth', 'status'])).toEqual([
-                '--json',
-                'auth',
-                'status',
-            ])
-        })
-        it('preserves args after --', () => {
-            expect(stripUserFlag(['task', 'list', '--', '--user', 'x'])).toEqual([
-                'task',
-                'list',
-                '--',
-                '--user',
-                'x',
-            ])
         })
     })
 

--- a/src/lib/global-args.ts
+++ b/src/lib/global-args.ts
@@ -131,36 +131,3 @@ export const shouldDisableSpinner = createSpinnerGate({
     envVar: 'TD_SPINNER',
     getArgs: store.get,
 })
-
-/**
- * Remove `--user <ref>` / `--user=<ref>` from an argv array so commander —
- * which has no global-option attachment — never sees the flag at subcommand
- * level. Returns a new array; the original is not mutated. Stops at the `--`
- * terminator so positional args after it are preserved verbatim.
- */
-export function stripUserFlag(argv: string[]): string[] {
-    const out: string[] = []
-    let stopped = false
-    for (let i = 0; i < argv.length; i++) {
-        const arg = argv[i]
-        if (stopped) {
-            out.push(arg)
-            continue
-        }
-        if (arg === '--') {
-            stopped = true
-            out.push(arg)
-            continue
-        }
-        if (arg === '--user') {
-            // Stays in lockstep with `parseTdLocalFlags` above.
-            if (i + 1 < argv.length && !argv[i + 1].startsWith('-')) i++
-            continue
-        }
-        if (arg.startsWith('--user=')) {
-            continue
-        }
-        out.push(arg)
-    }
-    return out
-}

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -77,6 +77,19 @@ export function getDefaultUser(config: Config): StoredUser | null {
 }
 
 /**
+ * The user that should be treated as the "default" when no `--user` ref is
+ * supplied: the explicitly-set default, or the sole stored user when only
+ * one exists. Returns `null` when no default can be inferred (empty store,
+ * or multiple users with no explicit default).
+ */
+export function getEffectiveDefaultUser(config: Config): StoredUser | null {
+    const explicit = getDefaultUser(config)
+    if (explicit) return explicit
+    const users = getStoredUsers(config)
+    return users.length === 1 ? users[0] : null
+}
+
+/**
  * Replace or append a user record. Returns a new config and whether the user
  * was already present (so callers can show "replaced" vs "added" messages).
  */


### PR DESCRIPTION
## Summary
- Bump `@doist/cli-core` from `0.10.0` → `0.12.0`, which reshapes `TokenStore<T>` as multi-user (`active(ref?)`, `clear(ref?)`, required `list()` + `setDefault(ref)`) and adds an exported `stripUserFlag` helper.
- Implement the new contract on `TodoistTokenStore` by wiring through todoist-cli's existing per-user primitives (`findUserByRef`, `getStoredUsers`, `getDefaultUser`, `setDefaultUserId`, `clearApiToken({ ref })`).
- Drop the local `stripUserFlag` implementation and its tests; import cli-core's instead. cli-core 0.12.0's `stripUserFlag` stops at the first positional, which matches the production pre-subcommand `--user` pattern in `src/index.ts` and lets commander's root-program `--user` option handle the post-subcommand case unchanged.

## Test plan
- [x] `npm run type-check` clean
- [x] `npm run check` clean
- [x] `npm test` — 1592 / 1592 pass (4 removed `stripUserFlag` tests now covered by cli-core)
- [x] `npm run build` succeeds
- [x] Smoke: `td task list --user scott@doist.com` works (post-subcommand `--user` still parsed by commander's root option)

🤖 Generated with [Claude Code](https://claude.com/claude-code)