### PR TITLE
fix: Update @doist/cli-core to 0.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "date-fns": "4.1.0",
         "marked": "18.0.3",
         "marked-terminal-renderer": "2.2.0",
+        "oauth4webapi": "3.8.6",
         "open": "11.0.0"
       },
       "bin": {
@@ -8326,6 +8327,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@doist/cli-core": "0.16.1",
+        "@doist/cli-core": "0.21.0",
         "@doist/todoist-sdk": "10.2.0",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@doist/cli-core": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.16.1.tgz",
-      "integrity": "sha512-OoHWYM8Rv+eoPhVR1BUMwFIejZGk5Wyxheva4Cp9x3zTh4RURE+OIJ03G95oBegbXCA2O9LRtZZ9Ww0D6vU1dQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.21.0.tgz",
+      "integrity": "sha512-K+MevAVxo1gNe0AvyMqMnRswVzpCjmJj+7ufLE6AA7CM26Dc6EeZ2Lbqe1va47ofPr4WYfOK0n2qsUDrMPFncA==",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
@@ -154,6 +154,7 @@
         "commander": ">=14",
         "marked": ">=18",
         "marked-terminal-renderer": ">=2",
+        "oauth4webapi": ">=3",
         "open": ">=10",
         "vitest": ">=4.1"
       },
@@ -165,6 +166,9 @@
           "optional": true
         },
         "marked-terminal-renderer": {
+          "optional": true
+        },
+        "oauth4webapi": {
           "optional": true
         },
         "open": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@doist/cli-core": "0.16.1",
+    "@doist/cli-core": "0.21.0",
     "@doist/todoist-sdk": "10.2.0",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "date-fns": "4.1.0",
     "marked": "18.0.3",
     "marked-terminal-renderer": "2.2.0",
+    "oauth4webapi": "3.8.6",
     "open": "11.0.0"
   },
   "devDependencies": {

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -341,6 +341,13 @@ describe('auth command', () => {
                         return { token: 'snapshot_token', account: SNAPSHOT_ACCOUNT }
                     },
                     async set() {},
+                    async setBundle() {},
+                    async activeBundle() {
+                        return {
+                            account: SNAPSHOT_ACCOUNT,
+                            bundle: { accessToken: 'snapshot_token' },
+                        }
+                    },
                     async clear() {},
                     async list() {
                         return [{ account: SNAPSHOT_ACCOUNT, isDefault: true }]

--- a/src/lib/auth-store.test.ts
+++ b/src/lib/auth-store.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the todoist-cli-specific overlay in `createTodoistTokenStore`.
+ * The keyring mechanics live in cli-core; here we only verify the env-var
+ * short-circuit that `active()` and `activeBundle()` add on top of the inner
+ * store, so a regression in either read path is caught locally.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const innerActive = vi.fn()
+const innerActiveBundle = vi.fn()
+
+vi.mock('@doist/cli-core/auth', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@doist/cli-core/auth')>()
+    return {
+        ...actual,
+        createKeyringTokenStore: () => ({
+            active: innerActive,
+            activeBundle: innerActiveBundle,
+            set: vi.fn(),
+            setBundle: vi.fn(),
+            clear: vi.fn(),
+            list: vi.fn(),
+            setDefault: vi.fn(),
+            getLastStorageResult: vi.fn(),
+            getLastClearResult: vi.fn(),
+        }),
+    }
+})
+
+const { createTodoistTokenStore, TOKEN_ENV_VAR } = await import('./auth-store.js')
+
+describe('createTodoistTokenStore env-var short-circuit', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        delete process.env[TOKEN_ENV_VAR]
+    })
+
+    afterEach(() => {
+        delete process.env[TOKEN_ENV_VAR]
+    })
+
+    it('active() returns null without touching the inner store when the env token is set', async () => {
+        process.env[TOKEN_ENV_VAR] = 'env-token'
+        const store = createTodoistTokenStore()
+
+        await expect(store.active()).resolves.toBeNull()
+        expect(innerActive).not.toHaveBeenCalled()
+    })
+
+    it('activeBundle() returns null without touching the inner store when the env token is set', async () => {
+        process.env[TOKEN_ENV_VAR] = 'env-token'
+        const store = createTodoistTokenStore()
+
+        await expect(store.activeBundle()).resolves.toBeNull()
+        expect(innerActiveBundle).not.toHaveBeenCalled()
+    })
+
+    it('activeBundle() delegates to the inner store when no env token is set', async () => {
+        const snapshot = { account: { id: '1', label: 'a' }, bundle: { accessToken: 't' } }
+        innerActiveBundle.mockResolvedValue(snapshot)
+        const store = createTodoistTokenStore()
+
+        await expect(store.activeBundle('ref')).resolves.toBe(snapshot)
+        expect(innerActiveBundle).toHaveBeenCalledWith('ref')
+    })
+})

--- a/src/lib/auth-store.ts
+++ b/src/lib/auth-store.ts
@@ -64,15 +64,21 @@ export type TodoistTokenStore = KeyringTokenStore<TodoistAccount>
  * `UserRecordStore` adapter. Two Todoist-specific overlays on top of the
  * defaults:
  *
- *   - `active()` short-circuits to `null` when `TODOIST_API_TOKEN` is set.
- *     The env var is the canonical override across the CLI; without this
- *     short-circuit, `td auth status` would render the stored account while
- *     `getAuthMetadata()` reports `source: 'env'` (wrong account, right
- *     diagnostic).
+ *   - `active()` / `activeBundle()` short-circuit to `null` when
+ *     `TODOIST_API_TOKEN` is set. The env var is the canonical override
+ *     across the CLI; without this short-circuit, `td auth status` would
+ *     render the stored account while `getAuthMetadata()` reports
+ *     `source: 'env'` (wrong account, right diagnostic). Both read paths must
+ *     honour it so the bundle-aware `fetchLive` path agrees with `active()`.
  *   - `accountForUser` / `matchAccount` are passed explicitly. `matchAccount`
  *     delegates to `matchUserRef` so the keyring-store path and the
  *     config-driven `findUserByRef` path share one matcher (case-insensitive
  *     email + trim).
+ *
+ * Built with `Object.assign(Object.create(inner), …)` (the same pattern as
+ * `withUserRefAware()`) so every method other than the two env-aware reads is
+ * inherited from `inner` via the prototype chain — a future cli-core method
+ * addition resolves automatically instead of being silently dropped.
  */
 export function createTodoistTokenStore(): TodoistTokenStore {
     const inner = createKeyringTokenStore<TodoistAccount>({
@@ -83,21 +89,11 @@ export function createTodoistTokenStore(): TodoistTokenStore {
         matchAccount: (account: TodoistAccount, ref: AccountRef) =>
             matchUserRef({ id: account.id, email: account.email }, ref),
     })
-    return {
-        active: async (ref) => {
-            if (process.env[TOKEN_ENV_VAR]) return null
-            return inner.active(ref)
-        },
-        set: (account, token) => inner.set(account, token),
-        setBundle: (account, bundle, options) => inner.setBundle(account, bundle, options),
-        activeBundle: async (ref) => {
-            if (process.env[TOKEN_ENV_VAR]) return null
-            return inner.activeBundle(ref)
-        },
-        clear: (ref) => inner.clear(ref),
-        list: () => inner.list(),
-        setDefault: (ref) => inner.setDefault(ref),
-        getLastStorageResult: () => inner.getLastStorageResult(),
-        getLastClearResult: () => inner.getLastClearResult(),
+    function envTokenSet(): boolean {
+        return Boolean(process.env[TOKEN_ENV_VAR])
     }
+    return Object.assign(Object.create(inner) as TodoistTokenStore, {
+        active: async (ref?: AccountRef) => (envTokenSet() ? null : inner.active(ref)),
+        activeBundle: async (ref?: AccountRef) => (envTokenSet() ? null : inner.activeBundle(ref)),
+    })
 }

--- a/src/lib/auth-store.ts
+++ b/src/lib/auth-store.ts
@@ -89,6 +89,11 @@ export function createTodoistTokenStore(): TodoistTokenStore {
             return inner.active(ref)
         },
         set: (account, token) => inner.set(account, token),
+        setBundle: (account, bundle, options) => inner.setBundle(account, bundle, options),
+        activeBundle: async (ref) => {
+            if (process.env[TOKEN_ENV_VAR]) return null
+            return inner.activeBundle(ref)
+        },
         clear: (ref) => inner.clear(ref),
         list: () => inner.list(),
         setDefault: (ref) => inner.setDefault(ref),


### PR DESCRIPTION
## Summary
- Bump `@doist/cli-core` 0.16.1 → 0.21.0
- `KeyringTokenStore` now requires `setBundle` and `activeBundle`; `createTodoistTokenStore` rebuilds the store as an object literal, so it forwards both methods
- `activeBundle` reuses the same `TODOIST_API_TOKEN` short-circuit as `active()` so the env-var override stays consistent across both read paths
- Updated the `auth.test.ts` snapshot mock store to implement the new methods
- Allows `td update` to check if the CLI was installed via Homebrew

## Test plan
- [x] `npm run build`
- [x] `npm run check`
- [x] `npm test` (1613 passing)
- [x] `tsc --noEmit` (pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)