### PR TITLE
docs: Updates readme to point to `todoist-cli-go`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A command-line interface for Todoist.
 
 > [!NOTE]
-> If you have come here after upgrading your `todoist-cli` package in Homebrew and it is not what you were expecting, you may have been using what is now [`todoist-cli-go`](https://formulae.brew.sh/formula/todoist-cli-go). 
+> If you have come here after upgrading your `todoist-cli` package in Homebrew and it is not what you were expecting, you may have been using what is now [`todoist-cli-go`](https://formulae.brew.sh/formula/todoist-cli-go).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A command-line interface for Todoist.
 
 > [!NOTE]
-> If you have come here after upgrading your `todoist-cli` package in homebrew and is not what you were expecting, you may have been using what is now [`todoist-cli-go`](https://formulae.brew.sh/formula/todoist-cli-go). 
+> If you have come here after upgrading your `todoist-cli` package in Homebrew and it is not what you were expecting, you may have been using what is now [`todoist-cli-go`](https://formulae.brew.sh/formula/todoist-cli-go). 
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 A command-line interface for Todoist.
 
+> [!NOTE]
+> If you have come here after upgrading your `todoist-cli` package in homebrew and is not what you were expecting, you may have been using what is now [`todoist-cli-go`](https://formulae.brew.sh/formula/todoist-cli-go). 
+
 ## Installation
 
 > ```bash


### PR DESCRIPTION
As agreed with @sachaos, we are adding a note for users who may end up at our repo after the switch on Homebrew. 