### PR TITLE
feat(billing): add billing commands and billing OAuth scope

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -46,7 +46,7 @@ src/
 │  ├─ goal.ts             # Flat command with subcommand registry inside
 │  ├─ task/, project/, label/, comment/, section/, filter/,
 │  │  reminder/, workspace/, folder/, notification/, template/,
-│  │  backup/, apps/, stats/, completed/, auth/, settings/,
+│  │  backup/, apps/, billing/, stats/, completed/, auth/, settings/,
 │  │  config/, skill/, hc/, completion/, update/
 │  └─ *.test.ts           # Co-located tests
 ├─ lib/                   # Shared utilities. See catalog — don't reimplement.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ td auth login --read-only
 
 In read-only mode, commands that change Todoist data (create/update/delete/complete/move/archive, etc.) are blocked by the CLI.
 
+Some commands need opt-in OAuth scopes, requested via `--additional-scopes=<list>` (comma-separated):
+
+```bash
+td auth login --additional-scopes=app-management   # td apps ...
+td auth login --additional-scopes=backups           # td backup ...
+td auth login --additional-scopes=billing           # td billing ...
+```
+
+Run `td auth login --help` for the full list. When a command fails for lack of a scope, the error suggests a re-login command that preserves whichever flags were originally used.
+
 ### Alternative methods
 
 **Manual token:** Get your API token from [Todoist Settings > Integrations > Developer](https://todoist.com/app/settings/integrations/developer):

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@doist/cli-core": "0.21.0",
-        "@doist/todoist-sdk": "10.2.0",
+        "@doist/todoist-sdk": "10.3.0",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@doist/todoist-sdk": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.2.0.tgz",
-      "integrity": "sha512-nh0mT4xOM0UPhQg0hGLh5oy7xOlhw/qLCcuL+dnyQ9BfGTRGc5jL0Uf9ccDmyo8kPzU/Ag8UKfX7m/LJt55IMQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.3.0.tgz",
+      "integrity": "sha512-Nxovh0n7TYmfBbZiJLjaWfZGJrcG09tSO3MKmG8RgQGHMHBhkM0r1yCXpQWzXbuRQ8ZLD/0akg+4w0FosrFfOg==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "@doist/cli-core": "0.21.0",
-    "@doist/todoist-sdk": "10.2.0",
+    "@doist/todoist-sdk": "10.3.0",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -39,6 +39,7 @@ td auth login --additional-scopes=app-management
 td auth login --read-only --additional-scopes=app-management
 td auth login --additional-scopes=backups
 td auth login --read-only --additional-scopes=backups
+td auth login --additional-scopes=billing
 td auth login --additional-scopes=app-management,backups
 td auth login --callback-port 9000           # override the OAuth callback port
 td auth login --json                         # emit the new account record as JSON
@@ -58,6 +59,7 @@ Opt-in OAuth scopes are requested via `--additional-scopes=<list>` (comma-separa
 
 - `app-management` — adds the `dev:app_console` scope (manage your registered Todoist apps — rotate secrets, edit webhooks, etc.). Required by `td apps list` and `td apps view`.
 - `backups` — adds the `backups:read` scope (list and download Todoist backups). Required by `td backup list` and `td backup download`.
+- `billing` — adds the `billing:read_write` scope, or `billing:read` when combined with `--read-only` (view subscription, plan, and pricing). Required by `td billing` subcommands.
 
 Combine freely with `--read-only` to keep data access read-only while still granting an opt-in scope (e.g. `td auth login --read-only --additional-scopes=backups`). When a command fails for lack of a scope, the error suggests a re-login command that preserves whichever flags were originally used.
 
@@ -96,6 +98,7 @@ Resolution order: `--user <ref>` > `user.defaultUser` from config > the only sto
 - Account and tooling: `td stats`, `td settings ...`, `td config view`, `td user ...`, `td completion ...`, `td view <todoist-url>`, `td doctor`, `td update`, `td changelog`
 - Developer apps: `td apps list/view` (requires `td auth login --additional-scopes=app-management`)
 - Backups: `td backup list/download` (requires `td auth login --additional-scopes=backups`)
+- Billing: `td billing subscription/plan/prices/pricing` (requires `td auth login --additional-scopes=billing`)
 
 ## References
 
@@ -344,6 +347,19 @@ The `apps` command surface manages the user's registered Todoist developer apps 
 `td apps update <ref> --add-oauth-redirect <url>` appends an OAuth redirect URI to the app, and `--remove-oauth-redirect <url>` takes one off (requires `--yes` to actually mutate, like `td task delete`). The two flags are mutually exclusive — pass one at a time. The URI is validated before any API call: `https://<host>`, `http(s)://localhost[:port][/path]`, `http(s)://127.0.0.1[:port][/path]`, or a custom-scheme URI (e.g. `myapp://callback`) are accepted; `javascript`, `data`, `file`, `vbscript`, and `ftp` custom schemes are rejected. Removals skip validation so users can clean up legacy malformed URIs. Adding a URI already set on the app fails with `ALREADY_EXISTS`; removing a URI that isn't on the app exits 0 with a message and makes no API call. Supports `--dry-run` and `--json`.
 
 The OAuth `client_id` is **public** and always shown. The four sensitive credentials — client secret, verification token, test access token, distribution token — are **hidden by default**. In plain mode each of those lines renders a `(hidden — pass --include-secrets to reveal)` hint; in `--json` / `--ndjson` the `clientSecret`, `verificationToken`, `distributionToken`, and `testToken` keys are omitted from the payload entirely. With `--include-secrets`, the values are rendered / emitted normally — in that mode a non-existent test token reads as `(not created)`. Webhook configuration is always included when configured (callback URL, event list, version); a missing webhook renders as `(not configured)` in plain output and `null` in JSON.
+
+### Billing
+```bash
+td billing                       # subscription (default subcommand)
+td billing subscription --json
+td billing plan
+td billing prices
+td billing pricing --formatted
+```
+
+The `billing` command surface is **read-only** and requires the `billing` OAuth scope — re-run `td auth login --additional-scopes=billing` to grant it. A normal login grants `billing:read_write`; adding `--read-only` narrows it to `billing:read`. Either satisfies these read commands. Without the scope, calls fail with a `MISSING_SCOPE` error whose hint preserves any previously used flags. All subcommands accept `--json` / `--ndjson`, which dump the raw SDK payload verbatim.
+
+`td billing subscription` (the default subcommand) shows the current plan, status, activation method, expiration date, plan price, invoice credit balance, and billing-portal URLs when present. `td billing plan` shows Pro plan status, downgrade date, and the per-cycle price list. `td billing prices` lists available Pro and Teams prices by billing cycle. `td billing pricing` shows current and legacy pricing keyed by version; `--formatted` returns localized price strings instead of minor-unit numbers.
 
 ### Settings, Stats, And Utilities
 ```bash

--- a/src/commands/billing/billing.test.ts
+++ b/src/commands/billing/billing.test.ts
@@ -1,4 +1,3 @@
-import { TodoistRequestError } from '@doist/todoist-sdk'
 import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -10,85 +9,18 @@ vi.mock('../../lib/api/core.js', async (importOriginal) => {
     }
 })
 
-vi.mock('../../lib/auth.js', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('../../lib/auth.js')>()
-    return {
-        ...actual,
-        getAuthMetadata: vi.fn(),
-    }
-})
-
-import { getApi, wrapApiError } from '../../lib/api/core.js'
-import { getAuthMetadata } from '../../lib/auth.js'
-import { CliError } from '../../lib/errors.js'
+import { getApi } from '../../lib/api/core.js'
+import { fixtures } from '../../test-support/fixtures.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
 import { registerBillingCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
-const mockGetAuthMetadata = vi.mocked(getAuthMetadata)
 
 function createProgram() {
     const program = new Command()
     program.exitOverride()
     registerBillingCommand(program)
     return program
-}
-
-const SUBSCRIPTION = {
-    status: 'autorenew',
-    plan: 'pro',
-    expirationDate: '2026-12-31',
-    activationMethod: 'stripe',
-    planPrice: {
-        amount: '600',
-        rawAmount: 600,
-        currency: 'USD',
-        billingCycle: 'monthly',
-        taxBehavior: 'exclusive',
-    },
-    billingPortalUrl: 'https://billing.stripe.com/portal/abc',
-    billingPortalSwitchToAnnualUrl: null,
-    hasBillingPortal: true,
-    hasBillingPortalSwitchToAnnual: false,
-    invoiceCreditBalance: { usd: 0 },
-    hasSwitchLegacyToCurrent: false,
-}
-
-const PRO_PLAN_DETAILS = {
-    currentPlanStatus: 'Active',
-    downgradeAt: null,
-    priceList: [
-        {
-            billingCycle: 'monthly',
-            prices: [{ currency: 'USD', unitAmount: 600, taxBehavior: 'exclusive' }],
-        },
-    ],
-}
-
-const PRICES = {
-    pro: [
-        {
-            billingCycle: 'yearly',
-            prices: [{ currency: 'USD', unitAmount: 6000, taxBehavior: 'exclusive' }],
-        },
-    ],
-    teams: [
-        {
-            billingCycle: 'monthly',
-            prices: [{ currency: 'USD', unitAmount: 800, taxBehavior: 'inclusive' }],
-        },
-    ],
-}
-
-const PRICING = {
-    latestPro: 'v25',
-    latestBiz: 'v25',
-    sessionPro: 'v25',
-    sessionBiz: 'v25',
-    v25: {
-        pro: { usd: { monthly: 400, yearly: 2900 } },
-        biz: { usd: { monthly: 800, yearly: 7200 } },
-    },
 }
 
 describe('billing subscription', () => {
@@ -103,7 +35,7 @@ describe('billing subscription', () => {
     it('is the default subcommand and renders the subscription summary', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-        mockApi.getSubscriptionInfo.mockResolvedValue(SUBSCRIPTION)
+        mockApi.getSubscriptionInfo.mockResolvedValue(fixtures.billing.subscription)
 
         // No subcommand given → default subscription
         await program.parseAsync(['node', 'td', 'billing'])
@@ -114,7 +46,7 @@ describe('billing subscription', () => {
         expect(output).toContain('Status:             autorenew')
         expect(output).toContain('Activation:         stripe')
         expect(output).toContain('Expires:            2026-12-31')
-        expect(output).toContain('$6.00/mo')
+        expect(output).toContain('$6/mo')
         expect(output).toContain('https://billing.stripe.com/portal/abc')
         consoleSpy.mockRestore()
     })
@@ -122,25 +54,25 @@ describe('billing subscription', () => {
     it('outputs the raw payload with --json', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-        mockApi.getSubscriptionInfo.mockResolvedValue(SUBSCRIPTION)
+        mockApi.getSubscriptionInfo.mockResolvedValue(fixtures.billing.subscription)
 
         await program.parseAsync(['node', 'td', 'billing', 'subscription', '--json'])
 
         const output = consoleSpy.mock.calls[0][0] as string
-        expect(JSON.parse(output)).toEqual(SUBSCRIPTION)
+        expect(JSON.parse(output)).toEqual(fixtures.billing.subscription)
         consoleSpy.mockRestore()
     })
 
     it('outputs single-line JSON with --ndjson', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-        mockApi.getSubscriptionInfo.mockResolvedValue(SUBSCRIPTION)
+        mockApi.getSubscriptionInfo.mockResolvedValue(fixtures.billing.subscription)
 
         await program.parseAsync(['node', 'td', 'billing', 'subscription', '--ndjson'])
 
         const output = consoleSpy.mock.calls[0][0] as string
         expect(output).not.toContain('\n')
-        expect(JSON.parse(output)).toEqual(SUBSCRIPTION)
+        expect(JSON.parse(output)).toEqual(fixtures.billing.subscription)
         consoleSpy.mockRestore()
     })
 
@@ -148,7 +80,7 @@ describe('billing subscription', () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
         mockApi.getSubscriptionInfo.mockResolvedValue({
-            ...SUBSCRIPTION,
+            ...fixtures.billing.subscription,
             status: 'none',
             plan: 'free',
             expirationDate: null,
@@ -179,25 +111,27 @@ describe('billing plan', () => {
     it('renders pro plan details', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-        mockApi.getProPlanDetails.mockResolvedValue(PRO_PLAN_DETAILS)
+        mockApi.getProPlanDetails.mockResolvedValue(fixtures.billing.proPlanDetails)
 
         await program.parseAsync(['node', 'td', 'billing', 'plan'])
 
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('Status:             Active')
         expect(output).toContain('Downgrade at:       (none)')
-        expect(output).toContain('monthly: $6.00')
+        expect(output).toContain('monthly: $6')
         consoleSpy.mockRestore()
     })
 
     it('outputs the raw payload with --json', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-        mockApi.getProPlanDetails.mockResolvedValue(PRO_PLAN_DETAILS)
+        mockApi.getProPlanDetails.mockResolvedValue(fixtures.billing.proPlanDetails)
 
         await program.parseAsync(['node', 'td', 'billing', 'plan', '--json'])
 
-        expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toEqual(PRO_PLAN_DETAILS)
+        expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toEqual(
+            fixtures.billing.proPlanDetails,
+        )
         consoleSpy.mockRestore()
     })
 })
@@ -214,15 +148,15 @@ describe('billing prices', () => {
     it('renders pro and teams price listings', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-        mockApi.getPrices.mockResolvedValue(PRICES)
+        mockApi.getPrices.mockResolvedValue(fixtures.billing.prices)
 
         await program.parseAsync(['node', 'td', 'billing', 'prices'])
 
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('Pro')
-        expect(output).toContain('yearly: $60.00')
+        expect(output).toContain('yearly: $60')
         expect(output).toContain('Teams')
-        expect(output).toContain('monthly: $8.00')
+        expect(output).toContain('monthly: $8')
         consoleSpy.mockRestore()
     })
 })
@@ -239,7 +173,7 @@ describe('billing pricing', () => {
     it('formats minor-unit numbers as money and lists version entries', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-        mockApi.getPricing.mockResolvedValue(PRICING)
+        mockApi.getPricing.mockResolvedValue(fixtures.billing.pricing)
 
         await program.parseAsync(['node', 'td', 'billing', 'pricing'])
 
@@ -247,20 +181,14 @@ describe('billing pricing', () => {
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('Latest Pro:         v25')
         expect(output).toContain('v25')
-        expect(output).toContain('pro (USD): $4.00/mo, $29.00/yr')
+        expect(output).toContain('pro (USD): $4/mo, $29/yr')
         consoleSpy.mockRestore()
     })
 
     it('passes --formatted through and prints pre-formatted strings as-is', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-        mockApi.getPricing.mockResolvedValue({
-            latestPro: 'v25',
-            latestBiz: 'v25',
-            sessionPro: 'v25',
-            sessionBiz: 'v25',
-            v25: { pro: { usd: { monthly: '$4', yearly: '$29' } } },
-        })
+        mockApi.getPricing.mockResolvedValue(fixtures.billing.pricingFormatted)
 
         await program.parseAsync(['node', 'td', 'billing', 'pricing', '--formatted'])
 
@@ -268,45 +196,5 @@ describe('billing pricing', () => {
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('pro (USD): $4/mo, $29/yr')
         consoleSpy.mockRestore()
-    })
-})
-
-describe('billing wrapApiError → MISSING_SCOPE', () => {
-    function scopeError() {
-        return new TodoistRequestError('HTTP 403: Forbidden', 403, {
-            error: 'Insufficient Token scope',
-            error_tag: 'AUTH_INSUFFICIENT_TOKEN_SCOPE',
-        })
-    }
-
-    beforeEach(() => {
-        vi.clearAllMocks()
-        mockGetAuthMetadata.mockResolvedValue({ authMode: 'read-write', source: 'secure-store' })
-    })
-
-    it('emits the billing hint (read_write scope) for billing read methods', async () => {
-        for (const method of [
-            'getSubscriptionInfo',
-            'getProPlanDetails',
-            'getPrices',
-            'getPricing',
-        ]) {
-            const wrapped = (await wrapApiError(scopeError(), method)) as CliError
-            expect(wrapped.code).toBe('MISSING_SCOPE')
-            expect(wrapped.hints?.[0]).toContain('--additional-scopes=billing')
-            expect(wrapped.hints?.[0]).toContain('billing:read_write')
-        }
-    })
-
-    it('names billing:read and preserves --read-only for a read-only login', async () => {
-        mockGetAuthMetadata.mockResolvedValue({
-            authMode: 'read-only',
-            authFlags: ['read-only'],
-            source: 'secure-store',
-        })
-        const wrapped = (await wrapApiError(scopeError(), 'getSubscriptionInfo')) as CliError
-        expect(wrapped.hints?.[0]).toContain('--read-only --additional-scopes=billing')
-        expect(wrapped.hints?.[0]).toContain('billing:read')
-        expect(wrapped.hints?.[0]).not.toContain('billing:read_write')
     })
 })

--- a/src/commands/billing/billing.test.ts
+++ b/src/commands/billing/billing.test.ts
@@ -12,6 +12,7 @@ vi.mock('../../lib/api/core.js', async (importOriginal) => {
 import { getApi } from '../../lib/api/core.js'
 import { fixtures } from '../../test-support/fixtures.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { resolveLocale } from './format.js'
 import { registerBillingCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
@@ -30,6 +31,7 @@ describe('billing subscription', () => {
         vi.clearAllMocks()
         mockApi = createMockApi()
         mockGetApi.mockResolvedValue(mockApi)
+        mockApi.getUser.mockResolvedValue({ lang: 'en' })
     })
 
     it('is the default subcommand and renders the subscription summary', async () => {
@@ -41,6 +43,8 @@ describe('billing subscription', () => {
         await program.parseAsync(['node', 'td', 'billing'])
 
         expect(mockApi.getSubscriptionInfo).toHaveBeenCalledTimes(1)
+        // Human output resolves the user's locale for money formatting.
+        expect(mockApi.getUser).toHaveBeenCalledTimes(1)
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('Plan:               pro')
         expect(output).toContain('Status:             autorenew')
@@ -60,6 +64,8 @@ describe('billing subscription', () => {
 
         const output = consoleSpy.mock.calls[0][0] as string
         expect(JSON.parse(output)).toEqual(fixtures.billing.subscription)
+        // Machine output dumps the raw payload, so it must not pay for getUser.
+        expect(mockApi.getUser).not.toHaveBeenCalled()
         consoleSpy.mockRestore()
     })
 
@@ -106,6 +112,7 @@ describe('billing plan', () => {
         vi.clearAllMocks()
         mockApi = createMockApi()
         mockGetApi.mockResolvedValue(mockApi)
+        mockApi.getUser.mockResolvedValue({ lang: 'en' })
     })
 
     it('renders pro plan details', async () => {
@@ -143,6 +150,7 @@ describe('billing prices', () => {
         vi.clearAllMocks()
         mockApi = createMockApi()
         mockGetApi.mockResolvedValue(mockApi)
+        mockApi.getUser.mockResolvedValue({ lang: 'en' })
     })
 
     it('renders pro and teams price listings', async () => {
@@ -168,6 +176,7 @@ describe('billing pricing', () => {
         vi.clearAllMocks()
         mockApi = createMockApi()
         mockGetApi.mockResolvedValue(mockApi)
+        mockApi.getUser.mockResolvedValue({ lang: 'en' })
     })
 
     it('formats minor-unit numbers as money and lists version entries', async () => {
@@ -196,5 +205,25 @@ describe('billing pricing', () => {
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('pro (USD): $4/mo, $29/yr')
         consoleSpy.mockRestore()
+    })
+})
+
+describe('resolveLocale', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+    })
+
+    it('maps the user language to a BCP-47 tag (pt_BR → pt-BR)', async () => {
+        mockApi.getUser.mockResolvedValue({ lang: 'pt_BR' })
+        expect(await resolveLocale(mockApi, {})).toBe('pt-BR')
+    })
+
+    it('skips the getUser fetch for machine output', async () => {
+        expect(await resolveLocale(mockApi, { json: true })).toBeUndefined()
+        expect(await resolveLocale(mockApi, { ndjson: true })).toBeUndefined()
+        expect(mockApi.getUser).not.toHaveBeenCalled()
     })
 })

--- a/src/commands/billing/billing.test.ts
+++ b/src/commands/billing/billing.test.ts
@@ -1,0 +1,312 @@
+import { TodoistRequestError } from '@doist/todoist-sdk'
+import { Command } from 'commander'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../lib/api/core.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../lib/api/core.js')>()
+    return {
+        ...actual,
+        getApi: vi.fn(),
+    }
+})
+
+vi.mock('../../lib/auth.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../lib/auth.js')>()
+    return {
+        ...actual,
+        getAuthMetadata: vi.fn(),
+    }
+})
+
+import { getApi, wrapApiError } from '../../lib/api/core.js'
+import { getAuthMetadata } from '../../lib/auth.js'
+import { CliError } from '../../lib/errors.js'
+import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { registerBillingCommand } from './index.js'
+
+const mockGetApi = vi.mocked(getApi)
+const mockGetAuthMetadata = vi.mocked(getAuthMetadata)
+
+function createProgram() {
+    const program = new Command()
+    program.exitOverride()
+    registerBillingCommand(program)
+    return program
+}
+
+const SUBSCRIPTION = {
+    status: 'autorenew',
+    plan: 'pro',
+    expirationDate: '2026-12-31',
+    activationMethod: 'stripe',
+    planPrice: {
+        amount: '600',
+        rawAmount: 600,
+        currency: 'USD',
+        billingCycle: 'monthly',
+        taxBehavior: 'exclusive',
+    },
+    billingPortalUrl: 'https://billing.stripe.com/portal/abc',
+    billingPortalSwitchToAnnualUrl: null,
+    hasBillingPortal: true,
+    hasBillingPortalSwitchToAnnual: false,
+    invoiceCreditBalance: { usd: 0 },
+    hasSwitchLegacyToCurrent: false,
+}
+
+const PRO_PLAN_DETAILS = {
+    currentPlanStatus: 'Active',
+    downgradeAt: null,
+    priceList: [
+        {
+            billingCycle: 'monthly',
+            prices: [{ currency: 'USD', unitAmount: 600, taxBehavior: 'exclusive' }],
+        },
+    ],
+}
+
+const PRICES = {
+    pro: [
+        {
+            billingCycle: 'yearly',
+            prices: [{ currency: 'USD', unitAmount: 6000, taxBehavior: 'exclusive' }],
+        },
+    ],
+    teams: [
+        {
+            billingCycle: 'monthly',
+            prices: [{ currency: 'USD', unitAmount: 800, taxBehavior: 'inclusive' }],
+        },
+    ],
+}
+
+const PRICING = {
+    latestPro: 'v25',
+    latestBiz: 'v25',
+    sessionPro: 'v25',
+    sessionBiz: 'v25',
+    v25: {
+        pro: { usd: { monthly: 400, yearly: 2900 } },
+        biz: { usd: { monthly: 800, yearly: 7200 } },
+    },
+}
+
+describe('billing subscription', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+    })
+
+    it('is the default subcommand and renders the subscription summary', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getSubscriptionInfo.mockResolvedValue(SUBSCRIPTION)
+
+        // No subcommand given → default subscription
+        await program.parseAsync(['node', 'td', 'billing'])
+
+        expect(mockApi.getSubscriptionInfo).toHaveBeenCalledTimes(1)
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('Plan:               pro')
+        expect(output).toContain('Status:             autorenew')
+        expect(output).toContain('Activation:         stripe')
+        expect(output).toContain('Expires:            2026-12-31')
+        expect(output).toContain('$6.00/mo')
+        expect(output).toContain('https://billing.stripe.com/portal/abc')
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs the raw payload with --json', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getSubscriptionInfo.mockResolvedValue(SUBSCRIPTION)
+
+        await program.parseAsync(['node', 'td', 'billing', 'subscription', '--json'])
+
+        const output = consoleSpy.mock.calls[0][0] as string
+        expect(JSON.parse(output)).toEqual(SUBSCRIPTION)
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs single-line JSON with --ndjson', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getSubscriptionInfo.mockResolvedValue(SUBSCRIPTION)
+
+        await program.parseAsync(['node', 'td', 'billing', 'subscription', '--ndjson'])
+
+        const output = consoleSpy.mock.calls[0][0] as string
+        expect(output).not.toContain('\n')
+        expect(JSON.parse(output)).toEqual(SUBSCRIPTION)
+        consoleSpy.mockRestore()
+    })
+
+    it('renders a free plan with no price gracefully', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getSubscriptionInfo.mockResolvedValue({
+            ...SUBSCRIPTION,
+            status: 'none',
+            plan: 'free',
+            expirationDate: null,
+            planPrice: null,
+            invoiceCreditBalance: null,
+            hasBillingPortal: false,
+            billingPortalUrl: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'billing'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('Plan:               free')
+        expect(output).toContain('Price:              (none)')
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('billing plan', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+    })
+
+    it('renders pro plan details', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getProPlanDetails.mockResolvedValue(PRO_PLAN_DETAILS)
+
+        await program.parseAsync(['node', 'td', 'billing', 'plan'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('Status:             Active')
+        expect(output).toContain('Downgrade at:       (none)')
+        expect(output).toContain('monthly: $6.00')
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs the raw payload with --json', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getProPlanDetails.mockResolvedValue(PRO_PLAN_DETAILS)
+
+        await program.parseAsync(['node', 'td', 'billing', 'plan', '--json'])
+
+        expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toEqual(PRO_PLAN_DETAILS)
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('billing prices', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+    })
+
+    it('renders pro and teams price listings', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getPrices.mockResolvedValue(PRICES)
+
+        await program.parseAsync(['node', 'td', 'billing', 'prices'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('Pro')
+        expect(output).toContain('yearly: $60.00')
+        expect(output).toContain('Teams')
+        expect(output).toContain('monthly: $8.00')
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('billing pricing', () => {
+    let mockApi: MockApi
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = createMockApi()
+        mockGetApi.mockResolvedValue(mockApi)
+    })
+
+    it('formats minor-unit numbers as money and lists version entries', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getPricing.mockResolvedValue(PRICING)
+
+        await program.parseAsync(['node', 'td', 'billing', 'pricing'])
+
+        expect(mockApi.getPricing).toHaveBeenCalledWith({ formatted: undefined })
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('Latest Pro:         v25')
+        expect(output).toContain('v25')
+        expect(output).toContain('pro (USD): $4.00/mo, $29.00/yr')
+        consoleSpy.mockRestore()
+    })
+
+    it('passes --formatted through and prints pre-formatted strings as-is', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getPricing.mockResolvedValue({
+            latestPro: 'v25',
+            latestBiz: 'v25',
+            sessionPro: 'v25',
+            sessionBiz: 'v25',
+            v25: { pro: { usd: { monthly: '$4', yearly: '$29' } } },
+        })
+
+        await program.parseAsync(['node', 'td', 'billing', 'pricing', '--formatted'])
+
+        expect(mockApi.getPricing).toHaveBeenCalledWith({ formatted: true })
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('pro (USD): $4/mo, $29/yr')
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('billing wrapApiError → MISSING_SCOPE', () => {
+    function scopeError() {
+        return new TodoistRequestError('HTTP 403: Forbidden', 403, {
+            error: 'Insufficient Token scope',
+            error_tag: 'AUTH_INSUFFICIENT_TOKEN_SCOPE',
+        })
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockGetAuthMetadata.mockResolvedValue({ authMode: 'read-write', source: 'secure-store' })
+    })
+
+    it('emits the billing hint (read_write scope) for billing read methods', async () => {
+        for (const method of [
+            'getSubscriptionInfo',
+            'getProPlanDetails',
+            'getPrices',
+            'getPricing',
+        ]) {
+            const wrapped = (await wrapApiError(scopeError(), method)) as CliError
+            expect(wrapped.code).toBe('MISSING_SCOPE')
+            expect(wrapped.hints?.[0]).toContain('--additional-scopes=billing')
+            expect(wrapped.hints?.[0]).toContain('billing:read_write')
+        }
+    })
+
+    it('names billing:read and preserves --read-only for a read-only login', async () => {
+        mockGetAuthMetadata.mockResolvedValue({
+            authMode: 'read-only',
+            authFlags: ['read-only'],
+            source: 'secure-store',
+        })
+        const wrapped = (await wrapApiError(scopeError(), 'getSubscriptionInfo')) as CliError
+        expect(wrapped.hints?.[0]).toContain('--read-only --additional-scopes=billing')
+        expect(wrapped.hints?.[0]).toContain('billing:read')
+        expect(wrapped.hints?.[0]).not.toContain('billing:read_write')
+    })
+})

--- a/src/commands/billing/billing.test.ts
+++ b/src/commands/billing/billing.test.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../../lib/api/core.js')>()
@@ -24,11 +24,27 @@ function createProgram() {
     return program
 }
 
+// Manage the console.log spy via hooks so a failing assertion can't skip the
+// restore and leave console muted (and errors hidden) for later tests.
+let consoleSpy: ReturnType<typeof vi.spyOn>
+
+function consoleOutput(): string {
+    return consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+})
+
+afterEach(() => {
+    consoleSpy.mockRestore()
+})
+
 describe('billing subscription', () => {
     let mockApi: MockApi
 
     beforeEach(() => {
-        vi.clearAllMocks()
         mockApi = createMockApi()
         mockGetApi.mockResolvedValue(mockApi)
         mockApi.getUser.mockResolvedValue({ lang: 'en' })
@@ -36,7 +52,6 @@ describe('billing subscription', () => {
 
     it('is the default subcommand and renders the subscription summary', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
         mockApi.getSubscriptionInfo.mockResolvedValue(fixtures.billing.subscription)
 
         // No subcommand given → default subscription
@@ -45,19 +60,17 @@ describe('billing subscription', () => {
         expect(mockApi.getSubscriptionInfo).toHaveBeenCalledTimes(1)
         // Human output resolves the user's locale for money formatting.
         expect(mockApi.getUser).toHaveBeenCalledTimes(1)
-        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        const output = consoleOutput()
         expect(output).toContain('Plan:               pro')
         expect(output).toContain('Status:             autorenew')
         expect(output).toContain('Activation:         stripe')
         expect(output).toContain('Expires:            2026-12-31')
         expect(output).toContain('$6/mo')
         expect(output).toContain('https://billing.stripe.com/portal/abc')
-        consoleSpy.mockRestore()
     })
 
     it('outputs the raw payload with --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
         mockApi.getSubscriptionInfo.mockResolvedValue(fixtures.billing.subscription)
 
         await program.parseAsync(['node', 'td', 'billing', 'subscription', '--json'])
@@ -66,12 +79,10 @@ describe('billing subscription', () => {
         expect(JSON.parse(output)).toEqual(fixtures.billing.subscription)
         // Machine output dumps the raw payload, so it must not pay for getUser.
         expect(mockApi.getUser).not.toHaveBeenCalled()
-        consoleSpy.mockRestore()
     })
 
     it('outputs single-line JSON with --ndjson', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
         mockApi.getSubscriptionInfo.mockResolvedValue(fixtures.billing.subscription)
 
         await program.parseAsync(['node', 'td', 'billing', 'subscription', '--ndjson'])
@@ -79,12 +90,10 @@ describe('billing subscription', () => {
         const output = consoleSpy.mock.calls[0][0] as string
         expect(output).not.toContain('\n')
         expect(JSON.parse(output)).toEqual(fixtures.billing.subscription)
-        consoleSpy.mockRestore()
     })
 
     it('renders a free plan with no price gracefully', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
         mockApi.getSubscriptionInfo.mockResolvedValue({
             ...fixtures.billing.subscription,
             status: 'none',
@@ -98,10 +107,9 @@ describe('billing subscription', () => {
 
         await program.parseAsync(['node', 'td', 'billing'])
 
-        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        const output = consoleOutput()
         expect(output).toContain('Plan:               free')
         expect(output).toContain('Price:              (none)')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -109,7 +117,6 @@ describe('billing plan', () => {
     let mockApi: MockApi
 
     beforeEach(() => {
-        vi.clearAllMocks()
         mockApi = createMockApi()
         mockGetApi.mockResolvedValue(mockApi)
         mockApi.getUser.mockResolvedValue({ lang: 'en' })
@@ -117,21 +124,18 @@ describe('billing plan', () => {
 
     it('renders pro plan details', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
         mockApi.getProPlanDetails.mockResolvedValue(fixtures.billing.proPlanDetails)
 
         await program.parseAsync(['node', 'td', 'billing', 'plan'])
 
-        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        const output = consoleOutput()
         expect(output).toContain('Status:             Active')
         expect(output).toContain('Downgrade at:       (none)')
         expect(output).toContain('monthly: $6')
-        consoleSpy.mockRestore()
     })
 
     it('outputs the raw payload with --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
         mockApi.getProPlanDetails.mockResolvedValue(fixtures.billing.proPlanDetails)
 
         await program.parseAsync(['node', 'td', 'billing', 'plan', '--json'])
@@ -139,7 +143,6 @@ describe('billing plan', () => {
         expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toEqual(
             fixtures.billing.proPlanDetails,
         )
-        consoleSpy.mockRestore()
     })
 })
 
@@ -147,7 +150,6 @@ describe('billing prices', () => {
     let mockApi: MockApi
 
     beforeEach(() => {
-        vi.clearAllMocks()
         mockApi = createMockApi()
         mockGetApi.mockResolvedValue(mockApi)
         mockApi.getUser.mockResolvedValue({ lang: 'en' })
@@ -155,17 +157,15 @@ describe('billing prices', () => {
 
     it('renders pro and teams price listings', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
         mockApi.getPrices.mockResolvedValue(fixtures.billing.prices)
 
         await program.parseAsync(['node', 'td', 'billing', 'prices'])
 
-        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        const output = consoleOutput()
         expect(output).toContain('Pro')
         expect(output).toContain('yearly: $60')
         expect(output).toContain('Teams')
         expect(output).toContain('monthly: $8')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -173,7 +173,6 @@ describe('billing pricing', () => {
     let mockApi: MockApi
 
     beforeEach(() => {
-        vi.clearAllMocks()
         mockApi = createMockApi()
         mockGetApi.mockResolvedValue(mockApi)
         mockApi.getUser.mockResolvedValue({ lang: 'en' })
@@ -181,30 +180,39 @@ describe('billing pricing', () => {
 
     it('formats minor-unit numbers as money and lists version entries', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
         mockApi.getPricing.mockResolvedValue(fixtures.billing.pricing)
 
         await program.parseAsync(['node', 'td', 'billing', 'pricing'])
 
         expect(mockApi.getPricing).toHaveBeenCalledWith({ formatted: undefined })
-        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        const output = consoleOutput()
         expect(output).toContain('Latest Pro:         v25')
         expect(output).toContain('v25')
         expect(output).toContain('pro (USD): $4/mo, $29/yr')
-        consoleSpy.mockRestore()
     })
 
-    it('passes --formatted through and prints pre-formatted strings as-is', async () => {
+    it('does not render non-version metadata keys as pricing versions', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockApi.getPricing.mockResolvedValue(fixtures.billing.pricingWithMetadata)
+
+        await program.parseAsync(['node', 'td', 'billing', 'pricing'])
+
+        const output = consoleOutput()
+        expect(output).not.toContain('revision')
+        // The real version block is still rendered.
+        expect(output).toContain('pro (USD): $4/mo, $29/yr')
+    })
+
+    it('passes --formatted through, prints strings as-is, and skips the locale fetch', async () => {
+        const program = createProgram()
         mockApi.getPricing.mockResolvedValue(fixtures.billing.pricingFormatted)
 
         await program.parseAsync(['node', 'td', 'billing', 'pricing', '--formatted'])
 
         expect(mockApi.getPricing).toHaveBeenCalledWith({ formatted: true })
-        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
-        expect(output).toContain('pro (USD): $4/mo, $29/yr')
-        consoleSpy.mockRestore()
+        // Formatted strings ignore locale, so the getUser fetch is skipped.
+        expect(mockApi.getUser).not.toHaveBeenCalled()
+        expect(consoleOutput()).toContain('pro (USD): $4/mo, $29/yr')
     })
 })
 
@@ -212,7 +220,6 @@ describe('resolveLocale', () => {
     let mockApi: MockApi
 
     beforeEach(() => {
-        vi.clearAllMocks()
         mockApi = createMockApi()
     })
 

--- a/src/commands/billing/billing.test.ts
+++ b/src/commands/billing/billing.test.ts
@@ -1,5 +1,4 @@
-import { Command } from 'commander'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../../lib/api/core.js')>()
@@ -9,49 +8,30 @@ vi.mock('../../lib/api/core.js', async (importOriginal) => {
     }
 })
 
-import { getApi } from '../../lib/api/core.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { fixtures } from '../../test-support/fixtures.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { resolveLocale } from './format.js'
 import { registerBillingCommand } from './index.js'
 
-const mockGetApi = vi.mocked(getApi)
-
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerBillingCommand(program)
-    return program
+    return createTestProgram(registerBillingCommand)
 }
-
-// Manage the console.log spy via hooks so a failing assertion can't skip the
-// restore and leave console muted (and errors hidden) for later tests.
-let consoleSpy: ReturnType<typeof vi.spyOn>
-
-function consoleOutput(): string {
-    return consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
-}
-
-beforeEach(() => {
-    vi.clearAllMocks()
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-})
-
-afterEach(() => {
-    consoleSpy.mockRestore()
-})
 
 describe('billing subscription', () => {
     let mockApi: MockApi
 
     beforeEach(() => {
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        vi.clearAllMocks()
+        mockApi = setupApiMock()
         mockApi.getUser.mockResolvedValue({ lang: 'en' })
     })
 
     it('is the default subcommand and renders the subscription summary', async () => {
         const program = createProgram()
+        const consoleSpy = mockConsoleLog()
         mockApi.getSubscriptionInfo.mockResolvedValue(fixtures.billing.subscription)
 
         // No subcommand given → default subscription
@@ -60,7 +40,7 @@ describe('billing subscription', () => {
         expect(mockApi.getSubscriptionInfo).toHaveBeenCalledTimes(1)
         // Human output resolves the user's locale for money formatting.
         expect(mockApi.getUser).toHaveBeenCalledTimes(1)
-        const output = consoleOutput()
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('Plan:               pro')
         expect(output).toContain('Status:             autorenew')
         expect(output).toContain('Activation:         stripe')
@@ -71,6 +51,7 @@ describe('billing subscription', () => {
 
     it('outputs the raw payload with --json', async () => {
         const program = createProgram()
+        const consoleSpy = mockConsoleLog()
         mockApi.getSubscriptionInfo.mockResolvedValue(fixtures.billing.subscription)
 
         await program.parseAsync(['node', 'td', 'billing', 'subscription', '--json'])
@@ -83,6 +64,7 @@ describe('billing subscription', () => {
 
     it('outputs single-line JSON with --ndjson', async () => {
         const program = createProgram()
+        const consoleSpy = mockConsoleLog()
         mockApi.getSubscriptionInfo.mockResolvedValue(fixtures.billing.subscription)
 
         await program.parseAsync(['node', 'td', 'billing', 'subscription', '--ndjson'])
@@ -94,6 +76,7 @@ describe('billing subscription', () => {
 
     it('renders a free plan with no price gracefully', async () => {
         const program = createProgram()
+        const consoleSpy = mockConsoleLog()
         mockApi.getSubscriptionInfo.mockResolvedValue({
             ...fixtures.billing.subscription,
             status: 'none',
@@ -107,7 +90,7 @@ describe('billing subscription', () => {
 
         await program.parseAsync(['node', 'td', 'billing'])
 
-        const output = consoleOutput()
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('Plan:               free')
         expect(output).toContain('Price:              (none)')
     })
@@ -117,18 +100,19 @@ describe('billing plan', () => {
     let mockApi: MockApi
 
     beforeEach(() => {
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        vi.clearAllMocks()
+        mockApi = setupApiMock()
         mockApi.getUser.mockResolvedValue({ lang: 'en' })
     })
 
     it('renders pro plan details', async () => {
         const program = createProgram()
+        const consoleSpy = mockConsoleLog()
         mockApi.getProPlanDetails.mockResolvedValue(fixtures.billing.proPlanDetails)
 
         await program.parseAsync(['node', 'td', 'billing', 'plan'])
 
-        const output = consoleOutput()
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('Status:             Active')
         expect(output).toContain('Downgrade at:       (none)')
         expect(output).toContain('monthly: $6')
@@ -136,6 +120,7 @@ describe('billing plan', () => {
 
     it('outputs the raw payload with --json', async () => {
         const program = createProgram()
+        const consoleSpy = mockConsoleLog()
         mockApi.getProPlanDetails.mockResolvedValue(fixtures.billing.proPlanDetails)
 
         await program.parseAsync(['node', 'td', 'billing', 'plan', '--json'])
@@ -150,18 +135,19 @@ describe('billing prices', () => {
     let mockApi: MockApi
 
     beforeEach(() => {
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        vi.clearAllMocks()
+        mockApi = setupApiMock()
         mockApi.getUser.mockResolvedValue({ lang: 'en' })
     })
 
     it('renders pro and teams price listings', async () => {
         const program = createProgram()
+        const consoleSpy = mockConsoleLog()
         mockApi.getPrices.mockResolvedValue(fixtures.billing.prices)
 
         await program.parseAsync(['node', 'td', 'billing', 'prices'])
 
-        const output = consoleOutput()
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('Pro')
         expect(output).toContain('yearly: $60')
         expect(output).toContain('Teams')
@@ -173,19 +159,20 @@ describe('billing pricing', () => {
     let mockApi: MockApi
 
     beforeEach(() => {
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        vi.clearAllMocks()
+        mockApi = setupApiMock()
         mockApi.getUser.mockResolvedValue({ lang: 'en' })
     })
 
     it('formats minor-unit numbers as money and lists version entries', async () => {
         const program = createProgram()
+        const consoleSpy = mockConsoleLog()
         mockApi.getPricing.mockResolvedValue(fixtures.billing.pricing)
 
         await program.parseAsync(['node', 'td', 'billing', 'pricing'])
 
         expect(mockApi.getPricing).toHaveBeenCalledWith({ formatted: undefined })
-        const output = consoleOutput()
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('Latest Pro:         v25')
         expect(output).toContain('v25')
         expect(output).toContain('pro (USD): $4/mo, $29/yr')
@@ -193,11 +180,12 @@ describe('billing pricing', () => {
 
     it('does not render non-version metadata keys as pricing versions', async () => {
         const program = createProgram()
+        const consoleSpy = mockConsoleLog()
         mockApi.getPricing.mockResolvedValue(fixtures.billing.pricingWithMetadata)
 
         await program.parseAsync(['node', 'td', 'billing', 'pricing'])
 
-        const output = consoleOutput()
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).not.toContain('revision')
         // The real version block is still rendered.
         expect(output).toContain('pro (USD): $4/mo, $29/yr')
@@ -205,6 +193,7 @@ describe('billing pricing', () => {
 
     it('passes --formatted through, prints strings as-is, and skips the locale fetch', async () => {
         const program = createProgram()
+        const consoleSpy = mockConsoleLog()
         mockApi.getPricing.mockResolvedValue(fixtures.billing.pricingFormatted)
 
         await program.parseAsync(['node', 'td', 'billing', 'pricing', '--formatted'])
@@ -212,7 +201,8 @@ describe('billing pricing', () => {
         expect(mockApi.getPricing).toHaveBeenCalledWith({ formatted: true })
         // Formatted strings ignore locale, so the getUser fetch is skipped.
         expect(mockApi.getUser).not.toHaveBeenCalled()
-        expect(consoleOutput()).toContain('pro (USD): $4/mo, $29/yr')
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('pro (USD): $4/mo, $29/yr')
     })
 })
 
@@ -220,7 +210,8 @@ describe('resolveLocale', () => {
     let mockApi: MockApi
 
     beforeEach(() => {
-        mockApi = createMockApi()
+        vi.clearAllMocks()
+        mockApi = setupApiMock()
     })
 
     it('maps the user language to a BCP-47 tag (pt_BR → pt-BR)', async () => {

--- a/src/commands/billing/format.test.ts
+++ b/src/commands/billing/format.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { formatMoney } from './format.js'
+
+// Locale is pinned so assertions are deterministic regardless of the host.
+const LOCALE = 'en'
+
+describe('formatMoney', () => {
+    it('formats a 2-decimal currency (USD) from minor units', () => {
+        expect(formatMoney(600, 'USD', LOCALE)).toBe('$6')
+        expect(formatMoney(650, 'USD', LOCALE)).toBe('$6.50')
+    })
+
+    it('does not divide a 0-decimal currency (JPY) by 100', () => {
+        // The bug this guards: with a hard-coded /100, ¥700 would render as ¥7.
+        expect(formatMoney(700, 'JPY', LOCALE)).toBe('¥700')
+    })
+
+    it('uses 3 fraction digits for a 3-decimal currency (BHD)', () => {
+        // 1500 minor units = 1.5 BHD (divisor 1000), not 15.
+        const result = formatMoney(1500, 'BHD', LOCALE)
+        expect(result).toContain('1.5')
+        expect(result).not.toContain('15')
+    })
+
+    it('falls back to the raw minor-unit number for an invalid currency code', () => {
+        // A malformed (non 3-letter) code makes Intl throw; we degrade safely.
+        expect(formatMoney(500, 'US', LOCALE)).toBe('US 500')
+    })
+})

--- a/src/commands/billing/format.ts
+++ b/src/commands/billing/format.ts
@@ -1,8 +1,23 @@
-import type { PriceListing } from '@doist/todoist-sdk'
+import type { PriceListing, TodoistApi } from '@doist/todoist-sdk'
 import type { ViewOptions } from '../../lib/options.js'
 import { formatJson, formatNdjson } from '../../lib/output.js'
 
 export type BillingViewOptions = Pick<ViewOptions, 'json' | 'ndjson'>
+
+/**
+ * Resolve the locale used to format money, from the user's Todoist language
+ * (e.g. `pt_BR` → `pt-BR` for `Intl`). Only fetched for human output — machine
+ * output dumps the raw payload, so it skips the extra `getUser` call entirely.
+ * Returns `undefined` (the `Intl` default locale) when no fetch is made.
+ */
+export async function resolveLocale(
+    api: TodoistApi,
+    options: BillingViewOptions,
+): Promise<string | undefined> {
+    if (options.json || options.ndjson) return undefined
+    const user = await api.getUser()
+    return user.lang.replace(/_/g, '-')
+}
 
 /**
  * Emit the raw payload as JSON (`--json`) or NDJSON (`--ndjson`) and report
@@ -43,11 +58,15 @@ function currencyFractionDigits(currency: string): number {
     return digits
 }
 
-function getFormatter(currency: string, minimumFractionDigits: number): Intl.NumberFormat {
-    const key = `${currency}|${minimumFractionDigits}`
+function getFormatter(
+    locale: string | undefined,
+    currency: string,
+    minimumFractionDigits: number,
+): Intl.NumberFormat {
+    const key = `${locale ?? ''}|${currency}|${minimumFractionDigits}`
     let formatter = formatterCache.get(key)
     if (!formatter) {
-        formatter = new Intl.NumberFormat('en-US', {
+        formatter = new Intl.NumberFormat(locale, {
             style: 'currency',
             currency,
             minimumFractionDigits,
@@ -61,13 +80,14 @@ function getFormatter(currency: string, minimumFractionDigits: number): Intl.Num
  * Format an amount given in a currency's minor units (e.g. cents) as money.
  * Mirrors todoist-web's `formatPrice`: the divisor comes from the currency's
  * fraction digits (so JPY isn't rendered 100× too small), and whole amounts
- * drop the decimals (`$6`, not `$6.00`).
+ * drop the decimals (`$6`, not `$6.00`). `locale` comes from the user's
+ * Todoist language; `undefined` uses the `Intl` default.
  */
-export function formatMoney(minorUnits: number, currency: string): string {
+export function formatMoney(minorUnits: number, currency: string, locale?: string): string {
     const code = currency.toUpperCase()
     try {
         const major = minorUnits / 10 ** currencyFractionDigits(code)
-        return getFormatter(code, Number.isInteger(major) ? 0 : 2).format(major)
+        return getFormatter(locale, code, Number.isInteger(major) ? 0 : 2).format(major)
     } catch {
         // Unknown/invalid currency code — Intl throws. Fall back to the raw
         // minor-unit number rather than guessing a divisor.
@@ -76,7 +96,9 @@ export function formatMoney(minorUnits: number, currency: string): string {
 }
 
 /** Render a single billing-cycle price listing, e.g. `monthly: $6, €6`. */
-export function formatListing(listing: PriceListing): string {
-    const prices = listing.prices.map((p) => formatMoney(p.unitAmount, p.currency)).join(', ')
+export function formatListing(listing: PriceListing, locale?: string): string {
+    const prices = listing.prices
+        .map((p) => formatMoney(p.unitAmount, p.currency, locale))
+        .join(', ')
     return `${listing.billingCycle}: ${prices}`
 }

--- a/src/commands/billing/format.ts
+++ b/src/commands/billing/format.ts
@@ -1,0 +1,37 @@
+import type { PriceListing } from '@doist/todoist-sdk'
+
+export interface BillingViewOptions {
+    json?: boolean
+    ndjson?: boolean
+}
+
+/**
+ * Emit the raw payload as JSON (`--json`, indented) or NDJSON (`--ndjson`,
+ * single line) and report whether machine output was produced, so callers can
+ * early-return before rendering the human view. Billing responses are not
+ * `output.ts` entity types, so they're serialized verbatim.
+ */
+export function outputMachine(payload: unknown, options: BillingViewOptions): boolean {
+    if (!options.json && !options.ndjson) return false
+    const indent = options.json ? 2 : undefined
+    console.log(JSON.stringify(payload, null, indent))
+    return true
+}
+
+/** Format an amount given in a currency's minor units (e.g. cents) as money. */
+export function formatMoney(minorUnits: number, currency: string): string {
+    const code = currency.toUpperCase()
+    try {
+        return new Intl.NumberFormat('en-US', { style: 'currency', currency: code }).format(
+            minorUnits / 100,
+        )
+    } catch {
+        return `${code} ${(minorUnits / 100).toFixed(2)}`
+    }
+}
+
+/** Render a single billing-cycle price listing, e.g. `monthly: $6.00, €6.00`. */
+export function formatListing(listing: PriceListing): string {
+    const prices = listing.prices.map((p) => formatMoney(p.unitAmount, p.currency)).join(', ')
+    return `${listing.billingCycle}: ${prices}`
+}

--- a/src/commands/billing/format.ts
+++ b/src/commands/billing/format.ts
@@ -1,36 +1,81 @@
 import type { PriceListing } from '@doist/todoist-sdk'
+import type { ViewOptions } from '../../lib/options.js'
+import { formatJson, formatNdjson } from '../../lib/output.js'
 
-export interface BillingViewOptions {
-    json?: boolean
-    ndjson?: boolean
+export type BillingViewOptions = Pick<ViewOptions, 'json' | 'ndjson'>
+
+/**
+ * Emit the raw payload as JSON (`--json`) or NDJSON (`--ndjson`) and report
+ * whether machine output was produced, so callers can early-return before
+ * rendering the human view. Reuses the shared `output.ts` helpers so billing
+ * machine output matches the rest of the CLI.
+ */
+export function outputMachine(payload: object, options: BillingViewOptions): boolean {
+    if (options.json) {
+        console.log(formatJson(payload))
+        return true
+    }
+    if (options.ndjson) {
+        console.log(formatNdjson([payload]))
+        return true
+    }
+    return false
+}
+
+// `Intl.NumberFormat` construction is comparatively slow, and `formatMoney` is
+// called in nested loops (pricing), so cache per currency + decimal-mode.
+const formatterCache = new Map<string, Intl.NumberFormat>()
+const fractionDigitsCache = new Map<string, number>()
+
+/**
+ * Number of fraction digits the currency uses (USD→2, JPY→0, BHD→3). Doubles
+ * as the minor-unit exponent: the divisor to convert minor units to major is
+ * `10 ** fractionDigits`.
+ */
+function currencyFractionDigits(currency: string): number {
+    let digits = fractionDigitsCache.get(currency)
+    if (digits === undefined) {
+        digits =
+            new Intl.NumberFormat('en-US', { style: 'currency', currency }).resolvedOptions()
+                .maximumFractionDigits ?? 2
+        fractionDigitsCache.set(currency, digits)
+    }
+    return digits
+}
+
+function getFormatter(currency: string, minimumFractionDigits: number): Intl.NumberFormat {
+    const key = `${currency}|${minimumFractionDigits}`
+    let formatter = formatterCache.get(key)
+    if (!formatter) {
+        formatter = new Intl.NumberFormat('en-US', {
+            style: 'currency',
+            currency,
+            minimumFractionDigits,
+        })
+        formatterCache.set(key, formatter)
+    }
+    return formatter
 }
 
 /**
- * Emit the raw payload as JSON (`--json`, indented) or NDJSON (`--ndjson`,
- * single line) and report whether machine output was produced, so callers can
- * early-return before rendering the human view. Billing responses are not
- * `output.ts` entity types, so they're serialized verbatim.
+ * Format an amount given in a currency's minor units (e.g. cents) as money.
+ * Mirrors todoist-web's `formatPrice`: the divisor comes from the currency's
+ * fraction digits (so JPY isn't rendered 100× too small), and whole amounts
+ * drop the decimals (`$6`, not `$6.00`).
  */
-export function outputMachine(payload: unknown, options: BillingViewOptions): boolean {
-    if (!options.json && !options.ndjson) return false
-    const indent = options.json ? 2 : undefined
-    console.log(JSON.stringify(payload, null, indent))
-    return true
-}
-
-/** Format an amount given in a currency's minor units (e.g. cents) as money. */
 export function formatMoney(minorUnits: number, currency: string): string {
     const code = currency.toUpperCase()
     try {
-        return new Intl.NumberFormat('en-US', { style: 'currency', currency: code }).format(
-            minorUnits / 100,
-        )
+        const major = minorUnits / 10 ** currencyFractionDigits(code)
+        return getFormatter(code, Number.isInteger(major) ? 0 : 2).format(major)
     } catch {
-        return `${code} ${(minorUnits / 100).toFixed(2)}`
+        // Unknown/invalid currency code — Intl throws. Fall back to the raw
+        // minor-unit number rather than guessing a divisor.
+        return `${code} ${minorUnits}`
     }
 }
 
-/** Render a single billing-cycle price listing, e.g. `monthly: $6.00, €6.00`. */
+/** Render a single billing-cycle price listing, e.g. `monthly: $6, €6`. */
 export function formatListing(listing: PriceListing): string {
     const prices = listing.prices.map((p) => formatMoney(p.unitAmount, p.currency)).join(', ')
     return `${listing.billingCycle}: ${prices}`

--- a/src/commands/billing/index.ts
+++ b/src/commands/billing/index.ts
@@ -1,0 +1,53 @@
+import { Command } from 'commander'
+import { viewPlan } from './plan.js'
+import { viewPrices } from './prices.js'
+import { viewPricing } from './pricing.js'
+import { viewSubscription } from './subscription.js'
+
+export function registerBillingCommand(program: Command): void {
+    const billing = program
+        .command('billing')
+        .description('View billing and subscription information')
+        .addHelpText(
+            'after',
+            `
+Examples:
+  td billing
+  td billing subscription --json
+  td billing plan
+  td billing prices
+  td billing pricing --formatted
+
+Requires authenticating with the billing scope:
+  td auth login --additional-scopes=billing`,
+        )
+
+    billing
+        .command('subscription', { isDefault: true })
+        .description('Show your current subscription status and plan')
+        .option('--json', 'Output as JSON')
+        .option('--ndjson', 'Output as newline-delimited JSON')
+        .action(viewSubscription)
+
+    billing
+        .command('plan')
+        .description('Show your Pro plan and billing details')
+        .option('--json', 'Output as JSON')
+        .option('--ndjson', 'Output as newline-delimited JSON')
+        .action(viewPlan)
+
+    billing
+        .command('prices')
+        .description('Show available Pro and Teams prices')
+        .option('--json', 'Output as JSON')
+        .option('--ndjson', 'Output as newline-delimited JSON')
+        .action(viewPrices)
+
+    billing
+        .command('pricing')
+        .description('Show current and legacy pricing by version')
+        .option('--formatted', 'Return localized formatted price strings')
+        .option('--json', 'Output as JSON')
+        .option('--ndjson', 'Output as newline-delimited JSON')
+        .action(viewPricing)
+}

--- a/src/commands/billing/plan.ts
+++ b/src/commands/billing/plan.ts
@@ -1,0 +1,23 @@
+import chalk from 'chalk'
+import { getApi } from '../../lib/api/core.js'
+import { type BillingViewOptions, formatListing, outputMachine } from './format.js'
+
+export async function viewPlan(options: BillingViewOptions = {}): Promise<void> {
+    const api = await getApi()
+    const details = await api.getProPlanDetails()
+
+    if (outputMachine(details, options)) return
+
+    console.log(chalk.bold('Pro plan'))
+    console.log('')
+    console.log(`  Status:             ${details.currentPlanStatus}`)
+    console.log(`  Downgrade at:       ${details.downgradeAt ?? chalk.dim('(none)')}`)
+
+    if (details.priceList.length > 0) {
+        console.log('')
+        console.log(chalk.bold('  Prices'))
+        for (const listing of details.priceList) {
+            console.log(`    ${formatListing(listing)}`)
+        }
+    }
+}

--- a/src/commands/billing/plan.ts
+++ b/src/commands/billing/plan.ts
@@ -1,9 +1,10 @@
 import chalk from 'chalk'
 import { getApi } from '../../lib/api/core.js'
-import { type BillingViewOptions, formatListing, outputMachine } from './format.js'
+import { type BillingViewOptions, formatListing, outputMachine, resolveLocale } from './format.js'
 
 export async function viewPlan(options: BillingViewOptions = {}): Promise<void> {
     const api = await getApi()
+    const locale = await resolveLocale(api, options)
     const details = await api.getProPlanDetails()
 
     if (outputMachine(details, options)) return
@@ -17,7 +18,7 @@ export async function viewPlan(options: BillingViewOptions = {}): Promise<void> 
         console.log('')
         console.log(chalk.bold('  Prices'))
         for (const listing of details.priceList) {
-            console.log(`    ${formatListing(listing)}`)
+            console.log(`    ${formatListing(listing, locale)}`)
         }
     }
 }

--- a/src/commands/billing/prices.ts
+++ b/src/commands/billing/prices.ts
@@ -1,0 +1,22 @@
+import chalk from 'chalk'
+import { getApi } from '../../lib/api/core.js'
+import { type BillingViewOptions, formatListing, outputMachine } from './format.js'
+
+export async function viewPrices(options: BillingViewOptions = {}): Promise<void> {
+    const api = await getApi()
+    const prices = await api.getPrices()
+
+    if (outputMachine(prices, options)) return
+
+    console.log(chalk.bold('Prices'))
+    console.log('')
+    console.log(chalk.bold('  Pro'))
+    for (const listing of prices.pro) {
+        console.log(`    ${formatListing(listing)}`)
+    }
+    console.log('')
+    console.log(chalk.bold('  Teams'))
+    for (const listing of prices.teams) {
+        console.log(`    ${formatListing(listing)}`)
+    }
+}

--- a/src/commands/billing/prices.ts
+++ b/src/commands/billing/prices.ts
@@ -1,9 +1,10 @@
 import chalk from 'chalk'
 import { getApi } from '../../lib/api/core.js'
-import { type BillingViewOptions, formatListing, outputMachine } from './format.js'
+import { type BillingViewOptions, formatListing, outputMachine, resolveLocale } from './format.js'
 
 export async function viewPrices(options: BillingViewOptions = {}): Promise<void> {
     const api = await getApi()
+    const locale = await resolveLocale(api, options)
     const prices = await api.getPrices()
 
     if (outputMachine(prices, options)) return
@@ -12,11 +13,11 @@ export async function viewPrices(options: BillingViewOptions = {}): Promise<void
     console.log('')
     console.log(chalk.bold('  Pro'))
     for (const listing of prices.pro) {
-        console.log(`    ${formatListing(listing)}`)
+        console.log(`    ${formatListing(listing, locale)}`)
     }
     console.log('')
     console.log(chalk.bold('  Teams'))
     for (const listing of prices.teams) {
-        console.log(`    ${formatListing(listing)}`)
+        console.log(`    ${formatListing(listing, locale)}`)
     }
 }

--- a/src/commands/billing/pricing.ts
+++ b/src/commands/billing/pricing.ts
@@ -22,6 +22,10 @@ export async function viewPricing(options: PricingOptions = {}): Promise<void> {
     console.log(`  Session Business:   ${sessionBiz}`)
 
     for (const [version, plans] of Object.entries(versions)) {
+        // Version entries are objects (plan → currency → terms); skip any
+        // future top-level scalar metadata the SDK might add so it isn't
+        // rendered as if it were a pricing version.
+        if (typeof plans !== 'object' || plans === null) continue
         console.log('')
         console.log(chalk.bold(`  ${version}`))
         for (const [plan, currencies] of Object.entries(plans)) {

--- a/src/commands/billing/pricing.ts
+++ b/src/commands/billing/pricing.ts
@@ -1,0 +1,43 @@
+import chalk from 'chalk'
+import { getApi } from '../../lib/api/core.js'
+import { type BillingViewOptions, formatMoney, outputMachine } from './format.js'
+
+interface PricingOptions extends BillingViewOptions {
+    formatted?: boolean
+}
+
+export async function viewPricing(options: PricingOptions = {}): Promise<void> {
+    const api = await getApi()
+    const pricing = await api.getPricing({ formatted: options.formatted })
+
+    if (outputMachine(pricing, options)) return
+
+    const { latestPro, latestBiz, sessionPro, sessionBiz, ...versions } = pricing
+
+    console.log(chalk.bold('Pricing'))
+    console.log('')
+    console.log(`  Latest Pro:         ${latestPro}`)
+    console.log(`  Latest Business:    ${latestBiz}`)
+    console.log(`  Session Pro:        ${sessionPro}`)
+    console.log(`  Session Business:   ${sessionBiz}`)
+
+    for (const [version, plans] of Object.entries(versions)) {
+        console.log('')
+        console.log(chalk.bold(`  ${version}`))
+        for (const [plan, currencies] of Object.entries(plans)) {
+            for (const [currency, terms] of Object.entries(currencies)) {
+                const monthly = formatTerm(terms.monthly, currency)
+                const yearly = formatTerm(terms.yearly, currency)
+                console.log(`    ${plan} (${currency.toUpperCase()}): ${monthly}/mo, ${yearly}/yr`)
+            }
+        }
+    }
+}
+
+/**
+ * Pricing amounts are minor units (numbers) by default, or pre-formatted
+ * localized strings when the endpoint is called with `--formatted`.
+ */
+function formatTerm(value: number | string, currency: string): string {
+    return typeof value === 'number' ? formatMoney(value, currency) : value
+}

--- a/src/commands/billing/pricing.ts
+++ b/src/commands/billing/pricing.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import { getApi } from '../../lib/api/core.js'
-import { type BillingViewOptions, formatMoney, outputMachine } from './format.js'
+import { type BillingViewOptions, formatMoney, outputMachine, resolveLocale } from './format.js'
 
 interface PricingOptions extends BillingViewOptions {
     formatted?: boolean
@@ -8,6 +8,7 @@ interface PricingOptions extends BillingViewOptions {
 
 export async function viewPricing(options: PricingOptions = {}): Promise<void> {
     const api = await getApi()
+    const locale = await resolveLocale(api, options)
     const pricing = await api.getPricing({ formatted: options.formatted })
 
     if (outputMachine(pricing, options)) return
@@ -30,8 +31,8 @@ export async function viewPricing(options: PricingOptions = {}): Promise<void> {
         console.log(chalk.bold(`  ${version}`))
         for (const [plan, currencies] of Object.entries(plans)) {
             for (const [currency, terms] of Object.entries(currencies)) {
-                const monthly = formatTerm(terms.monthly, currency)
-                const yearly = formatTerm(terms.yearly, currency)
+                const monthly = formatTerm(terms.monthly, currency, locale)
+                const yearly = formatTerm(terms.yearly, currency, locale)
                 console.log(`    ${plan} (${currency.toUpperCase()}): ${monthly}/mo, ${yearly}/yr`)
             }
         }
@@ -42,6 +43,6 @@ export async function viewPricing(options: PricingOptions = {}): Promise<void> {
  * Pricing amounts are minor units (numbers) by default, or pre-formatted
  * localized strings when the endpoint is called with `--formatted`.
  */
-function formatTerm(value: number | string, currency: string): string {
-    return typeof value === 'number' ? formatMoney(value, currency) : value
+function formatTerm(value: number | string, currency: string, locale?: string): string {
+    return typeof value === 'number' ? formatMoney(value, currency, locale) : value
 }

--- a/src/commands/billing/pricing.ts
+++ b/src/commands/billing/pricing.ts
@@ -8,7 +8,9 @@ interface PricingOptions extends BillingViewOptions {
 
 export async function viewPricing(options: PricingOptions = {}): Promise<void> {
     const api = await getApi()
-    const locale = await resolveLocale(api, options)
+    // `--formatted` returns pre-localized strings, so locale (and the getUser
+    // fetch it costs) is only needed for the numeric formatting branch.
+    const locale = options.formatted ? undefined : await resolveLocale(api, options)
     const pricing = await api.getPricing({ formatted: options.formatted })
 
     if (outputMachine(pricing, options)) return
@@ -23,10 +25,10 @@ export async function viewPricing(options: PricingOptions = {}): Promise<void> {
     console.log(`  Session Business:   ${sessionBiz}`)
 
     for (const [version, plans] of Object.entries(versions)) {
-        // Version entries are objects (plan → currency → terms); skip any
-        // future top-level scalar metadata the SDK might add so it isn't
-        // rendered as if it were a pricing version.
-        if (typeof plans !== 'object' || plans === null) continue
+        // Only render keys that look like version pointers (v1, v25, …). Any
+        // other top-level field the SDK might add — scalar or object — is
+        // metadata, not a pricing version, and must not be rendered as one.
+        if (!/^v\d+/.test(version)) continue
         console.log('')
         console.log(chalk.bold(`  ${version}`))
         for (const [plan, currencies] of Object.entries(plans)) {

--- a/src/commands/billing/subscription.ts
+++ b/src/commands/billing/subscription.ts
@@ -1,9 +1,10 @@
 import chalk from 'chalk'
 import { getApi } from '../../lib/api/core.js'
-import { type BillingViewOptions, formatMoney, outputMachine } from './format.js'
+import { type BillingViewOptions, formatMoney, outputMachine, resolveLocale } from './format.js'
 
 export async function viewSubscription(options: BillingViewOptions = {}): Promise<void> {
     const api = await getApi()
+    const locale = await resolveLocale(api, options)
     const info = await api.getSubscriptionInfo()
 
     if (outputMachine(info, options)) return
@@ -18,14 +19,14 @@ export async function viewSubscription(options: BillingViewOptions = {}): Promis
     if (info.planPrice) {
         const { rawAmount, currency, billingCycle } = info.planPrice
         const cycle = billingCycle ? `/${billingCycle === 'yearly' ? 'yr' : 'mo'}` : ''
-        console.log(`  Price:              ${formatMoney(rawAmount, currency)}${cycle}`)
+        console.log(`  Price:              ${formatMoney(rawAmount, currency, locale)}${cycle}`)
     } else {
         console.log(`  Price:              ${chalk.dim('(none)')}`)
     }
 
     if (info.invoiceCreditBalance && Object.keys(info.invoiceCreditBalance).length > 0) {
         const credits = Object.entries(info.invoiceCreditBalance)
-            .map(([currency, amount]) => formatMoney(amount, currency))
+            .map(([currency, amount]) => formatMoney(amount, currency, locale))
             .join(', ')
         console.log(`  Credit balance:     ${credits}`)
     }

--- a/src/commands/billing/subscription.ts
+++ b/src/commands/billing/subscription.ts
@@ -1,0 +1,39 @@
+import chalk from 'chalk'
+import { getApi } from '../../lib/api/core.js'
+import { type BillingViewOptions, formatMoney, outputMachine } from './format.js'
+
+export async function viewSubscription(options: BillingViewOptions = {}): Promise<void> {
+    const api = await getApi()
+    const info = await api.getSubscriptionInfo()
+
+    if (outputMachine(info, options)) return
+
+    console.log(chalk.bold('Subscription'))
+    console.log('')
+    console.log(`  Plan:               ${info.plan}`)
+    console.log(`  Status:             ${info.status}`)
+    console.log(`  Activation:         ${info.activationMethod}`)
+    console.log(`  Expires:            ${info.expirationDate ?? chalk.dim('(none)')}`)
+
+    if (info.planPrice) {
+        const { rawAmount, currency, billingCycle } = info.planPrice
+        const cycle = billingCycle ? `/${billingCycle === 'yearly' ? 'yr' : 'mo'}` : ''
+        console.log(`  Price:              ${formatMoney(rawAmount, currency)}${cycle}`)
+    } else {
+        console.log(`  Price:              ${chalk.dim('(none)')}`)
+    }
+
+    if (info.invoiceCreditBalance && Object.keys(info.invoiceCreditBalance).length > 0) {
+        const credits = Object.entries(info.invoiceCreditBalance)
+            .map(([currency, amount]) => formatMoney(amount, currency))
+            .join(', ')
+        console.log(`  Credit balance:     ${credits}`)
+    }
+
+    if (info.hasBillingPortal && info.billingPortalUrl) {
+        console.log(`  Billing portal:     ${info.billingPortalUrl}`)
+    }
+    if (info.hasBillingPortalSwitchToAnnual && info.billingPortalSwitchToAnnualUrl) {
+        console.log(`  Switch to annual:   ${info.billingPortalSwitchToAnnualUrl}`)
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,10 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
         'Manage backups',
         async () => (await import('./commands/backup/index.js')).registerBackupCommand,
     ],
+    billing: [
+        'View billing and subscription information',
+        async () => (await import('./commands/billing/index.js')).registerBillingCommand,
+    ],
     stats: [
         'View productivity stats and karma',
         async () => (await import('./commands/stats/index.js')).registerStatsCommand,
@@ -257,6 +261,7 @@ if (process.argv[2] === 'completion-server') {
             // when output will be pretty-printed (not JSON/NDJSON/raw)
             const noMarkdownCommands = new Set([
                 'backup',
+                'billing',
                 'changelog',
                 'doctor',
                 'update',

--- a/src/lib/api/core.test.ts
+++ b/src/lib/api/core.test.ts
@@ -1,5 +1,19 @@
-import { describe, expect, it } from 'vitest'
-import { buildRescheduleDate } from './core.js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../auth.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../auth.js')>()
+    return {
+        ...actual,
+        getAuthMetadata: vi.fn(),
+    }
+})
+
+import { TodoistRequestError } from '@doist/todoist-sdk'
+import { getAuthMetadata } from '../auth.js'
+import { CliError } from '../errors.js'
+import { buildRescheduleDate, wrapApiError } from './core.js'
+
+const mockGetAuthMetadata = vi.mocked(getAuthMetadata)
 
 describe('buildRescheduleDate', () => {
     it('returns date as-is when input is date-only and task has no datetime', () => {
@@ -48,5 +62,57 @@ describe('buildRescheduleDate', () => {
             isRecurring: false,
         })
         expect(result).toBe('2026-03-20T10:00:00')
+    })
+})
+
+describe('wrapApiError → MISSING_SCOPE (billing)', () => {
+    function scopeError() {
+        return new TodoistRequestError('HTTP 403: Forbidden', 403, {
+            error: 'Insufficient Token scope',
+            error_tag: 'AUTH_INSUFFICIENT_TOKEN_SCOPE',
+        })
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockGetAuthMetadata.mockResolvedValue({ authMode: 'read-write', source: 'secure-store' })
+    })
+
+    it('emits the billing hint (read_write scope) for billing read methods', async () => {
+        for (const method of [
+            'getSubscriptionInfo',
+            'getProPlanDetails',
+            'getPrices',
+            'getPricing',
+        ]) {
+            const wrapped = (await wrapApiError(scopeError(), method)) as CliError
+            expect(wrapped.code).toBe('MISSING_SCOPE')
+            expect(wrapped.hints?.[0]).toContain('--additional-scopes=billing')
+            expect(wrapped.hints?.[0]).toContain('billing:read_write')
+        }
+    })
+
+    it('names billing:read and preserves --read-only for a read-only login', async () => {
+        mockGetAuthMetadata.mockResolvedValue({
+            authMode: 'read-only',
+            authFlags: ['read-only'],
+            source: 'secure-store',
+        })
+        const wrapped = (await wrapApiError(scopeError(), 'getSubscriptionInfo')) as CliError
+        expect(wrapped.hints?.[0]).toContain('--read-only --additional-scopes=billing')
+        expect(wrapped.hints?.[0]).toContain('billing:read')
+        expect(wrapped.hints?.[0]).not.toContain('billing:read_write')
+    })
+
+    it('names billing:read for migrated read-only configs with no auth_flags', async () => {
+        mockGetAuthMetadata.mockResolvedValue({
+            authMode: 'read-only',
+            authFlags: undefined,
+            source: 'config-file',
+        })
+        const wrapped = (await wrapApiError(scopeError(), 'getSubscriptionInfo')) as CliError
+        expect(wrapped.hints?.[0]).toContain('--read-only --additional-scopes=billing')
+        expect(wrapped.hints?.[0]).toContain('billing:read')
+        expect(wrapped.hints?.[0]).not.toContain('billing:read_write')
     })
 })

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -212,6 +212,10 @@ const METHOD_REQUIRED_FLAG: Record<string, AdditionalScopeFlag> = {
     getAppWebhook: 'app-management',
     getBackups: 'backups',
     downloadBackup: 'backups',
+    getSubscriptionInfo: 'billing',
+    getProPlanDetails: 'billing',
+    getPrices: 'billing',
+    getPricing: 'billing',
 }
 
 const STANDARD_REMEDIATION =
@@ -224,7 +228,8 @@ async function getScopeRemediation(methodName: string | undefined): Promise<stri
     }
     const metadata = await getAuthMetadata()
     const command = buildReloginCommand(metadata, requiredFlag)
-    return `This command requires the ${oauthScopeFor(requiredFlag)} scope. Re-run \`${command}\` to grant it.`
+    const scope = oauthScopeFor(requiredFlag, metadata.authMode === 'read-only')
+    return `This command requires the ${scope} scope. Re-run \`${command}\` to grant it.`
 }
 
 export async function wrapApiError(error: unknown, methodName?: string): Promise<Error> {

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -109,6 +109,12 @@ const API_SPINNER_MESSAGES: Record<string, { text: string; color?: 'blue' | 'gre
         getAppDistributionToken: { text: 'Loading app...', color: 'blue' },
         getAppWebhook: { text: 'Loading app...', color: 'blue' },
         updateApp: { text: 'Updating app...', color: 'yellow' },
+        // Billing — all billing reads share one label so a command that also
+        // fetches the user (for locale) reads as a single spinner.
+        getSubscriptionInfo: { text: 'Loading billing...', color: 'blue' },
+        getProPlanDetails: { text: 'Loading billing...', color: 'blue' },
+        getPrices: { text: 'Loading billing...', color: 'blue' },
+        getPricing: { text: 'Loading billing...', color: 'blue' },
         // Folders
         getFolders: { text: 'Loading folders...', color: 'blue' },
         getFolder: { text: 'Loading folder...', color: 'blue' },

--- a/src/lib/auth-flags.test.ts
+++ b/src/lib/auth-flags.test.ts
@@ -29,6 +29,15 @@ describe('buildReloginCommand', () => {
         )
     })
 
+    it('honours a read-only authMode even when authFlags is unset (migrated v1 config)', () => {
+        expect(
+            buildReloginCommand(
+                metadata({ authMode: 'read-only', authFlags: undefined }),
+                'billing',
+            ),
+        ).toBe('td auth login --read-only --additional-scopes=billing')
+    })
+
     it('does not duplicate the required flag if it is already present', () => {
         expect(buildReloginCommand(metadata({ authFlags: ['backups'] }), 'backups')).toBe(
             'td auth login --additional-scopes=backups',

--- a/src/lib/auth-flags.ts
+++ b/src/lib/auth-flags.ts
@@ -12,10 +12,14 @@ import { AUTH_FLAG_ORDER, type AuthFlag } from './config.js'
  *
  * When `metadata.authFlags` is missing (older configs, env-var tokens,
  * manual `td auth token` logins) we treat it as "no flags" — the base login.
+ * We still honour a read-only `authMode` even when `auth_flags` is unset
+ * (migrated v1 configs), so the suggested command keeps the user read-only
+ * rather than silently widening them to read-write.
  */
 export function buildReloginCommand(metadata: AuthMetadata, requiredFlag: AuthFlag): string {
     const existing = metadata.authFlags ?? []
     const merged = new Set<AuthFlag>([...existing, requiredFlag])
+    if (metadata.authMode === 'read-only') merged.add('read-only')
     const orderedFlags = AUTH_FLAG_ORDER.filter((flag) => merged.has(flag))
     const parts = ['td auth login']
     if (orderedFlags.includes('read-only')) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -41,7 +41,7 @@ export interface UserConfig {
  * a new flag only requires appending it here and wiring it into the login
  * command; everything downstream stays consistent.
  */
-export const AUTH_FLAG_ORDER = ['read-only', 'app-management', 'backups'] as const
+export const AUTH_FLAG_ORDER = ['read-only', 'app-management', 'backups', 'billing'] as const
 export type AuthFlag = (typeof AUTH_FLAG_ORDER)[number]
 
 /**

--- a/src/lib/oauth-scopes.test.ts
+++ b/src/lib/oauth-scopes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { CliError } from './errors.js'
-import { formatScopesHelp, parseScopesOption } from './oauth-scopes.js'
+import { formatScopesHelp, parseScopesOption, resolveAuthScope } from './oauth-scopes.js'
 
 describe('parseScopesOption', () => {
     it('parses a single scope', () => {
@@ -9,6 +9,10 @@ describe('parseScopesOption', () => {
 
     it('parses multiple comma-separated scopes', () => {
         expect(parseScopesOption('app-management,backups')).toEqual(['app-management', 'backups'])
+    })
+
+    it('parses the billing scope', () => {
+        expect(parseScopesOption('billing')).toEqual(['billing'])
     })
 
     it('trims whitespace around entries', () => {
@@ -88,5 +92,31 @@ describe('formatScopesHelp', () => {
         expect(help).toContain('--additional-scopes=app-management')
         expect(help).toContain('--additional-scopes=backups')
         expect(help).toContain('--additional-scopes=app-management,backups')
+    })
+
+    it('lists the billing scope', () => {
+        expect(formatScopesHelp()).toContain('billing')
+    })
+})
+
+describe('resolveAuthScope', () => {
+    it('grants billing:read_write by default', () => {
+        const scope = resolveAuthScope({ additionalScopes: ['billing'] })
+        expect(scope).toContain('data:read_write')
+        expect(scope).toContain('billing:read_write')
+    })
+
+    it('narrows billing to billing:read under --read-only', () => {
+        const scope = resolveAuthScope({ readOnly: true, additionalScopes: ['billing'] })
+        expect(scope).toContain('data:read')
+        expect(scope).toContain('billing:read')
+        expect(scope).not.toContain('billing:read_write')
+    })
+
+    it('leaves scopes without a read-only variant unchanged', () => {
+        // app-management has no readOnlyScope, so --read-only must not alter it.
+        expect(
+            resolveAuthScope({ readOnly: true, additionalScopes: ['app-management'] }),
+        ).toContain('dev:app_console')
     })
 })

--- a/src/lib/oauth-scopes.test.ts
+++ b/src/lib/oauth-scopes.test.ts
@@ -119,4 +119,22 @@ describe('resolveAuthScope', () => {
             resolveAuthScope({ readOnly: true, additionalScopes: ['app-management'] }),
         ).toContain('dev:app_console')
     })
+
+    it('composes a mixed read-only scope set in canonical order', () => {
+        // The higher-value case: --read-only --additional-scopes=app-management,billing.
+        // parseScopesOption canonicalises the order; resolveAuthScope must then
+        // emit the read-only base + each scope's read-only variant where it has one.
+        const flags = parseScopesOption('billing,app-management')
+        expect(flags).toEqual(['app-management', 'billing'])
+        expect(resolveAuthScope({ readOnly: true, additionalScopes: flags })).toBe(
+            'data:read,dev:app_console,billing:read',
+        )
+    })
+
+    it('composes the same mixed set as read-write by default', () => {
+        const flags = parseScopesOption('billing,app-management')
+        expect(resolveAuthScope({ additionalScopes: flags })).toBe(
+            'data:read_write,data:delete,project:delete,dev:app_console,billing:read_write',
+        )
+    })
 })

--- a/src/lib/oauth-scopes.ts
+++ b/src/lib/oauth-scopes.ts
@@ -19,7 +19,7 @@ export type AuthScopeOptions = {
 export function resolveAuthScope(options: AuthScopeOptions): string {
     const parts = [options.readOnly ? READ_ONLY_SCOPES : READ_WRITE_SCOPES]
     for (const scope of options.additionalScopes ?? []) {
-        parts.push(oauthScopeFor(scope))
+        parts.push(oauthScopeFor(scope, options.readOnly))
     }
     return parts.join(',')
 }
@@ -36,6 +36,13 @@ export interface ScopeDefinition {
     readonly flag: AdditionalScopeFlag
     /** Raw OAuth scope string sent to the Todoist authorize endpoint. */
     readonly oauthScope: string
+    /**
+     * Scope to request instead of `oauthScope` when the login is `--read-only`.
+     * Lets a single flag map to a read-write grant by default and a narrower
+     * read grant under `--read-only` (e.g. billing). Omit when the scope does
+     * not vary by mode.
+     */
+    readonly readOnlyScope?: string
     /** One-line summary shown in `td auth login --help`. */
     readonly summary: string
 }
@@ -57,6 +64,12 @@ export const ADDITIONAL_SCOPES: readonly ScopeDefinition[] = [
         oauthScope: 'backups:read',
         summary: 'List and download your Todoist backups.',
     },
+    {
+        flag: 'billing',
+        oauthScope: 'billing:read_write',
+        readOnlyScope: 'billing:read',
+        summary: 'View your billing and subscription information.',
+    },
 ]
 
 const ADDITIONAL_SCOPE_FLAGS: ReadonlySet<AdditionalScopeFlag> = new Set(
@@ -67,13 +80,13 @@ export function isAdditionalScopeFlag(value: string): value is AdditionalScopeFl
     return ADDITIONAL_SCOPE_FLAGS.has(value as AdditionalScopeFlag)
 }
 
-export function oauthScopeFor(flag: AdditionalScopeFlag): string {
+export function oauthScopeFor(flag: AdditionalScopeFlag, readOnly = false): string {
     const def = ADDITIONAL_SCOPES.find((s) => s.flag === flag)
     if (!def) {
         // Unreachable — the AdditionalScopeFlag type is derived from ADDITIONAL_SCOPES.
         throw new Error(`Unknown additional scope: ${flag}`)
     }
-    return def.oauthScope
+    return readOnly && def.readOnlyScope ? def.readOnlyScope : def.oauthScope
 }
 
 /**
@@ -150,6 +163,7 @@ Examples:
   td auth login
   td auth login --read-only
   td auth login --additional-scopes=app-management
+  td auth login --additional-scopes=billing
   td auth login --read-only --additional-scopes=backups
   td auth login --additional-scopes=app-management,backups`
 }

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -88,6 +88,16 @@ describe('permissions', () => {
         expect(isMutatingApiMethod('sync')).toBe(false)
     })
 
+    it('treats billing read methods as non-mutating', () => {
+        // getSubscriptionInfo is a POST but read-only — it must be on the
+        // allowlist so the proxy never routes it through ensureWriteAllowed and
+        // blocks it under a data:read token.
+        expect(isMutatingApiMethod('getSubscriptionInfo')).toBe(false)
+        expect(isMutatingApiMethod('getProPlanDetails')).toBe(false)
+        expect(isMutatingApiMethod('getPrices')).toBe(false)
+        expect(isMutatingApiMethod('getPricing')).toBe(false)
+    })
+
     it('defaults to mutating for unknown methods', () => {
         expect(isMutatingApiMethod('brandNewApiMethod')).toBe(true)
     })

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -74,6 +74,12 @@ const KNOWN_SAFE_API_METHODS = new Set([
     'getAppTestToken',
     'getAppDistributionToken',
     'getAppWebhook',
+    // Billing (gated by billing:read / billing:read_write scope). getSubscriptionInfo
+    // is a POST but read-only, so it must be listed explicitly.
+    'getSubscriptionInfo',
+    'getProPlanDetails',
+    'getPrices',
+    'getPricing',
     // Folders
     'getFolders',
     'getFolder',

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -35,6 +35,7 @@ td auth login --additional-scopes=app-management
 td auth login --read-only --additional-scopes=app-management
 td auth login --additional-scopes=backups
 td auth login --read-only --additional-scopes=backups
+td auth login --additional-scopes=billing
 td auth login --additional-scopes=app-management,backups
 td auth login --callback-port 9000           # override the OAuth callback port
 td auth login --json                         # emit the new account record as JSON
@@ -54,6 +55,7 @@ Opt-in OAuth scopes are requested via \`--additional-scopes=<list>\` (comma-sepa
 
 - \`app-management\` — adds the \`dev:app_console\` scope (manage your registered Todoist apps — rotate secrets, edit webhooks, etc.). Required by \`td apps list\` and \`td apps view\`.
 - \`backups\` — adds the \`backups:read\` scope (list and download Todoist backups). Required by \`td backup list\` and \`td backup download\`.
+- \`billing\` — adds the \`billing:read_write\` scope, or \`billing:read\` when combined with \`--read-only\` (view subscription, plan, and pricing). Required by \`td billing\` subcommands.
 
 Combine freely with \`--read-only\` to keep data access read-only while still granting an opt-in scope (e.g. \`td auth login --read-only --additional-scopes=backups\`). When a command fails for lack of a scope, the error suggests a re-login command that preserves whichever flags were originally used.
 
@@ -92,6 +94,7 @@ Resolution order: \`--user <ref>\` > \`user.defaultUser\` from config > the only
 - Account and tooling: \`td stats\`, \`td settings ...\`, \`td config view\`, \`td user ...\`, \`td completion ...\`, \`td view <todoist-url>\`, \`td doctor\`, \`td update\`, \`td changelog\`
 - Developer apps: \`td apps list/view\` (requires \`td auth login --additional-scopes=app-management\`)
 - Backups: \`td backup list/download\` (requires \`td auth login --additional-scopes=backups\`)
+- Billing: \`td billing subscription/plan/prices/pricing\` (requires \`td auth login --additional-scopes=billing\`)
 
 ## References
 
@@ -340,6 +343,19 @@ The \`apps\` command surface manages the user's registered Todoist developer app
 \`td apps update <ref> --add-oauth-redirect <url>\` appends an OAuth redirect URI to the app, and \`--remove-oauth-redirect <url>\` takes one off (requires \`--yes\` to actually mutate, like \`td task delete\`). The two flags are mutually exclusive — pass one at a time. The URI is validated before any API call: \`https://<host>\`, \`http(s)://localhost[:port][/path]\`, \`http(s)://127.0.0.1[:port][/path]\`, or a custom-scheme URI (e.g. \`myapp://callback\`) are accepted; \`javascript\`, \`data\`, \`file\`, \`vbscript\`, and \`ftp\` custom schemes are rejected. Removals skip validation so users can clean up legacy malformed URIs. Adding a URI already set on the app fails with \`ALREADY_EXISTS\`; removing a URI that isn't on the app exits 0 with a message and makes no API call. Supports \`--dry-run\` and \`--json\`.
 
 The OAuth \`client_id\` is **public** and always shown. The four sensitive credentials — client secret, verification token, test access token, distribution token — are **hidden by default**. In plain mode each of those lines renders a \`(hidden — pass --include-secrets to reveal)\` hint; in \`--json\` / \`--ndjson\` the \`clientSecret\`, \`verificationToken\`, \`distributionToken\`, and \`testToken\` keys are omitted from the payload entirely. With \`--include-secrets\`, the values are rendered / emitted normally — in that mode a non-existent test token reads as \`(not created)\`. Webhook configuration is always included when configured (callback URL, event list, version); a missing webhook renders as \`(not configured)\` in plain output and \`null\` in JSON.
+
+### Billing
+\`\`\`bash
+td billing                       # subscription (default subcommand)
+td billing subscription --json
+td billing plan
+td billing prices
+td billing pricing --formatted
+\`\`\`
+
+The \`billing\` command surface is **read-only** and requires the \`billing\` OAuth scope — re-run \`td auth login --additional-scopes=billing\` to grant it. A normal login grants \`billing:read_write\`; adding \`--read-only\` narrows it to \`billing:read\`. Either satisfies these read commands. Without the scope, calls fail with a \`MISSING_SCOPE\` error whose hint preserves any previously used flags. All subcommands accept \`--json\` / \`--ndjson\`, which dump the raw SDK payload verbatim.
+
+\`td billing subscription\` (the default subcommand) shows the current plan, status, activation method, expiration date, plan price, invoice credit balance, and billing-portal URLs when present. \`td billing plan\` shows Pro plan status, downgrade date, and the per-cycle price list. \`td billing prices\` lists available Pro and Teams prices by billing cycle. \`td billing pricing\` shows current and legacy pricing keyed by version; \`--formatted\` returns localized price strings instead of minor-unit numbers.
 
 ### Settings, Stats, And Utilities
 \`\`\`bash

--- a/src/test-support/fixtures.ts
+++ b/src/test-support/fixtures.ts
@@ -402,6 +402,16 @@ export const fixtures = {
             sessionBiz: 'v25',
             v25: { pro: { usd: { monthly: '$4', yearly: '$29' } } },
         } as unknown as PricingResponse,
+        // Carries an extra top-level field the view must treat as metadata, not
+        // a pricing version.
+        pricingWithMetadata: {
+            latestPro: 'v25',
+            latestBiz: 'v25',
+            sessionPro: 'v25',
+            sessionBiz: 'v25',
+            revision: 3,
+            v25: { pro: { usd: { monthly: 400, yearly: 2900 } } },
+        } as unknown as PricingResponse,
     },
 }
 

--- a/src/test-support/fixtures.ts
+++ b/src/test-support/fixtures.ts
@@ -1,4 +1,12 @@
-import type { Comment, Label, Task } from '@doist/todoist-sdk'
+import type {
+    Comment,
+    Label,
+    PricesResponse,
+    PricingResponse,
+    ProPlanDetails,
+    SubscriptionInfo,
+    Task,
+} from '@doist/todoist-sdk'
 import type { Project, Section } from '../lib/api/core.js'
 import type { Filter } from '../lib/api/filters.js'
 
@@ -329,6 +337,71 @@ export const fixtures = {
             email: 'test@example.com',
             inboxProjectId: 'proj-inbox',
         },
+    },
+    billing: {
+        subscription: {
+            status: 'autorenew',
+            plan: 'pro',
+            expirationDate: '2026-12-31',
+            activationMethod: 'stripe',
+            planPrice: {
+                amount: '600',
+                rawAmount: 600,
+                currency: 'USD',
+                billingCycle: 'monthly',
+                taxBehavior: 'exclusive',
+            },
+            billingPortalUrl: 'https://billing.stripe.com/portal/abc',
+            billingPortalSwitchToAnnualUrl: null,
+            hasBillingPortal: true,
+            hasBillingPortalSwitchToAnnual: false,
+            invoiceCreditBalance: { usd: 0 },
+            hasSwitchLegacyToCurrent: false,
+        } as SubscriptionInfo,
+        proPlanDetails: {
+            currentPlanStatus: 'Active',
+            downgradeAt: null,
+            priceList: [
+                {
+                    billingCycle: 'monthly',
+                    prices: [{ currency: 'USD', unitAmount: 600, taxBehavior: 'exclusive' }],
+                },
+            ],
+        } as ProPlanDetails,
+        prices: {
+            pro: [
+                {
+                    billingCycle: 'yearly',
+                    prices: [{ currency: 'USD', unitAmount: 6000, taxBehavior: 'exclusive' }],
+                },
+            ],
+            teams: [
+                {
+                    billingCycle: 'monthly',
+                    prices: [{ currency: 'USD', unitAmount: 800, taxBehavior: 'inclusive' }],
+                },
+            ],
+        } as PricesResponse,
+        pricing: {
+            latestPro: 'v25',
+            latestBiz: 'v25',
+            sessionPro: 'v25',
+            sessionBiz: 'v25',
+            v25: {
+                pro: { usd: { monthly: 400, yearly: 2900 } },
+                biz: { usd: { monthly: 800, yearly: 7200 } },
+            },
+            // PricingResponse's zod `.catchall` infers a string index signature
+            // that no literal can satisfy (every key would need to be a pricing
+            // version); cast through `unknown` like the SDK's own tests.
+        } as unknown as PricingResponse,
+        pricingFormatted: {
+            latestPro: 'v25',
+            latestBiz: 'v25',
+            sessionPro: 'v25',
+            sessionBiz: 'v25',
+            v25: { pro: { usd: { monthly: '$4', yearly: '$29' } } },
+        } as unknown as PricingResponse,
     },
 }
 

--- a/src/test-support/mock-api.ts
+++ b/src/test-support/mock-api.ts
@@ -201,6 +201,11 @@ export function createMockApi(overrides: Partial<TodoistApi> = {}): MockApi {
         getAppDistributionToken: vi.fn().mockResolvedValue({ distributionToken: '' }),
         getAppWebhook: vi.fn().mockResolvedValue(null),
         updateApp: vi.fn(),
+        // Billing
+        getSubscriptionInfo: vi.fn(),
+        getProPlanDetails: vi.fn(),
+        getPrices: vi.fn().mockResolvedValue({ pro: [], teams: [] }),
+        getPricing: vi.fn(),
         // Folders
         getFolders: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
         getFolder: vi.fn(),


### PR DESCRIPTION
## Summary

Surfaces the SDK's read-only billing endpoints (shipped in `@doist/todoist-sdk@10.3.0`, [SDK PR #608](https://github.com/Doist/todoist-sdk-typescript/pull/608)) as a new `td billing` command group.

- `td billing subscription` (default) — plan, status, activation, expiry, price, credit balance, billing-portal URLs
- `td billing plan` — Pro plan status, downgrade date, price list
- `td billing prices` — available Pro and Teams prices by billing cycle
- `td billing pricing [--formatted]` — current/legacy pricing keyed by version
- All subcommands support `--json` / `--ndjson` (raw SDK payload).

## OAuth scope

Adds a single opt-in `billing` flag: `td auth login --additional-scopes=billing`.

- Default login grants `billing:read_write`; adding `--read-only` narrows it to `billing:read`.
- Either variant satisfies the read commands (the gate is a `billing:read` substring check, and `billing:read_write` contains it). The read_write default is forward-looking should write commands land later.
- Implemented via a new optional `readOnlyScope` on `ScopeDefinition`; `resolveAuthScope`/`oauthScopeFor` now honor read-only mode (the single chokepoint used by both the login request and the persisted scope).

## Wiring

- `getSubscriptionInfo` is a POST but read-only, so it's added to the read-only safe-method allowlist (`permissions.ts`).
- The four read methods are mapped in `METHOD_REQUIRED_FLAG → billing`, so a 403 surfaces a `MISSING_SCOPE` error with a `--additional-scopes=billing` re-login hint (names `billing:read` for read-only logins).
- `billing` appended to `AUTH_FLAG_ORDER`; command registered in the lazy registry.
- Docs/skill updated (SKILL.md synced), CODEBASE.md tree, README opt-in-scopes note.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run check` (oxlint + oxfmt) clean
- [x] `npm test` — full suite green (1629 tests), incl. new `billing.test.ts` and `resolveAuthScope` coverage
- [x] `npm run check:skill-sync` passes
- [x] `td billing --help` and `td auth login --help` show the new command/scope
- [ ] Manual end-to-end against a real account: `td auth login --additional-scopes=billing`, then each `td billing` subcommand (+ `--json`); verify read-only login yields `billing:read`; verify a token without the scope fails with `MISSING_SCOPE`