### PR TITLE
test: Dedupe test suite with shared helpers

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -55,6 +55,9 @@ src/
 │  └─ skills/             # content.ts (SKILL_CONTENT), create-installer.ts
 └─ test-support/
    ├─ mock-api.ts         # createMockApi() — vitest mocks of every SDK method
+   ├─ api-mock.ts         # setupApiMock() — wires getApi() to a fresh mock API
+   ├─ program.ts          # createTestProgram(register) — Commander test harness
+   ├─ console-spy.ts      # mockConsoleLog/Error + mockProcessStdout/Stderr spies
    └─ fixtures.ts         # Sample task/project/label/section fixtures
 ```
 
@@ -242,7 +245,16 @@ re-migrate a stale legacy slot.
 - **Mocks:** `src/test-support/mock-api.ts` — `createMockApi()` returns
   vitest-mocked versions of every SDK method. Use factories from
   `src/test-support/fixtures.ts` — do NOT hand-build mock entities.
-- **Pattern:** mock `getApi` via `vi.mock`, then `program.parseAsync(['node','td','<cmd>',…])`.
+- **Helpers:** `setupApiMock()` (`api-mock.ts`) creates a mock API and wires
+  `getApi()` to it; `createTestProgram(register)` (`program.ts`) builds the
+  Commander harness; `mockConsoleLog`/`mockConsoleError` and
+  `mockProcessStdout`/`mockProcessStderr` (`console-spy.ts`) spy on output.
+- **Pattern:** still `vi.mock('…/api/core.js')` (hoisted) per file, then in
+  `beforeEach` `mockApi = setupApiMock()`; build with
+  `createTestProgram(registerXCommand)` and run
+  `program.parseAsync(['node','td','<cmd>',…])`.
+- **Auto-restore:** `vitest.config.ts` sets `restoreMocks: true`, so spies are
+  restored between tests automatically — do NOT add manual `.mockRestore()`.
 - **`@doist/cli-core` inlining:** `vitest.config.ts` lists `@doist/cli-core` in
   `server.deps.inline` so `vi.doMock('node:fs/promises', …)` /
   `vi.doMock('node:os', …)` reach cli-core's compiled imports. Without it

--- a/src/commands/activity.test.ts
+++ b/src/commands/activity.test.ts
@@ -5,12 +5,12 @@ vi.mock('../lib/api/core.js', () => ({
     getCurrentUserId: vi.fn(),
 }))
 
-import { getApi, getCurrentUserId } from '../lib/api/core.js'
-import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { getCurrentUserId } from '../lib/api/core.js'
+import { setupApiMock } from '../test-support/api-mock.js'
+import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerActivityCommand } from './activity.js'
 
-const mockGetApi = vi.mocked(getApi)
 const mockGetCurrentUserId = vi.mocked(getCurrentUserId)
 
 function createProgram() {
@@ -23,8 +23,7 @@ describe('activity command', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockGetCurrentUserId.mockResolvedValue('user-123')
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })

--- a/src/commands/activity.test.ts
+++ b/src/commands/activity.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/api/core.js', () => ({
     getApi: vi.fn(),
@@ -7,6 +7,7 @@ vi.mock('../lib/api/core.js', () => ({
 
 import { getCurrentUserId } from '../lib/api/core.js'
 import { setupApiMock } from '../test-support/api-mock.js'
+import { mockConsoleLog } from '../test-support/console-spy.js'
 import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerActivityCommand } from './activity.js'
@@ -25,11 +26,7 @@ describe('activity command', () => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
         mockGetCurrentUserId.mockResolvedValue('user-123')
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('shows activity events', async () => {

--- a/src/commands/activity.test.ts
+++ b/src/commands/activity.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/api/core.js', () => ({
@@ -8,16 +7,14 @@ vi.mock('../lib/api/core.js', () => ({
 
 import { getApi, getCurrentUserId } from '../lib/api/core.js'
 import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { createTestProgram } from '../test-support/program.js'
 import { registerActivityCommand } from './activity.js'
 
 const mockGetApi = vi.mocked(getApi)
 const mockGetCurrentUserId = vi.mocked(getCurrentUserId)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerActivityCommand(program)
-    return program
+    return createTestProgram(registerActivityCommand)
 }
 
 describe('activity command', () => {

--- a/src/commands/add.test.ts
+++ b/src/commands/add.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/api/core.js', () => ({
@@ -12,16 +11,14 @@ vi.mock('../lib/stdin.js', () => ({
 import { getApi } from '../lib/api/core.js'
 import { readStdin } from '../lib/stdin.js'
 import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { createTestProgram } from '../test-support/program.js'
 import { registerAddCommand } from './add.js'
 
 const mockGetApi = vi.mocked(getApi)
 const mockReadStdin = vi.mocked(readStdin)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerAddCommand(program)
-    return program
+    return createTestProgram(registerAddCommand)
 }
 
 describe('add command', () => {

--- a/src/commands/add.test.ts
+++ b/src/commands/add.test.ts
@@ -10,6 +10,7 @@ vi.mock('../lib/stdin.js', () => ({
 
 import { readStdin } from '../lib/stdin.js'
 import { setupApiMock } from '../test-support/api-mock.js'
+import { mockConsoleLog } from '../test-support/console-spy.js'
 import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerAddCommand } from './add.js'
@@ -30,7 +31,7 @@ describe('add command', () => {
 
     it('calls quickAddTask with text', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.quickAddTask.mockResolvedValue({
             id: 'task-1',
@@ -41,12 +42,11 @@ describe('add command', () => {
         await program.parseAsync(['node', 'td', 'add', 'Buy milk'])
 
         expect(mockApi.quickAddTask).toHaveBeenCalledWith({ text: 'Buy milk' })
-        consoleSpy.mockRestore()
     })
 
     it('displays created task content', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.quickAddTask.mockResolvedValue({
             id: 'task-1',
@@ -57,12 +57,11 @@ describe('add command', () => {
         await program.parseAsync(['node', 'td', 'add', 'Buy milk tomorrow'])
 
         expect(consoleSpy).toHaveBeenCalledWith('Created: Buy milk tomorrow')
-        consoleSpy.mockRestore()
     })
 
     it('displays due date when present', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.quickAddTask.mockResolvedValue({
             id: 'task-1',
@@ -73,12 +72,11 @@ describe('add command', () => {
         await program.parseAsync(['node', 'td', 'add', 'Meeting tomorrow'])
 
         expect(consoleSpy).toHaveBeenCalledWith('Due: tomorrow')
-        consoleSpy.mockRestore()
     })
 
     it('displays task ID', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.quickAddTask.mockResolvedValue({
             id: 'task-123',
@@ -89,12 +87,11 @@ describe('add command', () => {
         await program.parseAsync(['node', 'td', 'add', 'Test'])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('task-123'))
-        consoleSpy.mockRestore()
     })
 
     it('handles text with natural language and tags', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.quickAddTask.mockResolvedValue({
             id: 'task-1',
@@ -107,23 +104,21 @@ describe('add command', () => {
         expect(mockApi.quickAddTask).toHaveBeenCalledWith({
             text: 'Buy milk tomorrow p1 #Shopping',
         })
-        consoleSpy.mockRestore()
     })
 
     it('--dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync(['node', 'td', 'add', 'Buy milk', '--dry-run'])
 
         expect(mockApi.quickAddTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would quick add task'))
-        consoleSpy.mockRestore()
     })
 
     it('reads text from stdin with --stdin', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockReadStdin.mockResolvedValue('Buy milk tomorrow\n')
         mockApi.quickAddTask.mockResolvedValue({
@@ -136,7 +131,6 @@ describe('add command', () => {
 
         expect(mockReadStdin).toHaveBeenCalled()
         expect(mockApi.quickAddTask).toHaveBeenCalledWith({ text: 'Buy milk tomorrow' })
-        consoleSpy.mockRestore()
     })
 
     it('errors when both text and --stdin are provided', async () => {
@@ -149,7 +143,7 @@ describe('add command', () => {
 
     it('--json outputs JSON of created task', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.quickAddTask.mockResolvedValue({
             id: 'task-1',
@@ -163,6 +157,5 @@ describe('add command', () => {
         const output = consoleSpy.mock.calls[0][0] as string
         expect(() => JSON.parse(output)).not.toThrow()
         expect(JSON.parse(output)).toMatchObject({ id: 'task-1', content: 'Buy milk' })
-        consoleSpy.mockRestore()
     })
 })

--- a/src/commands/add.test.ts
+++ b/src/commands/add.test.ts
@@ -8,13 +8,12 @@ vi.mock('../lib/stdin.js', () => ({
     readStdin: vi.fn(),
 }))
 
-import { getApi } from '../lib/api/core.js'
 import { readStdin } from '../lib/stdin.js'
-import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { setupApiMock } from '../test-support/api-mock.js'
+import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerAddCommand } from './add.js'
 
-const mockGetApi = vi.mocked(getApi)
 const mockReadStdin = vi.mocked(readStdin)
 
 function createProgram() {
@@ -26,8 +25,7 @@ describe('add command', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('calls quickAddTask with text', async () => {

--- a/src/commands/apps/apps.test.ts
+++ b/src/commands/apps/apps.test.ts
@@ -22,6 +22,7 @@ import { wrapApiError } from '../../lib/api/core.js'
 import { getAuthMetadata } from '../../lib/auth.js'
 import { CliError } from '../../lib/errors.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerAppsCommand } from './index.js'
@@ -87,7 +88,7 @@ describe('apps list', () => {
 
     it('lists apps with displayName (id:N), Client ID, and a description line', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApps.mockResolvedValue([APP_A, APP_B])
 
@@ -100,7 +101,6 @@ describe('apps list', () => {
         expect(output).toContain('Client ID: client-xyz')
         // App B has no description → fallback string
         expect(output).toContain('(no description)')
-        consoleSpy.mockRestore()
     })
 
     describeEmptyMachineOutput('empty machine output contract', {
@@ -116,7 +116,7 @@ describe('apps list', () => {
 
     it('outputs full JSON with --json flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApps.mockResolvedValue([APP_A])
 
@@ -128,12 +128,11 @@ describe('apps list', () => {
         expect(parsed[0].id).toBe('9909')
         expect(parsed[0].displayName).toBe('Todoist for VS Code')
         expect(parsed[0].oauthRedirectUri).toBe('vscode://doist.todoist-vs-code/auth-complete')
-        consoleSpy.mockRestore()
     })
 
     it('outputs NDJSON with --ndjson flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApps.mockResolvedValue([APP_A, APP_B])
 
@@ -144,7 +143,6 @@ describe('apps list', () => {
         expect(lines).toHaveLength(2)
         expect(JSON.parse(lines[0]).id).toBe('9909')
         expect(JSON.parse(lines[1]).id).toBe('9910')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -158,7 +156,7 @@ describe('apps view', () => {
 
     it('resolves id:N directly via getApp without listing', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
 
@@ -166,12 +164,11 @@ describe('apps view', () => {
 
         expect(mockApi.getApp).toHaveBeenCalledWith('9909')
         expect(mockApi.getApps).not.toHaveBeenCalled()
-        consoleSpy.mockRestore()
     })
 
     it('resolves a raw numeric id via getApp directly (no listing roundtrip)', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
 
@@ -179,12 +176,11 @@ describe('apps view', () => {
 
         expect(mockApi.getApp).toHaveBeenCalledWith('9909')
         expect(mockApi.getApps).not.toHaveBeenCalled()
-        consoleSpy.mockRestore()
     })
 
     it('resolves a name via fuzzy match then re-fetches via getApp to enrich with userCount', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApps.mockResolvedValue([APP_A, APP_B])
         mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
@@ -207,24 +203,22 @@ describe('apps view', () => {
         expect(output).toContain('OAuth redirect:     vscode://doist.todoist-vs-code/auth-complete')
         expect(output).toContain('Token scopes:       data:read, data:read_write')
         expect(output).toContain('Helps you manage tasks from VS Code')
-        consoleSpy.mockRestore()
     })
 
     it('does not call getApp twice on id:N (no redundant detail fetch)', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
 
         await program.parseAsync(['node', 'td', 'apps', 'view', 'id:9909'])
 
         expect(mockApi.getApp).toHaveBeenCalledTimes(1)
-        consoleSpy.mockRestore()
     })
 
     it('shows fallback strings for null fields and (none) for empty token scopes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue(APP_B_DETAIL)
 
@@ -235,7 +229,6 @@ describe('apps view', () => {
         expect(output).toContain('OAuth redirect:     (none)')
         expect(output).toContain('Token scopes:       data:read')
         expect(output).toContain('(no description)')
-        consoleSpy.mockRestore()
     })
 
     it('throws AMBIGUOUS_APP when a substring matches multiple apps', async () => {
@@ -289,7 +282,7 @@ describe('apps view', () => {
 
     it('treats `td apps <ref>` as `td apps view <ref>` (implicit default subcommand)', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
 
@@ -299,7 +292,6 @@ describe('apps view', () => {
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('Todoist for VS Code')
         expect(output).toContain('ID:                 9909')
-        consoleSpy.mockRestore()
     })
 
     it('does not attempt getApp() for alphanumeric refs (avoids the 400 from the apps endpoint)', async () => {
@@ -315,7 +307,7 @@ describe('apps view', () => {
 
     it('renders a multi-URI JSON-array oauthRedirectUri as separate indented lines', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue({
             ...APP_A_DETAIL,
@@ -330,12 +322,11 @@ describe('apps view', () => {
         expect(output).toContain('                      https://b.example/cb')
         // Raw JSON-array blob should not leak into the plain renderer.
         expect(output).not.toContain('["https://a.example/cb"')
-        consoleSpy.mockRestore()
     })
 
     it('treats empty-string serviceUrl/oauthRedirectUri the same as null', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue({
             ...APP_A_DETAIL,
@@ -348,12 +339,11 @@ describe('apps view', () => {
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('Service URL:        (none)')
         expect(output).toContain('OAuth redirect:     (none)')
-        consoleSpy.mockRestore()
     })
 
     it('outputs full JSON of AppWithUserCount with --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
 
@@ -364,12 +354,11 @@ describe('apps view', () => {
         expect(parsed.id).toBe('9909')
         expect(parsed.userCount).toBe(42)
         expect(parsed.appTokenScopes).toEqual(['data:read', 'data:read_write'])
-        consoleSpy.mockRestore()
     })
 
     it('outputs single-line JSON with --ndjson', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
 
@@ -378,7 +367,6 @@ describe('apps view', () => {
         const output = consoleSpy.mock.calls[0][0] as string
         expect(output.split('\n')).toHaveLength(1)
         expect(JSON.parse(output).id).toBe('9909')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -408,7 +396,7 @@ describe('apps view — enriched fields', () => {
 
     it('only fetches webhook by default (no secret-bearing endpoints touched)', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         await program.parseAsync(['node', 'td', 'apps', 'view', 'id:9909'])
 
@@ -420,12 +408,11 @@ describe('apps view — enriched fields', () => {
         expect(mockApi.getAppVerificationToken).not.toHaveBeenCalled()
         expect(mockApi.getAppTestToken).not.toHaveBeenCalled()
         expect(mockApi.getAppDistributionToken).not.toHaveBeenCalled()
-        consoleSpy.mockRestore()
     })
 
     it('fires all five enrichment calls with --include-secrets', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         await program.parseAsync(['node', 'td', 'apps', 'view', 'id:9909', '--include-secrets'])
 
@@ -434,12 +421,11 @@ describe('apps view — enriched fields', () => {
         expect(mockApi.getAppTestToken).toHaveBeenCalledWith('9909')
         expect(mockApi.getAppDistributionToken).toHaveBeenCalledWith('9909')
         expect(mockApi.getAppWebhook).toHaveBeenCalledWith('9909')
-        consoleSpy.mockRestore()
     })
 
     it('shows Client ID by default and hides the four sensitive credential lines', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync(['node', 'td', 'apps', 'view', 'id:9909'])
 
@@ -457,12 +443,11 @@ describe('apps view — enriched fields', () => {
         expect(output).not.toContain('dist-jkl')
         // Webhook line is still shown (callback URL is user-supplied, not a secret)
         expect(output).toContain('Webhook:            (not configured)')
-        consoleSpy.mockRestore()
     })
 
     it('reveals every sensitive value with --include-secrets', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getAppTestToken.mockResolvedValue({ accessToken: 'test-mno' })
 
@@ -476,12 +461,11 @@ describe('apps view — enriched fields', () => {
         expect(output).toContain('Distribution token: dist-jkl')
         // No hidden placeholders remain
         expect(output).not.toContain('pass --include-secrets')
-        consoleSpy.mockRestore()
     })
 
     it('renders webhook details when configured', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getAppWebhook.mockResolvedValue(WEBHOOK)
 
@@ -491,12 +475,11 @@ describe('apps view — enriched fields', () => {
         expect(output).toContain('Webhook:            active — https://example.com/hook')
         expect(output).toContain('Webhook events:     item:added, item:completed')
         expect(output).toContain('Webhook version:    1')
-        consoleSpy.mockRestore()
     })
 
     it('keeps (not created) for a null test token even with --include-secrets', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getAppTestToken.mockResolvedValue({ accessToken: null })
 
@@ -504,12 +487,11 @@ describe('apps view — enriched fields', () => {
 
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('Test token:         (not created)')
-        consoleSpy.mockRestore()
     })
 
     it('includes clientId but omits sensitive credential keys from --json by default', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getAppWebhook.mockResolvedValue(WEBHOOK)
 
@@ -527,12 +509,11 @@ describe('apps view — enriched fields', () => {
             status: 'active',
             callbackUrl: 'https://example.com/hook',
         })
-        consoleSpy.mockRestore()
     })
 
     it('includes every sensitive field in --json --include-secrets', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getAppTestToken.mockResolvedValue({ accessToken: 'test-mno' })
 
@@ -552,18 +533,16 @@ describe('apps view — enriched fields', () => {
         expect(parsed.verificationToken).toBe('verify-ghi')
         expect(parsed.distributionToken).toBe('dist-jkl')
         expect(parsed.testToken).toEqual({ accessToken: 'test-mno' })
-        consoleSpy.mockRestore()
     })
 
     it('emits webhook: null in --json when the app has no webhook configured', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync(['node', 'td', 'apps', 'view', 'id:9909', '--json'])
 
         const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string)
         expect(parsed.webhook).toBeNull()
-        consoleSpy.mockRestore()
     })
 })
 
@@ -624,7 +603,7 @@ describe('apps update --add-oauth-redirect / --remove-oauth-redirect', () => {
 
     it('does not validate the URI on --remove (lets users clean up legacy malformed data)', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         // App's stored URI is malformed but we want to let the user remove it.
         mockApi.getApp.mockResolvedValue({
@@ -645,12 +624,11 @@ describe('apps update --add-oauth-redirect / --remove-oauth-redirect', () => {
         ])
 
         expect(mockApi.updateApp).toHaveBeenCalledWith('9909', { oauthRedirectUri: null })
-        consoleSpy.mockRestore()
     })
 
     it('adds a new redirect URI to an app that has one (serializes as JSON array)', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
         mockApi.updateApp.mockResolvedValue({
@@ -676,12 +654,11 @@ describe('apps update --add-oauth-redirect / --remove-oauth-redirect', () => {
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('Added OAuth redirect URI to Todoist for VS Code')
         expect(output).toContain('https://example.com/cb')
-        consoleSpy.mockRestore()
     })
 
     it('adds a first redirect URI to an app that has none (serializes as plain string)', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue(APP_B_DETAIL)
         mockApi.updateApp.mockResolvedValue({
@@ -702,7 +679,6 @@ describe('apps update --add-oauth-redirect / --remove-oauth-redirect', () => {
         expect(mockApi.updateApp).toHaveBeenCalledWith('9910', {
             oauthRedirectUri: 'https://example.com/cb',
         })
-        consoleSpy.mockRestore()
     })
 
     it('rejects adding a URI that is already set', async () => {
@@ -726,7 +702,7 @@ describe('apps update --add-oauth-redirect / --remove-oauth-redirect', () => {
 
     it('add --dry-run previews without calling updateApp', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
 
@@ -745,12 +721,11 @@ describe('apps update --add-oauth-redirect / --remove-oauth-redirect', () => {
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('[dry-run]')
         expect(output).toContain('https://example.com/cb')
-        consoleSpy.mockRestore()
     })
 
     it('remove exits without error when URI is not present on the app', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
 
@@ -769,12 +744,11 @@ describe('apps update --add-oauth-redirect / --remove-oauth-redirect', () => {
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('is not an OAuth redirect URI')
         expect(output).toContain('nothing to remove')
-        consoleSpy.mockRestore()
     })
 
     it('remove no-op with --json outputs the unchanged app as JSON', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
 
@@ -795,7 +769,6 @@ describe('apps update --add-oauth-redirect / --remove-oauth-redirect', () => {
         const parsed = JSON.parse(output)
         expect(parsed.id).toBe('9909')
         expect(parsed.oauthRedirectUri).toBe('vscode://doist.todoist-vs-code/auth-complete')
-        consoleSpy.mockRestore()
     })
 
     it('remove without --yes and with --json throws CONFIRMATION_REQUIRED instead of printing a preview', async () => {
@@ -820,7 +793,7 @@ describe('apps update --add-oauth-redirect / --remove-oauth-redirect', () => {
 
     it('remove requires --yes; without it prints preview and does not call updateApp', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
 
@@ -838,12 +811,11 @@ describe('apps update --add-oauth-redirect / --remove-oauth-redirect', () => {
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('Would remove OAuth redirect URI')
         expect(output).toContain('Use --yes to confirm.')
-        consoleSpy.mockRestore()
     })
 
     it('remove with --yes clears oauthRedirectUri to null when removing the only URI', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
         mockApi.updateApp.mockResolvedValue({ ...APP_A_DETAIL, oauthRedirectUri: null })
@@ -862,12 +834,11 @@ describe('apps update --add-oauth-redirect / --remove-oauth-redirect', () => {
         expect(mockApi.updateApp).toHaveBeenCalledWith('9909', { oauthRedirectUri: null })
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('Removed OAuth redirect URI from Todoist for VS Code')
-        consoleSpy.mockRestore()
     })
 
     it('add with --json outputs only the essential app fields via the shared formatter', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
         mockApi.updateApp.mockResolvedValue({
@@ -896,12 +867,11 @@ describe('apps update --add-oauth-redirect / --remove-oauth-redirect', () => {
         // Essential-fields filter drops noisy/secondary keys.
         expect(parsed).not.toHaveProperty('iconSm')
         expect(parsed).not.toHaveProperty('userId')
-        consoleSpy.mockRestore()
     })
 
     it('remove with --yes writes the remaining URIs when multiple were set', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getApp.mockResolvedValue({
             ...APP_A_DETAIL,
@@ -927,7 +897,6 @@ describe('apps update --add-oauth-redirect / --remove-oauth-redirect', () => {
         expect(mockApi.updateApp).toHaveBeenCalledWith('9909', {
             oauthRedirectUri: 'https://b.example/cb',
         })
-        consoleSpy.mockRestore()
     })
 })
 

--- a/src/commands/apps/apps.test.ts
+++ b/src/commands/apps/apps.test.ts
@@ -1,6 +1,5 @@
 import { describeEmptyMachineOutput } from '@doist/cli-core/testing'
 import { TodoistRequestError } from '@doist/todoist-sdk'
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', async (importOriginal) => {
@@ -23,16 +22,14 @@ import { getApi, wrapApiError } from '../../lib/api/core.js'
 import { getAuthMetadata } from '../../lib/auth.js'
 import { CliError } from '../../lib/errors.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerAppsCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
 const mockGetAuthMetadata = vi.mocked(getAuthMetadata)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerAppsCommand(program)
-    return program
+    return createTestProgram(registerAppsCommand)
 }
 
 const APP_A = {

--- a/src/commands/apps/apps.test.ts
+++ b/src/commands/apps/apps.test.ts
@@ -18,14 +18,14 @@ vi.mock('../../lib/auth.js', async (importOriginal) => {
     }
 })
 
-import { getApi, wrapApiError } from '../../lib/api/core.js'
+import { wrapApiError } from '../../lib/api/core.js'
 import { getAuthMetadata } from '../../lib/auth.js'
 import { CliError } from '../../lib/errors.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerAppsCommand } from './index.js'
 
-const mockGetApi = vi.mocked(getApi)
 const mockGetAuthMetadata = vi.mocked(getAuthMetadata)
 
 function createProgram() {
@@ -82,8 +82,7 @@ describe('apps list', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('lists apps with displayName (id:N), Client ID, and a description line', async () => {
@@ -154,8 +153,7 @@ describe('apps view', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('resolves id:N directly via getApp without listing', async () => {
@@ -399,8 +397,7 @@ describe('apps view — enriched fields', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockApi.getApp.mockResolvedValue(APP_A_DETAIL)
         mockApi.getAppSecrets.mockResolvedValue(SECRETS)
         mockApi.getAppVerificationToken.mockResolvedValue(VERIFICATION)
@@ -575,8 +572,7 @@ describe('apps update --add-oauth-redirect / --remove-oauth-redirect', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('errors when both --add- and --remove-oauth-redirect are passed', async () => {

--- a/src/commands/attachment.test.ts
+++ b/src/commands/attachment.test.ts
@@ -6,6 +6,7 @@ vi.mock('../lib/api/core.js', () => ({
 }))
 
 import { setupApiMock } from '../test-support/api-mock.js'
+import { mockConsoleLog } from '../test-support/console-spy.js'
 import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerAttachmentCommand } from './attachment.js'
@@ -61,8 +62,8 @@ describe('attachment view', () => {
     })
 
     it('calls api.viewAttachment with the URL', async () => {
-        const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
-        const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+        vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+        vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
         mockApi.viewAttachment.mockResolvedValue(
             createMockResponse({ contentType: 'text/plain', body: 'hello' }),
         )
@@ -77,8 +78,6 @@ describe('attachment view', () => {
         ])
 
         expect(mockApi.viewAttachment).toHaveBeenCalledWith('https://files.todoist.com/file.txt')
-        stdoutSpy.mockRestore()
-        stderrSpy.mockRestore()
     })
 
     describe('text files', () => {
@@ -101,13 +100,11 @@ describe('attachment view', () => {
             expect(stdoutSpy).toHaveBeenCalledWith('Hello, world!')
             expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('notes.txt'))
             expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('text/plain'))
-            stdoutSpy.mockRestore()
-            stderrSpy.mockRestore()
         })
 
         it('handles JSON files as text', async () => {
             const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
-            const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
             const jsonContent = '{"key": "value"}'
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({ contentType: 'application/json', body: jsonContent }),
@@ -123,14 +120,12 @@ describe('attachment view', () => {
             ])
 
             expect(stdoutSpy).toHaveBeenCalledWith(jsonContent)
-            stdoutSpy.mockRestore()
-            stderrSpy.mockRestore()
         })
     })
 
     describe('image files', () => {
         it('outputs base64 for PNG files', async () => {
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+            const consoleSpy = mockConsoleLog()
             const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
             const imageData = new Uint8Array([137, 80, 78, 71]).buffer
             mockApi.viewAttachment.mockResolvedValue(
@@ -149,15 +144,13 @@ describe('attachment view', () => {
             const base64 = Buffer.from(imageData).toString('base64')
             expect(consoleSpy).toHaveBeenCalledWith(base64)
             expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('base64'))
-            consoleSpy.mockRestore()
-            stderrSpy.mockRestore()
         })
     })
 
     describe('binary files', () => {
         it('outputs base64 for PDF files', async () => {
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-            const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            const consoleSpy = mockConsoleLog()
+            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
             const pdfData = new Uint8Array([0x25, 0x50, 0x44, 0x46]).buffer
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({ contentType: 'application/pdf', body: pdfData }),
@@ -174,15 +167,13 @@ describe('attachment view', () => {
 
             const base64 = Buffer.from(pdfData).toString('base64')
             expect(consoleSpy).toHaveBeenCalledWith(base64)
-            consoleSpy.mockRestore()
-            stderrSpy.mockRestore()
         })
     })
 
     describe('--json output', () => {
         it('returns JSON with utf-8 encoding for text files', async () => {
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-            const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            const consoleSpy = mockConsoleLog()
+            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({ contentType: 'text/plain', body: 'hello world' }),
             )
@@ -206,13 +197,11 @@ describe('attachment view', () => {
                 content: 'hello world',
             })
             expect(output.fileSize).toBe(Buffer.byteLength('hello world', 'utf-8'))
-            consoleSpy.mockRestore()
-            stderrSpy.mockRestore()
         })
 
         it('returns JSON with base64 encoding for binary files', async () => {
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-            const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            const consoleSpy = mockConsoleLog()
+            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
             const pdfData = new Uint8Array([0x25, 0x50, 0x44, 0x46]).buffer
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({ contentType: 'application/pdf', body: pdfData }),
@@ -236,15 +225,13 @@ describe('attachment view', () => {
                 encoding: 'base64',
             })
             expect(output.content).toBe(Buffer.from(pdfData).toString('base64'))
-            consoleSpy.mockRestore()
-            stderrSpy.mockRestore()
         })
     })
 
     describe('content-type handling', () => {
         it('strips charset from content-type', async () => {
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-            const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            const consoleSpy = mockConsoleLog()
+            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({
                     contentType: 'text/plain; charset=utf-8',
@@ -264,13 +251,11 @@ describe('attachment view', () => {
 
             const output = JSON.parse(consoleSpy.mock.calls[0][0])
             expect(output.contentType).toBe('text/plain')
-            consoleSpy.mockRestore()
-            stderrSpy.mockRestore()
         })
 
         it('falls back to URL extension when content-type is application/octet-stream', async () => {
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-            const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            const consoleSpy = mockConsoleLog()
+            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({
                     contentType: 'application/octet-stream',
@@ -291,8 +276,6 @@ describe('attachment view', () => {
             const output = JSON.parse(consoleSpy.mock.calls[0][0])
             expect(output.contentType).toBe('image/png')
             expect(output.contentCategory).toBe('image')
-            consoleSpy.mockRestore()
-            stderrSpy.mockRestore()
         })
     })
 
@@ -359,8 +342,8 @@ describe('attachment view', () => {
 
     describe('charset handling', () => {
         it('uses declared charset for text decoding', async () => {
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-            const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            const consoleSpy = mockConsoleLog()
+            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({
                     contentType: 'text/plain; charset=utf-8',
@@ -381,13 +364,11 @@ describe('attachment view', () => {
             const output = JSON.parse(consoleSpy.mock.calls[0][0])
             expect(output.encoding).toBe('utf-8')
             expect(output.content).toBe('hello')
-            consoleSpy.mockRestore()
-            stderrSpy.mockRestore()
         })
 
         it('reports declared charset in encoding field', async () => {
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-            const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            const consoleSpy = mockConsoleLog()
+            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({
                     contentType: 'text/plain; charset=iso-8859-1',
@@ -407,15 +388,13 @@ describe('attachment view', () => {
 
             const output = JSON.parse(consoleSpy.mock.calls[0][0])
             expect(output.encoding).toBe('iso-8859-1')
-            consoleSpy.mockRestore()
-            stderrSpy.mockRestore()
         })
     })
 
     describe('filename handling', () => {
         it('decodes URL-encoded filenames', async () => {
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-            const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            const consoleSpy = mockConsoleLog()
+            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({ contentType: 'text/plain', body: 'content' }),
             )
@@ -432,15 +411,13 @@ describe('attachment view', () => {
 
             const output = JSON.parse(consoleSpy.mock.calls[0][0])
             expect(output.fileName).toBe('my file (1).txt')
-            consoleSpy.mockRestore()
-            stderrSpy.mockRestore()
         })
     })
 
     describe('default subcommand', () => {
         it('td attachment <url> works as td attachment view <url>', async () => {
-            const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
-            const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({ contentType: 'text/plain', body: 'content' }),
             )
@@ -456,8 +433,6 @@ describe('attachment view', () => {
             expect(mockApi.viewAttachment).toHaveBeenCalledWith(
                 'https://files.todoist.com/file.txt',
             )
-            stdoutSpy.mockRestore()
-            stderrSpy.mockRestore()
         })
     })
 })

--- a/src/commands/attachment.test.ts
+++ b/src/commands/attachment.test.ts
@@ -6,7 +6,11 @@ vi.mock('../lib/api/core.js', () => ({
 }))
 
 import { setupApiMock } from '../test-support/api-mock.js'
-import { mockConsoleLog } from '../test-support/console-spy.js'
+import {
+    mockConsoleLog,
+    mockProcessStderr,
+    mockProcessStdout,
+} from '../test-support/console-spy.js'
 import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerAttachmentCommand } from './attachment.js'
@@ -62,8 +66,8 @@ describe('attachment view', () => {
     })
 
     it('calls api.viewAttachment with the URL', async () => {
-        vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
-        vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+        mockProcessStdout()
+        mockProcessStderr()
         mockApi.viewAttachment.mockResolvedValue(
             createMockResponse({ contentType: 'text/plain', body: 'hello' }),
         )
@@ -82,8 +86,8 @@ describe('attachment view', () => {
 
     describe('text files', () => {
         it('outputs text content to stdout without trailing newline', async () => {
-            const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
-            const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            const stdoutSpy = mockProcessStdout()
+            const stderrSpy = mockProcessStderr()
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({ contentType: 'text/plain', body: 'Hello, world!' }),
             )
@@ -103,8 +107,8 @@ describe('attachment view', () => {
         })
 
         it('handles JSON files as text', async () => {
-            const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
-            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            const stdoutSpy = mockProcessStdout()
+            mockProcessStderr()
             const jsonContent = '{"key": "value"}'
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({ contentType: 'application/json', body: jsonContent }),
@@ -126,7 +130,7 @@ describe('attachment view', () => {
     describe('image files', () => {
         it('outputs base64 for PNG files', async () => {
             const consoleSpy = mockConsoleLog()
-            const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            const stderrSpy = mockProcessStderr()
             const imageData = new Uint8Array([137, 80, 78, 71]).buffer
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({ contentType: 'image/png', body: imageData }),
@@ -150,7 +154,7 @@ describe('attachment view', () => {
     describe('binary files', () => {
         it('outputs base64 for PDF files', async () => {
             const consoleSpy = mockConsoleLog()
-            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            mockProcessStderr()
             const pdfData = new Uint8Array([0x25, 0x50, 0x44, 0x46]).buffer
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({ contentType: 'application/pdf', body: pdfData }),
@@ -173,7 +177,7 @@ describe('attachment view', () => {
     describe('--json output', () => {
         it('returns JSON with utf-8 encoding for text files', async () => {
             const consoleSpy = mockConsoleLog()
-            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            mockProcessStderr()
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({ contentType: 'text/plain', body: 'hello world' }),
             )
@@ -201,7 +205,7 @@ describe('attachment view', () => {
 
         it('returns JSON with base64 encoding for binary files', async () => {
             const consoleSpy = mockConsoleLog()
-            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            mockProcessStderr()
             const pdfData = new Uint8Array([0x25, 0x50, 0x44, 0x46]).buffer
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({ contentType: 'application/pdf', body: pdfData }),
@@ -231,7 +235,7 @@ describe('attachment view', () => {
     describe('content-type handling', () => {
         it('strips charset from content-type', async () => {
             const consoleSpy = mockConsoleLog()
-            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            mockProcessStderr()
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({
                     contentType: 'text/plain; charset=utf-8',
@@ -255,7 +259,7 @@ describe('attachment view', () => {
 
         it('falls back to URL extension when content-type is application/octet-stream', async () => {
             const consoleSpy = mockConsoleLog()
-            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            mockProcessStderr()
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({
                     contentType: 'application/octet-stream',
@@ -343,7 +347,7 @@ describe('attachment view', () => {
     describe('charset handling', () => {
         it('uses declared charset for text decoding', async () => {
             const consoleSpy = mockConsoleLog()
-            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            mockProcessStderr()
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({
                     contentType: 'text/plain; charset=utf-8',
@@ -368,7 +372,7 @@ describe('attachment view', () => {
 
         it('reports declared charset in encoding field', async () => {
             const consoleSpy = mockConsoleLog()
-            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            mockProcessStderr()
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({
                     contentType: 'text/plain; charset=iso-8859-1',
@@ -394,7 +398,7 @@ describe('attachment view', () => {
     describe('filename handling', () => {
         it('decodes URL-encoded filenames', async () => {
             const consoleSpy = mockConsoleLog()
-            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            mockProcessStderr()
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({ contentType: 'text/plain', body: 'content' }),
             )
@@ -416,8 +420,8 @@ describe('attachment view', () => {
 
     describe('default subcommand', () => {
         it('td attachment <url> works as td attachment view <url>', async () => {
-            vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
-            vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+            mockProcessStdout()
+            mockProcessStderr()
             mockApi.viewAttachment.mockResolvedValue(
                 createMockResponse({ contentType: 'text/plain', body: 'content' }),
             )

--- a/src/commands/attachment.test.ts
+++ b/src/commands/attachment.test.ts
@@ -5,12 +5,10 @@ vi.mock('../lib/api/core.js', () => ({
     getApi: vi.fn(),
 }))
 
-import { getApi } from '../lib/api/core.js'
-import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { setupApiMock } from '../test-support/api-mock.js'
+import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerAttachmentCommand } from './attachment.js'
-
-const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
     return createTestProgram(registerAttachmentCommand)
@@ -59,8 +57,7 @@ describe('attachment view', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('calls api.viewAttachment with the URL', async () => {

--- a/src/commands/attachment.test.ts
+++ b/src/commands/attachment.test.ts
@@ -1,5 +1,4 @@
 import type { FileResponse } from '@doist/todoist-sdk'
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/api/core.js', () => ({
@@ -8,15 +7,13 @@ vi.mock('../lib/api/core.js', () => ({
 
 import { getApi } from '../lib/api/core.js'
 import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { createTestProgram } from '../test-support/program.js'
 import { registerAttachmentCommand } from './attachment.js'
 
 const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerAttachmentCommand(program)
-    return program
+    return createTestProgram(registerAttachmentCommand)
 }
 
 function createMockResponse({

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -74,6 +74,7 @@ import { createApiForToken, getApi } from '../../lib/api/core.js'
 import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
 import { NoTokenError, getAuthMetadata, listStoredUsers, readConfig } from '../../lib/auth.js'
 import { resetGlobalArgs } from '../../lib/global-args.js'
+import { mockConsoleError, mockConsoleLog } from '../../test-support/console-spy.js'
 import { createMockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerAuthCommand } from './index.js'
@@ -109,8 +110,8 @@ describe('auth command', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-        errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        consoleSpy = mockConsoleLog()
+        errorSpy = mockConsoleError()
         mockListStoredUsers.mockResolvedValue([])
         mockReadConfig.mockResolvedValue({})
     })
@@ -172,13 +173,12 @@ describe('auth command', () => {
             }
             mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
             stubProbeApiForUser()
-            const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+            vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
 
             await program.parseAsync(['node', 'td', 'auth', 'token'])
 
             expect(mockRl.question).toHaveBeenCalled()
             expect(setMock).toHaveBeenCalledWith(expect.anything(), 'interactive_token_456')
-            writeSpy.mockRestore()
         })
 
         it('shows error when interactive input is empty', async () => {
@@ -191,13 +191,12 @@ describe('auth command', () => {
                 _writeToOutput: vi.fn(),
             }
             mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
-            const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+            vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
 
             await program.parseAsync(['node', 'td', 'auth', 'token'])
 
             expect(setMock).not.toHaveBeenCalled()
             expect(errorSpy).toHaveBeenCalledWith('Error:', 'No token provided')
-            writeSpy.mockRestore()
         })
 
         it('surfaces config-file fallback warning', async () => {
@@ -537,7 +536,6 @@ describe('auth command', () => {
             } finally {
                 process.argv = originalArgv
                 resetGlobalArgs()
-                stdoutWrite.mockRestore()
             }
         })
 

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -74,7 +74,11 @@ import { createApiForToken, getApi } from '../../lib/api/core.js'
 import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
 import { NoTokenError, getAuthMetadata, listStoredUsers, readConfig } from '../../lib/auth.js'
 import { resetGlobalArgs } from '../../lib/global-args.js'
-import { mockConsoleError, mockConsoleLog } from '../../test-support/console-spy.js'
+import {
+    mockConsoleError,
+    mockConsoleLog,
+    mockProcessStdout,
+} from '../../test-support/console-spy.js'
 import { createMockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerAuthCommand } from './index.js'
@@ -171,7 +175,7 @@ describe('auth command', () => {
             }
             mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
             stubProbeApiForUser()
-            vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+            mockProcessStdout()
 
             await program.parseAsync(['node', 'td', 'auth', 'token'])
 
@@ -189,7 +193,7 @@ describe('auth command', () => {
                 _writeToOutput: vi.fn(),
             }
             mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
-            vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+            mockProcessStdout()
 
             await program.parseAsync(['node', 'td', 'auth', 'token'])
 
@@ -523,7 +527,7 @@ describe('auth command', () => {
             activeMock.mockResolvedValue({ token: 'stored-token-1234567', account })
 
             const program = createProgram()
-            const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+            const stdoutWrite = mockProcessStdout()
             const originalArgv = process.argv
             process.argv = ['node', 'td', '--user', 'a@example.com', 'auth', 'token', 'view']
             resetGlobalArgs()

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -75,6 +75,7 @@ import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
 import { NoTokenError, getAuthMetadata, listStoredUsers, readConfig } from '../../lib/auth.js'
 import { resetGlobalArgs } from '../../lib/global-args.js'
 import { createMockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerAuthCommand } from './index.js'
 import { attachTodoistStatusCommand } from './status.js'
 
@@ -99,10 +100,7 @@ function stubProbeApiForUser(user = TEST_USER) {
 }
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerAuthCommand(program)
-    return program
+    return createTestProgram(registerAuthCommand)
 }
 
 describe('auth command', () => {

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -117,8 +117,6 @@ describe('auth command', () => {
     })
 
     afterEach(() => {
-        consoleSpy.mockRestore()
-        errorSpy.mockRestore()
         process.exitCode = undefined
     })
 

--- a/src/commands/auth/login.test.ts
+++ b/src/commands/auth/login.test.ts
@@ -38,6 +38,7 @@ vi.mock('@doist/cli-core/auth', async (importOriginal) => {
 })
 
 import { createTodoistTokenStore } from '../../lib/auth-store.js'
+import { mockConsoleError, mockConsoleLog } from '../../test-support/console-spy.js'
 import { attachTodoistLoginCommand } from './login.js'
 
 type AttachOptions = {
@@ -95,8 +96,8 @@ describe('attachTodoistLoginCommand: onSuccess output formatting', () => {
     let errorSpy: ReturnType<typeof vi.spyOn>
 
     beforeEach(() => {
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-        errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        consoleSpy = mockConsoleLog()
+        errorSpy = mockConsoleError()
     })
 
     afterEach(() => {

--- a/src/commands/auth/login.test.ts
+++ b/src/commands/auth/login.test.ts
@@ -101,8 +101,6 @@ describe('attachTodoistLoginCommand: onSuccess output formatting', () => {
     })
 
     afterEach(() => {
-        consoleSpy.mockRestore()
-        errorSpy.mockRestore()
         capturedAttachOptions.length = 0
     })
 

--- a/src/commands/auth/login.test.ts
+++ b/src/commands/auth/login.test.ts
@@ -39,6 +39,7 @@ vi.mock('@doist/cli-core/auth', async (importOriginal) => {
 
 import { createTodoistTokenStore } from '../../lib/auth-store.js'
 import { mockConsoleError, mockConsoleLog } from '../../test-support/console-spy.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { attachTodoistLoginCommand } from './login.js'
 
 type AttachOptions = {
@@ -53,9 +54,7 @@ type AttachOptions = {
 
 function attachAndCapture(): AttachOptions {
     capturedAttachOptions.length = 0
-    const program = new Command()
-    program.exitOverride()
-    attachTodoistLoginCommand(program, createTodoistTokenStore())
+    createTestProgram((program) => attachTodoistLoginCommand(program, createTodoistTokenStore()))
     return capturedAttachOptions[capturedAttachOptions.length - 1].options as AttachOptions
 }
 

--- a/src/commands/backup/backup.test.ts
+++ b/src/commands/backup/backup.test.ts
@@ -9,13 +9,12 @@ vi.mock('../../lib/auth.js', () => ({
     getAuthMetadata: vi.fn(),
 }))
 
-import { getApi } from '../../lib/api/core.js'
 import { getAuthMetadata } from '../../lib/auth.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerBackupCommand } from './index.js'
 
-const mockGetApi = vi.mocked(getApi)
 const mockGetAuthMetadata = vi.mocked(getAuthMetadata)
 
 function createProgram() {
@@ -27,8 +26,7 @@ describe('backup list', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockGetAuthMetadata.mockResolvedValue({
             authMode: 'read-write',
             authScope: 'data:read_write,data:delete,project:delete,backups:read',
@@ -171,8 +169,7 @@ describe('backup download', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockGetAuthMetadata.mockResolvedValue({
             authMode: 'read-write',
             authScope: 'data:read_write,data:delete,project:delete,backups:read',

--- a/src/commands/backup/backup.test.ts
+++ b/src/commands/backup/backup.test.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs'
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
@@ -13,16 +12,14 @@ vi.mock('../../lib/auth.js', () => ({
 import { getApi } from '../../lib/api/core.js'
 import { getAuthMetadata } from '../../lib/auth.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerBackupCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
 const mockGetAuthMetadata = vi.mocked(getAuthMetadata)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerBackupCommand(program)
-    return program
+    return createTestProgram(registerBackupCommand)
 }
 
 describe('backup list', () => {

--- a/src/commands/backup/backup.test.ts
+++ b/src/commands/backup/backup.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../lib/auth.js', () => ({
 
 import { getAuthMetadata } from '../../lib/auth.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleError, mockConsoleLog } from '../../test-support/console-spy.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerBackupCommand } from './index.js'
@@ -36,7 +37,7 @@ describe('backup list', () => {
 
     it('lists available backups', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getBackups.mockResolvedValue([
             { version: '2024-01-15_12:00', url: 'https://example.com/backup1.zip' },
@@ -47,24 +48,22 @@ describe('backup list', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('2024-01-15_12:00'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('2024-01-14_12:00'))
-        consoleSpy.mockRestore()
     })
 
     it('shows "No backups found." when empty', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getBackups.mockResolvedValue([])
 
         await program.parseAsync(['node', 'td', 'backup', 'list'])
 
         expect(consoleSpy).toHaveBeenCalledWith('No backups found.')
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getBackups.mockResolvedValue([
             { version: '2024-01-15_12:00', url: 'https://example.com/backup1.zip' },
@@ -77,12 +76,11 @@ describe('backup list', () => {
         expect(parsed.results).toHaveLength(1)
         expect(parsed.results[0].version).toBe('2024-01-15_12:00')
         expect(parsed.nextCursor).toBeNull()
-        consoleSpy.mockRestore()
     })
 
     it('outputs NDJSON with --ndjson flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getBackups.mockResolvedValue([
             { version: '2024-01-15_12:00', url: 'https://example.com/backup1.zip' },
@@ -96,7 +94,6 @@ describe('backup list', () => {
         expect(lines).toHaveLength(2)
         const line1 = JSON.parse(lines[0])
         expect(line1.version).toBe('2024-01-15_12:00')
-        consoleSpy.mockRestore()
     })
 
     it('throws error when token is missing backups:read scope', async () => {
@@ -179,7 +176,7 @@ describe('backup download', () => {
 
     it('downloads a backup to the specified output path', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
         const writeSpy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {})
 
         mockApi.getBackups.mockResolvedValue([
@@ -207,8 +204,6 @@ describe('backup download', () => {
         })
         expect(writeSpy).toHaveBeenCalledWith('/tmp/backup.zip', expect.any(Buffer))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('/tmp/backup.zip'))
-        consoleSpy.mockRestore()
-        writeSpy.mockRestore()
     })
 
     it('throws error when download response is not ok', async () => {
@@ -239,13 +234,11 @@ describe('backup download', () => {
 
     it('errors when --output-file is not provided', async () => {
         const program = createProgram()
-        const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        mockConsoleError()
 
         await expect(
             program.parseAsync(['node', 'td', 'backup', 'download', '2024-01-15_12:00']),
         ).rejects.toThrow()
-
-        stderrSpy.mockRestore()
     })
 
     it('throws error when version is not found', async () => {

--- a/src/commands/changelog.test.ts
+++ b/src/commands/changelog.test.ts
@@ -5,6 +5,7 @@ vi.mock('node:fs/promises')
 
 import { readFile } from 'node:fs/promises'
 import packageJson from '../../package.json' with { type: 'json' }
+import { mockConsoleLog } from '../test-support/console-spy.js'
 import { registerChangelogCommand } from './changelog.js'
 
 const mockReadFile = vi.mocked(readFile)
@@ -26,7 +27,7 @@ describe('changelog wrapper', () => {
     let logSpy: ReturnType<typeof vi.spyOn>
 
     beforeEach(() => {
-        logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        logSpy = mockConsoleLog()
     })
 
     afterEach(() => {

--- a/src/commands/comment/comment.test.ts
+++ b/src/commands/comment/comment.test.ts
@@ -9,7 +9,8 @@ vi.mock('../../lib/api/core.js', () => ({
 }))
 
 import { getApi } from '../../lib/api/core.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerCommentCommand } from './index.js'
 
@@ -37,8 +38,7 @@ describe('comment list', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('resolves task and lists comments', async () => {
@@ -130,8 +130,7 @@ describe('comment add', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('adds comment to task', async () => {
@@ -184,8 +183,7 @@ describe('comment delete', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('rejects plain text references', async () => {
@@ -236,8 +234,7 @@ describe('comment update', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('rejects plain text references', async () => {
@@ -322,8 +319,7 @@ describe('comment add with attachment', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('uploads file and attaches to comment', async () => {
@@ -459,8 +455,7 @@ describe('comment list with attachments', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('shows [file] marker for comments with attachments', async () => {
@@ -578,8 +573,7 @@ describe('comment view', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('rejects plain text references', async () => {
@@ -851,8 +845,7 @@ describe('project comment list', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('lists comments on a project with --project flag', async () => {
@@ -905,8 +898,7 @@ describe('comment add with --stdin', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('reads content from stdin with --stdin flag', async () => {
@@ -999,8 +991,7 @@ describe('comment add --json', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('outputs created comment as JSON', async () => {
@@ -1068,8 +1059,7 @@ describe('comment update --json', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('outputs updated comment as JSON', async () => {
@@ -1111,8 +1101,7 @@ describe('project comment add', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('adds comment to project with --project flag', async () => {
@@ -1189,8 +1178,7 @@ describe('comment --dry-run', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('comment add --dry-run previews without calling API', async () => {

--- a/src/commands/comment/comment.test.ts
+++ b/src/commands/comment/comment.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../lib/api/core.js', () => ({
 
 import { getApi } from '../../lib/api/core.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerCommentCommand } from './index.js'
@@ -43,7 +44,7 @@ describe('comment list', () => {
 
     it('resolves task and lists comments', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Buy milk' })
         mockApi.getComments.mockResolvedValue({
@@ -69,12 +70,11 @@ describe('comment list', () => {
         )
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Remember organic'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Got it'))
-        consoleSpy.mockRestore()
     })
 
     it('shows "No comments" when empty', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Test' })
         mockApi.getComments.mockResolvedValue({ results: [], nextCursor: null })
@@ -82,12 +82,11 @@ describe('comment list', () => {
         await program.parseAsync(['node', 'td', 'comment', 'list', 'id:task-1'])
 
         expect(consoleSpy).toHaveBeenCalledWith('No comments.')
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Test' })
         mockApi.getComments.mockResolvedValue({
@@ -103,12 +102,11 @@ describe('comment list', () => {
         const parsed = JSON.parse(output)
         expect(parsed.results).toBeDefined()
         expect(parsed.results[0].content).toBe('Note')
-        consoleSpy.mockRestore()
     })
 
     it('resolves task by name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'Buy milk' }],
@@ -121,7 +119,6 @@ describe('comment list', () => {
         expect(mockApi.getComments).toHaveBeenCalledWith(
             expect.objectContaining({ taskId: 'task-1' }),
         )
-        consoleSpy.mockRestore()
     })
 })
 
@@ -135,7 +132,7 @@ describe('comment add', () => {
 
     it('adds comment to task', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Buy milk' })
         mockApi.addComment.mockResolvedValue({
@@ -158,12 +155,11 @@ describe('comment add', () => {
             content: 'Get 2%',
         })
         expect(consoleSpy).toHaveBeenCalledWith('Added comment to "Buy milk"')
-        consoleSpy.mockRestore()
     })
 
     it('shows comment ID after creation', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Test' })
         mockApi.addComment.mockResolvedValue({
@@ -174,7 +170,6 @@ describe('comment add', () => {
         await program.parseAsync(['node', 'td', 'comment', 'add', 'id:task-1', '--content', 'Note'])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('comment-xyz'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -196,7 +191,7 @@ describe('comment delete', () => {
 
     it('shows dry-run without --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getComment.mockResolvedValue({
             id: 'comment-1',
@@ -208,12 +203,11 @@ describe('comment delete', () => {
         expect(mockApi.deleteComment).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Would delete comment: Test comment')
         expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
-        consoleSpy.mockRestore()
     })
 
     it('deletes comment with id: prefix and --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getComment.mockResolvedValue({
             id: 'comment-123',
@@ -225,7 +219,6 @@ describe('comment delete', () => {
 
         expect(mockApi.deleteComment).toHaveBeenCalledWith('comment-123')
         expect(consoleSpy).toHaveBeenCalledWith('Deleted comment: Test comment (id:comment-123)')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -255,7 +248,7 @@ describe('comment update', () => {
 
     it('updates comment content', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getComment.mockResolvedValue({
             id: 'comment-123',
@@ -280,12 +273,11 @@ describe('comment update', () => {
             content: 'New content',
         })
         expect(consoleSpy).toHaveBeenCalledWith('Updated comment: Old content (id:comment-123)')
-        consoleSpy.mockRestore()
     })
 
     it('truncates long content in output', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         const longContent = 'A'.repeat(60)
         mockApi.getComment.mockResolvedValue({
@@ -310,7 +302,6 @@ describe('comment update', () => {
         expect(consoleSpy).toHaveBeenCalledWith(
             `Updated comment: ${'A'.repeat(50)}... (id:comment-123)`,
         )
-        consoleSpy.mockRestore()
     })
 })
 
@@ -324,7 +315,7 @@ describe('comment add with attachment', () => {
 
     it('uploads file and attaches to comment', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Buy milk' })
         mockApi.addComment.mockResolvedValue({
@@ -360,12 +351,11 @@ describe('comment add with attachment', () => {
             },
         })
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Attached: test.pdf'))
-        consoleSpy.mockRestore()
     })
 
     it('forwards --file-name to api.uploadFile as the attachment filename', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Buy milk' })
         mockApi.addComment.mockResolvedValue({
@@ -391,7 +381,6 @@ describe('comment add with attachment', () => {
         expect(callArg.fileName).toBe('custom-name.pdf')
         // Override wins over basename(--file).
         expect(callArg.fileName).not.toBe('file.pdf')
-        consoleSpy.mockRestore()
     })
 
     it('returns FILE_NOT_FOUND when the --file path does not exist', async () => {
@@ -423,7 +412,7 @@ describe('comment add with attachment', () => {
 
     it('works without --file flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Buy milk' })
         mockApi.addComment.mockResolvedValue({
@@ -446,7 +435,6 @@ describe('comment add with attachment', () => {
             taskId: 'task-1',
             content: 'Just text',
         })
-        consoleSpy.mockRestore()
     })
 })
 
@@ -460,7 +448,7 @@ describe('comment list with attachments', () => {
 
     it('shows [file] marker for comments with attachments', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Test' })
         mockApi.getComments.mockResolvedValue({
@@ -482,12 +470,11 @@ describe('comment list with attachments', () => {
         await program.parseAsync(['node', 'td', 'comment', 'list', 'id:task-1'])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[file]'))
-        consoleSpy.mockRestore()
     })
 
     it('truncates long content to default 3 lines', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Test' })
         mockApi.getComments.mockResolvedValue({
@@ -508,12 +495,11 @@ describe('comment list with attachments', () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Line 2'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Line 3'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('...'))
-        consoleSpy.mockRestore()
     })
 
     it('respects --lines flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Test' })
         mockApi.getComments.mockResolvedValue({
@@ -532,12 +518,11 @@ describe('comment list with attachments', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Line 1'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('...'))
-        consoleSpy.mockRestore()
     })
 
     it('includes hasAttachment in JSON output', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Test' })
         mockApi.getComments.mockResolvedValue({
@@ -564,7 +549,6 @@ describe('comment list with attachments', () => {
         const parsed = JSON.parse(output)
         expect(parsed.results[0].hasAttachment).toBe(true)
         expect(parsed.results[1].hasAttachment).toBe(false)
-        consoleSpy.mockRestore()
     })
 })
 
@@ -586,7 +570,7 @@ describe('comment view', () => {
 
     it('implicit view: td comment <ref> behaves like td comment view <ref>', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getComment.mockResolvedValue({
             id: 'comment-123',
@@ -598,12 +582,11 @@ describe('comment view', () => {
         await program.parseAsync(['node', 'td', 'comment', 'id:comment-123'])
 
         expect(mockApi.getComment).toHaveBeenCalledWith('comment-123')
-        consoleSpy.mockRestore()
     })
 
     it('shows full comment content', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getComment.mockResolvedValue({
             id: 'comment-123',
@@ -618,12 +601,11 @@ describe('comment view', () => {
         expect(consoleSpy).toHaveBeenCalledWith(
             'Full content here\nWith multiple lines\nNo truncation',
         )
-        consoleSpy.mockRestore()
     })
 
     it('shows attachment details', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getComment.mockResolvedValue({
             id: 'comment-123',
@@ -648,12 +630,11 @@ describe('comment view', () => {
         )
         const output = consoleSpy.mock.calls.map((call) => call[0]).join('\n')
         expect(output).not.toContain('Hint:')
-        consoleSpy.mockRestore()
     })
 
     it('shows image-attachment hint steering agents away from direct download', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getComment.mockResolvedValue({
             id: 'comment-123',
@@ -675,12 +656,11 @@ describe('comment view', () => {
             "image attachment — fetch via 'td attachment view <url>' if needed",
         )
         expect(output).toContain('do not download and Read directly')
-        consoleSpy.mockRestore()
     })
 
     it('shows image-attachment hint when only fileName signals the image type', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getComment.mockResolvedValue({
             id: 'comment-123',
@@ -700,12 +680,11 @@ describe('comment view', () => {
         const output = consoleSpy.mock.calls.map((call) => call[0]).join('\n')
         expect(output).toContain('Hint:')
         expect(output).toContain('image attachment')
-        consoleSpy.mockRestore()
     })
 
     it('omits image hint when fileUrl is missing even if fileType is an image type', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getComment.mockResolvedValue({
             id: 'comment-123',
@@ -724,12 +703,11 @@ describe('comment view', () => {
 
         const output = consoleSpy.mock.calls.map((call) => call[0]).join('\n')
         expect(output).not.toContain('Hint:')
-        consoleSpy.mockRestore()
     })
 
     it('writes image hint to stderr when --json is used with an image attachment', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
         const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
 
         mockApi.getComment.mockResolvedValue({
@@ -754,14 +732,11 @@ describe('comment view', () => {
         const stderr = stderrSpy.mock.calls.map((call) => String(call[0])).join('')
         expect(stderr).toContain('Hint:')
         expect(stderr).toContain('image attachment')
-
-        stderrSpy.mockRestore()
-        consoleSpy.mockRestore()
     })
 
     it('does not write to stderr when --json is used with a non-image attachment', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
         const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
 
         mockApi.getComment.mockResolvedValue({
@@ -781,14 +756,11 @@ describe('comment view', () => {
 
         const stderr = stderrSpy.mock.calls.map((call) => String(call[0])).join('')
         expect(stderr).not.toContain('Hint:')
-
-        stderrSpy.mockRestore()
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getComment.mockResolvedValue({
             id: 'comment-123',
@@ -806,12 +778,11 @@ describe('comment view', () => {
         expect(parsed.id).toBe('comment-123')
         expect(parsed.content).toBe('Test content')
         expect(parsed.postedAt).toBe('2026-01-08T10:00:00.000Z')
-        consoleSpy.mockRestore()
     })
 
     it('outputs full JSON with --json --full', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getComment.mockResolvedValue({
             id: 'comment-123',
@@ -836,7 +807,6 @@ describe('comment view', () => {
         const output = consoleSpy.mock.calls[0][0]
         const parsed = JSON.parse(output)
         expect(parsed.extraField).toBe('extra')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -850,7 +820,7 @@ describe('project comment list', () => {
 
     it('lists comments on a project with --project flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Work' })
         mockApi.getComments.mockResolvedValue({
@@ -871,12 +841,11 @@ describe('project comment list', () => {
             expect.objectContaining({ projectId: 'proj-1' }),
         )
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Project note'))
-        consoleSpy.mockRestore()
     })
 
     it('resolves project by name with --project flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getProjects.mockResolvedValue({
             results: [{ id: 'proj-1', name: 'Work' }],
@@ -889,7 +858,6 @@ describe('project comment list', () => {
         expect(mockApi.getComments).toHaveBeenCalledWith(
             expect.objectContaining({ projectId: 'proj-1' }),
         )
-        consoleSpy.mockRestore()
     })
 })
 
@@ -903,10 +871,10 @@ describe('comment add with --stdin', () => {
 
     it('reads content from stdin with --stdin flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         const mockStdin = new PassThrough()
-        const stdinSpy = vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as any)
+        vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as any)
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Buy milk' })
         mockApi.addComment.mockResolvedValue({
@@ -930,8 +898,6 @@ describe('comment add with --stdin', () => {
             taskId: 'task-1',
             content: 'Multiline\ncontent here',
         })
-        consoleSpy.mockRestore()
-        stdinSpy.mockRestore()
     })
 
     it('errors when both --content and --stdin are provided', async () => {
@@ -955,10 +921,10 @@ describe('comment add with --stdin', () => {
 
     it('works with multiline content from stdin', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         const mockStdin = new PassThrough()
-        const stdinSpy = vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as any)
+        vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as any)
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'My task' })
         mockApi.addComment.mockResolvedValue({ id: 'comment-new', content: 'line1\nline2\nline3' })
@@ -981,8 +947,6 @@ describe('comment add with --stdin', () => {
             taskId: 'task-1',
             content: 'line1\nline2\nline3',
         })
-        consoleSpy.mockRestore()
-        stdinSpy.mockRestore()
     })
 })
 
@@ -996,7 +960,7 @@ describe('comment add --json', () => {
 
     it('outputs created comment as JSON', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Buy milk' })
         mockApi.addComment.mockResolvedValue({
@@ -1023,12 +987,11 @@ describe('comment add --json', () => {
         const parsed = JSON.parse(output)
         expect(parsed.id).toBe('comment-new')
         expect(parsed.content).toBe('Test note')
-        consoleSpy.mockRestore()
     })
 
     it('does not print plain-text confirmation with --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Buy milk' })
         mockApi.addComment.mockResolvedValue({
@@ -1050,7 +1013,6 @@ describe('comment add --json', () => {
         ])
 
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Added comment to'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1064,7 +1026,7 @@ describe('comment update --json', () => {
 
     it('outputs updated comment as JSON', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getComment.mockResolvedValue({
             id: 'comment-123',
@@ -1092,7 +1054,6 @@ describe('comment update --json', () => {
         const parsed = JSON.parse(output)
         expect(parsed.id).toBe('comment-123')
         expect(parsed.content).toBe('New content')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1106,7 +1067,7 @@ describe('project comment add', () => {
 
     it('adds comment to project with --project flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Work' })
         mockApi.addComment.mockResolvedValue({
@@ -1130,12 +1091,11 @@ describe('project comment add', () => {
             content: 'Project note',
         })
         expect(consoleSpy).toHaveBeenCalledWith('Added comment to "Work"')
-        consoleSpy.mockRestore()
     })
 
     it('adds comment with attachment to project', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Work' })
         mockApi.addComment.mockResolvedValue({
@@ -1169,7 +1129,6 @@ describe('project comment add', () => {
                 resourceType: 'file',
             },
         })
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1183,7 +1142,7 @@ describe('comment --dry-run', () => {
 
     it('comment add --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'Test task' }],
@@ -1203,12 +1162,11 @@ describe('comment --dry-run', () => {
 
         expect(mockApi.addComment).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would add comment'))
-        consoleSpy.mockRestore()
     })
 
     it('comment delete --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getComment.mockResolvedValue({ id: 'comment-1', content: 'Test comment' })
 
@@ -1216,12 +1174,11 @@ describe('comment --dry-run', () => {
 
         expect(mockApi.deleteComment).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would delete comment'))
-        consoleSpy.mockRestore()
     })
 
     it('comment update --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync([
             'node',
@@ -1236,7 +1193,6 @@ describe('comment --dry-run', () => {
 
         expect(mockApi.updateComment).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would update comment'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1254,6 +1210,5 @@ describe('comment (no args)', () => {
         const output = stdoutSpy.mock.calls.map((c) => c[0]).join('')
         expect(output).toContain('Examples:')
         expect(output).toContain('td comment list "Plan sprint"')
-        stdoutSpy.mockRestore()
     })
 })

--- a/src/commands/comment/comment.test.ts
+++ b/src/commands/comment/comment.test.ts
@@ -10,7 +10,11 @@ vi.mock('../../lib/api/core.js', () => ({
 
 import { getApi } from '../../lib/api/core.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
-import { mockConsoleLog } from '../../test-support/console-spy.js'
+import {
+    mockConsoleLog,
+    mockProcessStderr,
+    mockProcessStdout,
+} from '../../test-support/console-spy.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerCommentCommand } from './index.js'
@@ -708,7 +712,7 @@ describe('comment view', () => {
     it('writes image hint to stderr when --json is used with an image attachment', async () => {
         const program = createProgram()
         const consoleSpy = mockConsoleLog()
-        const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+        const stderrSpy = mockProcessStderr()
 
         mockApi.getComment.mockResolvedValue({
             id: 'comment-123',
@@ -737,7 +741,7 @@ describe('comment view', () => {
     it('does not write to stderr when --json is used with a non-image attachment', async () => {
         const program = createProgram()
         mockConsoleLog()
-        const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+        const stderrSpy = mockProcessStderr()
 
         mockApi.getComment.mockResolvedValue({
             id: 'comment-123',
@@ -1199,7 +1203,7 @@ describe('comment --dry-run', () => {
 describe('comment (no args)', () => {
     it('shows parent help with examples', async () => {
         const program = createProgram()
-        const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+        const stdoutSpy = mockProcessStdout()
 
         try {
             await program.parseAsync(['node', 'td', 'comment'])

--- a/src/commands/comment/comment.test.ts
+++ b/src/commands/comment/comment.test.ts
@@ -2,7 +2,6 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
-import { Command } from 'commander'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
@@ -11,6 +10,7 @@ vi.mock('../../lib/api/core.js', () => ({
 
 import { getApi } from '../../lib/api/core.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerCommentCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
@@ -29,10 +29,7 @@ afterAll(async () => {
 })
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerCommentCommand(program)
-    return program
+    return createTestProgram(registerCommentCommand)
 }
 
 describe('comment list', () => {

--- a/src/commands/completed/completed.test.ts
+++ b/src/commands/completed/completed.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
     getApi: vi.fn(),
 }))
 
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerCompletedCommand } from './index.js'
@@ -31,11 +32,7 @@ describe('completed command', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('shows completed tasks', async () => {

--- a/src/commands/completed/completed.test.ts
+++ b/src/commands/completed/completed.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
@@ -7,15 +6,13 @@ vi.mock('../../lib/api/core.js', () => ({
 
 import { getApi } from '../../lib/api/core.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerCompletedCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerCompletedCommand(program)
-    return program
+    return createTestProgram(registerCompletedCommand)
 }
 
 function getToday(): string {

--- a/src/commands/completed/completed.test.ts
+++ b/src/commands/completed/completed.test.ts
@@ -4,12 +4,10 @@ vi.mock('../../lib/api/core.js', () => ({
     getApi: vi.fn(),
 }))
 
-import { getApi } from '../../lib/api/core.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerCompletedCommand } from './index.js'
-
-const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
     return createTestProgram(registerCompletedCommand)
@@ -32,8 +30,7 @@ describe('completed command', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 

--- a/src/commands/config/config.test.ts
+++ b/src/commands/config/config.test.ts
@@ -21,6 +21,7 @@ import { SecureStoreUnavailableError } from '@doist/cli-core/auth'
 import { listStoredUsers, NoTokenError, probeApiToken } from '../../lib/auth.js'
 import { type Config, readConfigStrict } from '../../lib/config.js'
 import { CliError } from '../../lib/errors.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerConfigCommand } from './index.js'
 
@@ -80,7 +81,7 @@ describe('config view', () => {
             authScope: 'data:read,data:delete',
             authFlags: ['app-management'],
         })
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view'])
 
@@ -94,14 +95,12 @@ describe('config view', () => {
         expect(output).toContain('config file (plaintext fallback)')
         expect(output).toContain('read-write')
         expect(output).toContain('en-us')
-
-        consoleSpy.mockRestore()
     })
 
     it('labels tokens stored in the system credential manager', async () => {
         presentConfig({ auth_mode: 'read-write' })
         mockToken('secure-store', { token: 'tdo_keychainXXXXXXXX1234' })
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view'])
 
@@ -109,8 +108,6 @@ describe('config view', () => {
         expect(output).toContain('****…1234')
         expect(output).toContain('system credential manager')
         expect(output).not.toContain('plaintext')
-
-        consoleSpy.mockRestore()
     })
 
     it('labels env-sourced tokens and shows active mode, not stale config values', async () => {
@@ -122,7 +119,7 @@ describe('config view', () => {
             auth_flags: ['read-only'],
         })
         mockToken('env', { token: 'tdo_envXXXXXXXX5678', authMode: 'unknown' })
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view'])
 
@@ -133,14 +130,12 @@ describe('config view', () => {
         expect(output).toContain('Mode:          unknown')
         expect(output).not.toContain('data:read')
         expect(output).not.toMatch(/Flags:\s+read-only/)
-
-        consoleSpy.mockRestore()
     })
 
     it('degrades gracefully when the credential manager is unavailable', async () => {
         presentConfig({ auth_mode: 'read-write', update_channel: 'stable' })
         mockProbeApiToken.mockRejectedValue(new SecureStoreUnavailableError('macOS Keychain error'))
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view'])
 
@@ -148,13 +143,11 @@ describe('config view', () => {
         expect(output).toContain('unknown')
         expect(output).toContain('system credential manager unavailable')
         expect(output).toContain('stable')
-
-        consoleSpy.mockRestore()
     })
 
     it('--json emits the raw config with api_token masked', async () => {
         presentConfig()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view', '--json'])
 
@@ -162,14 +155,12 @@ describe('config view', () => {
         expect(parsed.api_token).toBe('****…7890')
         expect(parsed.auth_mode).toBe('read-write')
         expect(parsed.hc).toEqual({ defaultLocale: 'en-us' })
-
-        consoleSpy.mockRestore()
     })
 
     it('--show-token reveals the full token in both views', async () => {
         presentConfig()
         mockToken('config-file')
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view', '--show-token'])
         const pretty = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
@@ -179,14 +170,12 @@ describe('config view', () => {
         await createProgram().parseAsync(['node', 'td', 'config', 'view', '--json', '--show-token'])
         const json = JSON.parse(consoleSpy.mock.calls[0][0] as string)
         expect(json.api_token).toBe('tdo_abcdefghij1234567890')
-
-        consoleSpy.mockRestore()
     })
 
     it('handles a missing config file gracefully', async () => {
         missingConfig()
         mockProbeApiToken.mockRejectedValue(new NoTokenError())
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view'])
         expect(consoleSpy.mock.calls[0][0]).toContain('not created yet')
@@ -194,8 +183,6 @@ describe('config view', () => {
         consoleSpy.mockClear()
         await createProgram().parseAsync(['node', 'td', 'config', 'view', '--json'])
         expect(consoleSpy.mock.calls[0][0]).toBe('{}')
-
-        consoleSpy.mockRestore()
     })
 
     it('surfaces malformed-config errors instead of silently pretending it is empty', async () => {
@@ -216,26 +203,22 @@ describe('config view', () => {
     it('shows "not set" when no token can be found anywhere', async () => {
         presentConfig({ update_channel: 'stable' })
         mockProbeApiToken.mockRejectedValue(new NoTokenError())
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view'])
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
         expect(output).toContain('not set')
         expect(output).toContain('stable')
-
-        consoleSpy.mockRestore()
     })
 
     it('masks very short tokens without exposing characters', async () => {
         presentConfig({ api_token: 'abcd' })
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view', '--json'])
         const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string)
         expect(parsed.api_token).toBe('****')
         expect(parsed.api_token).not.toContain('abcd')
-
-        consoleSpy.mockRestore()
     })
 
     it('lists stored accounts and marks the default in pretty mode', async () => {
@@ -270,7 +253,7 @@ describe('config view', () => {
                 email: 'first@example.com',
             },
         })
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view'])
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
@@ -281,8 +264,6 @@ describe('config view', () => {
         expect(output).toContain('(default)')
         expect(output).toContain('Active:        first@example.com')
         expect(output).toContain('read-only (data:read)')
-
-        consoleSpy.mockRestore()
     })
 
     it('flags ambiguous resolution when multiple users with no default', async () => {
@@ -299,7 +280,7 @@ describe('config view', () => {
         ])
         const { NoUserSelectedError } = await import('../../lib/users.js')
         mockProbeApiToken.mockRejectedValue(new NoUserSelectedError())
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view'])
         const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
@@ -307,8 +288,6 @@ describe('config view', () => {
         expect(output).toContain('multiple stored accounts')
         expect(output).toContain('--user')
         expect(output).toContain('Stored accounts (2)')
-
-        consoleSpy.mockRestore()
     })
 
     it('--json masks per-user api_token entries', async () => {
@@ -322,13 +301,11 @@ describe('config view', () => {
                 },
             ],
         })
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await createProgram().parseAsync(['node', 'td', 'config', 'view', '--json'])
         const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string)
         expect(parsed.users[0].api_token).toBe('****…xxxx')
         expect(parsed.users[0].api_token).not.toContain('plaintext')
-
-        consoleSpy.mockRestore()
     })
 })

--- a/src/commands/config/config.test.ts
+++ b/src/commands/config/config.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/config.js', () => ({
@@ -22,6 +21,7 @@ import { SecureStoreUnavailableError } from '@doist/cli-core/auth'
 import { listStoredUsers, NoTokenError, probeApiToken } from '../../lib/auth.js'
 import { type Config, readConfigStrict } from '../../lib/config.js'
 import { CliError } from '../../lib/errors.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerConfigCommand } from './index.js'
 
 const mockReadConfigStrict = vi.mocked(readConfigStrict)
@@ -29,10 +29,7 @@ const mockProbeApiToken = vi.mocked(probeApiToken)
 const mockListStoredUsers = vi.mocked(listStoredUsers)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerConfigCommand(program)
-    return program
+    return createTestProgram(registerConfigCommand)
 }
 
 const fullConfig: Config = {

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -132,7 +132,6 @@ describe('doctor command', () => {
     })
 
     afterEach(() => {
-        consoleSpy.mockRestore()
         process.exitCode = undefined
         if (originalProcessVersion) {
             Object.defineProperty(process, 'version', originalProcessVersion)

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -1,5 +1,4 @@
 import { readFile } from 'node:fs/promises'
-import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { mockWithSpinner, mockProgressTracker, mockLoadingSpinnerStart, mockLoadingSpinnerStop } =
@@ -72,6 +71,7 @@ vi.mock('../lib/config.js', async (importOriginal) => {
 import { TodoistApi } from '@doist/todoist-sdk'
 import { NoTokenError, probeApiToken } from '../lib/auth.js'
 import { readConfig } from '../lib/config.js'
+import { createTestProgram } from '../test-support/program.js'
 import { registerDoctorCommand } from './doctor.js'
 
 const mockReadFile = vi.mocked(readFile)
@@ -80,10 +80,7 @@ const mockProbeApiToken = vi.mocked(probeApiToken)
 const mockReadConfig = vi.mocked(readConfig)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerDoctorCommand(program)
-    return program
+    return createTestProgram(registerDoctorCommand)
 }
 
 function mockFetch(version: string) {

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -71,6 +71,7 @@ vi.mock('../lib/config.js', async (importOriginal) => {
 import { TodoistApi } from '@doist/todoist-sdk'
 import { NoTokenError, probeApiToken } from '../lib/auth.js'
 import { readConfig } from '../lib/config.js'
+import { mockConsoleLog } from '../test-support/console-spy.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerDoctorCommand } from './doctor.js'
 
@@ -98,7 +99,7 @@ describe('doctor command', () => {
     let originalProcessVersion: PropertyDescriptor | undefined
 
     beforeEach(() => {
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        consoleSpy = mockConsoleLog()
         vi.clearAllMocks()
         vi.unstubAllGlobals()
         process.exitCode = undefined

--- a/src/commands/filter/filter.test.ts
+++ b/src/commands/filter/filter.test.ts
@@ -13,6 +13,7 @@ vi.mock('../../lib/api/filters.js', () => ({
 
 import { addFilter, deleteFilter, fetchFilters, updateFilter } from '../../lib/api/filters.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { makeFilter } from '../../test-support/fixtures.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
@@ -34,7 +35,7 @@ describe('filter list', () => {
 
     it('lists all filters', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Work tasks', query: '@work' }),
@@ -45,24 +46,22 @@ describe('filter list', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Work tasks'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Urgent'))
-        consoleSpy.mockRestore()
     })
 
     it('shows "No filters found" when empty', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([])
 
         await program.parseAsync(['node', 'td', 'filter', 'list'])
 
         expect(consoleSpy).toHaveBeenCalledWith('No filters found.')
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Work', query: '@work' }),
@@ -74,12 +73,11 @@ describe('filter list', () => {
         const parsed = JSON.parse(output)
         expect(parsed.results).toBeDefined()
         expect(parsed.results[0].name).toBe('Work')
-        consoleSpy.mockRestore()
     })
 
     it('outputs NDJSON with --ndjson flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Work', query: '@work' }),
@@ -91,7 +89,6 @@ describe('filter list', () => {
         const output = consoleSpy.mock.calls[0][0]
         const lines = output.split('\n')
         expect(lines).toHaveLength(2)
-        consoleSpy.mockRestore()
     })
 })
 
@@ -102,7 +99,7 @@ describe('filter create --json', () => {
 
     it('outputs created filter as JSON', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockAddFilter.mockResolvedValue({
             id: 'filter-new',
@@ -133,7 +130,6 @@ describe('filter create --json', () => {
         expect(parsed.name).toBe('My Filter')
         expect(parsed.query).toBe('today')
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Created:'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -144,7 +140,7 @@ describe('filter create', () => {
 
     it('creates filter with name and query', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockAddFilter.mockResolvedValue(
             makeFilter({ id: 'filter-new', name: 'Work', query: '@work' }),
@@ -165,12 +161,11 @@ describe('filter create', () => {
             expect.objectContaining({ name: 'Work', query: '@work' }),
         )
         expect(consoleSpy).toHaveBeenCalledWith('Created: Work')
-        consoleSpy.mockRestore()
     })
 
     it('creates filter with --color', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockAddFilter.mockResolvedValue(
             makeFilter({ id: 'filter-new', name: 'Urgent', query: 'p1', color: 'red' }),
@@ -192,12 +187,11 @@ describe('filter create', () => {
         expect(mockAddFilter).toHaveBeenCalledWith(
             expect.objectContaining({ name: 'Urgent', query: 'p1', color: 'red' }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('creates filter with --favorite', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockAddFilter.mockResolvedValue(
             makeFilter({ id: 'filter-new', name: 'Important', query: 'p1 | p2', isFavorite: true }),
@@ -218,12 +212,11 @@ describe('filter create', () => {
         expect(mockAddFilter).toHaveBeenCalledWith(
             expect.objectContaining({ name: 'Important', isFavorite: true }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('shows filter ID after creation', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockAddFilter.mockResolvedValue(
             makeFilter({ id: 'filter-xyz', name: 'Test', query: 'today' }),
@@ -241,7 +234,6 @@ describe('filter create', () => {
         ])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('id:filter-xyz'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -252,7 +244,7 @@ describe('filter delete', () => {
 
     it('shows dry-run without --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Work', query: '@work' }),
@@ -263,12 +255,11 @@ describe('filter delete', () => {
         expect(mockDeleteFilter).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Would delete: Work')
         expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
-        consoleSpy.mockRestore()
     })
 
     it('deletes by name with --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Work', query: '@work' }),
@@ -279,12 +270,11 @@ describe('filter delete', () => {
 
         expect(mockDeleteFilter).toHaveBeenCalledWith('filter-1')
         expect(consoleSpy).toHaveBeenCalledWith('Deleted: Work (id:filter-1)')
-        consoleSpy.mockRestore()
     })
 
     it('deletes by id: prefix with --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-123', name: 'Work', query: '@work' }),
@@ -294,7 +284,6 @@ describe('filter delete', () => {
         await program.parseAsync(['node', 'td', 'filter', 'delete', 'id:filter-123', '--yes'])
 
         expect(mockDeleteFilter).toHaveBeenCalledWith('filter-123')
-        consoleSpy.mockRestore()
     })
 
     it('throws for non-existent filter', async () => {
@@ -315,7 +304,7 @@ describe('filter update', () => {
 
     it('updates filter name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Old Name', query: '@work' }),
@@ -336,12 +325,11 @@ describe('filter update', () => {
             name: 'New Name',
         })
         expect(consoleSpy).toHaveBeenCalledWith('Updated: Old Name -> New Name (id:filter-1)')
-        consoleSpy.mockRestore()
     })
 
     it('updates filter query', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Work', query: '@work' }),
@@ -361,12 +349,11 @@ describe('filter update', () => {
         expect(mockUpdateFilter).toHaveBeenCalledWith('filter-1', {
             query: '@work & p1',
         })
-        consoleSpy.mockRestore()
     })
 
     it('updates filter color and favorite', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Work', query: '@work' }),
@@ -388,12 +375,11 @@ describe('filter update', () => {
             color: 'red',
             isFavorite: true,
         })
-        consoleSpy.mockRestore()
     })
 
     it('removes favorite with --no-favorite', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Work', query: '@work', isFavorite: true }),
@@ -405,12 +391,11 @@ describe('filter update', () => {
         expect(mockUpdateFilter).toHaveBeenCalledWith('filter-1', {
             isFavorite: false,
         })
-        consoleSpy.mockRestore()
     })
 
     it('updates by id: prefix', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-123', name: 'Work', query: '@work' }),
@@ -430,7 +415,6 @@ describe('filter update', () => {
         expect(mockUpdateFilter).toHaveBeenCalledWith('filter-123', {
             color: 'blue',
         })
-        consoleSpy.mockRestore()
     })
 
     it('throws when no changes specified', async () => {
@@ -474,7 +458,7 @@ describe('filter show', () => {
 
     it('shows tasks matching filter', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Work', query: '@work' }),
@@ -505,12 +489,11 @@ describe('filter show', () => {
         )
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Work'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Work task 1'))
-        consoleSpy.mockRestore()
     })
 
     it('shows "No tasks match this filter" when empty', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Empty', query: 'nonexistent' }),
@@ -524,12 +507,11 @@ describe('filter show', () => {
         await program.parseAsync(['node', 'td', 'filter', 'show', 'Empty'])
 
         expect(consoleSpy).toHaveBeenCalledWith('No tasks match this filter.')
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Work', query: '@work' }),
@@ -554,12 +536,11 @@ describe('filter show', () => {
         const parsed = JSON.parse(output)
         expect(parsed.results).toBeDefined()
         expect(parsed.results[0].content).toBe('Task 1')
-        consoleSpy.mockRestore()
     })
 
     it('shows filter by id: prefix', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-123', name: 'Work', query: '@work' }),
@@ -575,7 +556,6 @@ describe('filter show', () => {
         expect(mockApi.getTasksByFilter).toHaveBeenCalledWith(
             expect.objectContaining({ query: '@work' }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('throws for non-existent filter', async () => {
@@ -590,7 +570,7 @@ describe('filter show', () => {
 
     it('resolves partial name match', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Work Tasks', query: '@work' }),
@@ -606,7 +586,6 @@ describe('filter show', () => {
         expect(mockApi.getTasksByFilter).toHaveBeenCalledWith(
             expect.objectContaining({ query: '@work' }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('throws for ambiguous partial match', async () => {
@@ -647,7 +626,7 @@ describe('filter view (alias)', () => {
 
     it('works via "view" subcommand', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Work', query: '@work' }),
@@ -663,12 +642,11 @@ describe('filter view (alias)', () => {
         expect(mockApi.getTasksByFilter).toHaveBeenCalledWith(
             expect.objectContaining({ query: '@work' }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('defaults to view subcommand (td filter <ref>)', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Work', query: '@work' }),
@@ -684,7 +662,6 @@ describe('filter view (alias)', () => {
         expect(mockApi.getTasksByFilter).toHaveBeenCalledWith(
             expect.objectContaining({ query: '@work' }),
         )
-        consoleSpy.mockRestore()
     })
 })
 
@@ -698,7 +675,7 @@ describe('filter URL resolution', () => {
 
     it('resolves filter by URL in view command', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter1', name: 'Work', query: '@work' }),
@@ -720,12 +697,11 @@ describe('filter URL resolution', () => {
         expect(mockApi.getTasksByFilter).toHaveBeenCalledWith(
             expect.objectContaining({ query: '@work' }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('resolves filter by URL in delete command', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter1', name: 'Work', query: '@work' }),
@@ -742,7 +718,6 @@ describe('filter URL resolution', () => {
         ])
 
         expect(mockDeleteFilter).toHaveBeenCalledWith('filter1')
-        consoleSpy.mockRestore()
     })
 
     it('throws entity type mismatch for task URL in filter command', async () => {
@@ -782,7 +757,6 @@ describe('filter (no args)', () => {
         expect(output).toContain('delete')
         expect(output).toContain('update')
         expect(output).toContain('view')
-        stdoutSpy.mockRestore()
     })
 })
 
@@ -793,7 +767,7 @@ describe('filter --dry-run', () => {
 
     it('filter create --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync([
             'node',
@@ -809,12 +783,11 @@ describe('filter --dry-run', () => {
 
         expect(mockAddFilter).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would create filter'))
-        consoleSpy.mockRestore()
     })
 
     it('filter delete --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Work', query: '#Work' }),
@@ -824,12 +797,11 @@ describe('filter --dry-run', () => {
 
         expect(mockDeleteFilter).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would delete filter'))
-        consoleSpy.mockRestore()
     })
 
     it('filter update --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchFilters.mockResolvedValue([
             makeFilter({ id: 'filter-1', name: 'Work', query: '#Work' }),
@@ -848,6 +820,5 @@ describe('filter --dry-run', () => {
 
         expect(mockUpdateFilter).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would update filter'))
-        consoleSpy.mockRestore()
     })
 })

--- a/src/commands/filter/filter.test.ts
+++ b/src/commands/filter/filter.test.ts
@@ -11,14 +11,13 @@ vi.mock('../../lib/api/filters.js', () => ({
     deleteFilter: vi.fn(),
 }))
 
-import { getApi } from '../../lib/api/core.js'
 import { addFilter, deleteFilter, fetchFilters, updateFilter } from '../../lib/api/filters.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
 import { makeFilter } from '../../test-support/fixtures.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerFilterCommand } from './index.js'
 
-const mockGetApi = vi.mocked(getApi)
 const mockFetchFilters = vi.mocked(fetchFilters)
 const mockAddFilter = vi.mocked(addFilter)
 const mockUpdateFilter = vi.mocked(updateFilter)
@@ -470,8 +469,7 @@ describe('filter show', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('shows tasks matching filter', async () => {
@@ -644,8 +642,7 @@ describe('filter view (alias)', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('works via "view" subcommand', async () => {
@@ -696,8 +693,7 @@ describe('filter URL resolution', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('resolves filter by URL in view command', async () => {

--- a/src/commands/filter/filter.test.ts
+++ b/src/commands/filter/filter.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
@@ -16,6 +15,7 @@ import { getApi } from '../../lib/api/core.js'
 import { addFilter, deleteFilter, fetchFilters, updateFilter } from '../../lib/api/filters.js'
 import { makeFilter } from '../../test-support/fixtures.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerFilterCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
@@ -25,10 +25,7 @@ const mockUpdateFilter = vi.mocked(updateFilter)
 const mockDeleteFilter = vi.mocked(deleteFilter)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerFilterCommand(program)
-    return program
+    return createTestProgram(registerFilterCommand)
 }
 
 describe('filter list', () => {

--- a/src/commands/filter/filter.test.ts
+++ b/src/commands/filter/filter.test.ts
@@ -13,7 +13,7 @@ vi.mock('../../lib/api/filters.js', () => ({
 
 import { addFilter, deleteFilter, fetchFilters, updateFilter } from '../../lib/api/filters.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
-import { mockConsoleLog } from '../../test-support/console-spy.js'
+import { mockConsoleLog, mockProcessStdout } from '../../test-support/console-spy.js'
 import { makeFilter } from '../../test-support/fixtures.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
@@ -743,7 +743,7 @@ describe('filter URL resolution', () => {
 describe('filter (no args)', () => {
     it('shows parent help listing all subcommands', async () => {
         const program = createProgram()
-        const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+        const stdoutSpy = mockProcessStdout()
 
         try {
             await program.parseAsync(['node', 'td', 'filter'])

--- a/src/commands/folder/folder.test.ts
+++ b/src/commands/folder/folder.test.ts
@@ -9,13 +9,12 @@ vi.mock('../../lib/api/workspaces.js', () => ({
     fetchWorkspaceFolders: vi.fn(),
 }))
 
-import { getApi } from '../../lib/api/core.js'
 import { fetchWorkspaceFolders, fetchWorkspaces } from '../../lib/api/workspaces.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerFolderCommand } from './index.js'
 
-const mockGetApi = vi.mocked(getApi)
 const mockFetchWorkspaces = vi.mocked(fetchWorkspaces)
 const mockFetchWorkspaceFolders = vi.mocked(fetchWorkspaceFolders)
 
@@ -49,8 +48,7 @@ describe('folder list', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
@@ -123,8 +121,7 @@ describe('folder create', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
@@ -255,8 +252,7 @@ describe('folder update', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
         mockFetchWorkspaceFolders.mockResolvedValue([
             { id: 'folder-1', name: 'Engineering', workspaceId: '12345' },
@@ -342,8 +338,7 @@ describe('folder delete', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
         mockFetchWorkspaceFolders.mockResolvedValue([
             { id: 'folder-1', name: 'Engineering', workspaceId: '12345' },
@@ -393,8 +388,7 @@ describe('folder view', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
         mockFetchWorkspaceFolders.mockResolvedValue([
             { id: 'folder-1', name: 'Engineering', workspaceId: '12345' },
@@ -469,8 +463,7 @@ describe('folder workspace auto-detection', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockFetchWorkspaceFolders.mockResolvedValue([
             { id: 'folder-1', name: 'Engineering', workspaceId: '12345' },
         ])

--- a/src/commands/folder/folder.test.ts
+++ b/src/commands/folder/folder.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
@@ -13,6 +12,7 @@ vi.mock('../../lib/api/workspaces.js', () => ({
 import { getApi } from '../../lib/api/core.js'
 import { fetchWorkspaceFolders, fetchWorkspaces } from '../../lib/api/workspaces.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerFolderCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
@@ -20,10 +20,7 @@ const mockFetchWorkspaces = vi.mocked(fetchWorkspaces)
 const mockFetchWorkspaceFolders = vi.mocked(fetchWorkspaceFolders)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerFolderCommand(program)
-    return program
+    return createTestProgram(registerFolderCommand)
 }
 
 const mockWorkspace = {

--- a/src/commands/folder/folder.test.ts
+++ b/src/commands/folder/folder.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../lib/api/workspaces.js', () => ({
 
 import { fetchWorkspaceFolders, fetchWorkspaces } from '../../lib/api/workspaces.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerFolderCommand } from './index.js'
@@ -50,7 +51,7 @@ describe('folder list', () => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        consoleSpy = mockConsoleLog()
     })
 
     it('lists folders for a workspace', async () => {
@@ -67,7 +68,6 @@ describe('folder list', () => {
         )
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Engineering'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Design'))
-        consoleSpy.mockRestore()
     })
 
     it('shows "No folders found." when empty', async () => {
@@ -77,7 +77,6 @@ describe('folder list', () => {
         await program.parseAsync(['node', 'td', 'folder', 'list', 'Acme'])
 
         expect(consoleSpy).toHaveBeenCalledWith('No folders found.')
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json flag', async () => {
@@ -93,7 +92,6 @@ describe('folder list', () => {
         const parsed = JSON.parse(output)
         expect(parsed.results).toBeDefined()
         expect(parsed.results[0].name).toBe('Engineering')
-        consoleSpy.mockRestore()
     })
 
     it('accepts --workspace flag instead of positional arg', async () => {
@@ -103,7 +101,6 @@ describe('folder list', () => {
         await program.parseAsync(['node', 'td', 'folder', 'list', '--workspace', 'Acme'])
 
         expect(mockApi.getFolders).toHaveBeenCalled()
-        consoleSpy.mockRestore()
     })
 
     it('errors when both positional and --workspace are provided', async () => {
@@ -123,7 +120,7 @@ describe('folder create', () => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        consoleSpy = mockConsoleLog()
     })
 
     it('creates folder in workspace', async () => {
@@ -147,7 +144,6 @@ describe('folder create', () => {
             childOrder: undefined,
         })
         expect(consoleSpy).toHaveBeenCalledWith('Created: Engineering')
-        consoleSpy.mockRestore()
     })
 
     it('shows folder ID after creation', async () => {
@@ -165,7 +161,6 @@ describe('folder create', () => {
         ])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('folder-1'))
-        consoleSpy.mockRestore()
     })
 
     it('outputs created folder as JSON with --json', async () => {
@@ -187,7 +182,6 @@ describe('folder create', () => {
         const parsed = JSON.parse(output)
         expect(parsed.id).toBe('folder-1')
         expect(parsed.name).toBe('Engineering')
-        consoleSpy.mockRestore()
     })
 
     it('shows dry-run preview with --dry-run', async () => {
@@ -206,7 +200,6 @@ describe('folder create', () => {
 
         expect(mockApi.addFolder).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would create folder'))
-        consoleSpy.mockRestore()
     })
 
     it('rejects invalid --default-order', async () => {
@@ -257,7 +250,7 @@ describe('folder update', () => {
         mockFetchWorkspaceFolders.mockResolvedValue([
             { id: 'folder-1', name: 'Engineering', workspaceId: '12345' },
         ])
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        consoleSpy = mockConsoleLog()
     })
 
     it('updates folder name by id:xxx', async () => {
@@ -277,7 +270,6 @@ describe('folder update', () => {
 
         expect(mockApi.updateFolder).toHaveBeenCalledWith('folder-1', { name: 'Platform' })
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Engineering → Platform'))
-        consoleSpy.mockRestore()
     })
 
     it('outputs updated folder as JSON with --json', async () => {
@@ -299,7 +291,6 @@ describe('folder update', () => {
         const output = consoleSpy.mock.calls[0][0]
         const parsed = JSON.parse(output)
         expect(parsed.name).toBe('Platform')
-        consoleSpy.mockRestore()
     })
 
     it('errors with NO_CHANGES when no update flags provided', async () => {
@@ -328,7 +319,6 @@ describe('folder update', () => {
 
         expect(mockApi.updateFolder).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would update folder'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -343,7 +333,7 @@ describe('folder delete', () => {
         mockFetchWorkspaceFolders.mockResolvedValue([
             { id: 'folder-1', name: 'Engineering', workspaceId: '12345' },
         ])
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        consoleSpy = mockConsoleLog()
     })
 
     it('shows confirmation prompt without --yes', async () => {
@@ -355,7 +345,6 @@ describe('folder delete', () => {
         expect(mockApi.deleteFolder).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Would delete folder: Engineering')
         expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
-        consoleSpy.mockRestore()
     })
 
     it('deletes folder with --yes', async () => {
@@ -367,7 +356,6 @@ describe('folder delete', () => {
 
         expect(mockApi.deleteFolder).toHaveBeenCalledWith('folder-1')
         expect(consoleSpy).toHaveBeenCalledWith('Deleted: Engineering (id:folder-1)')
-        consoleSpy.mockRestore()
     })
 
     it('shows dry-run preview with --dry-run', async () => {
@@ -378,7 +366,6 @@ describe('folder delete', () => {
 
         expect(mockApi.deleteFolder).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would delete folder'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -393,7 +380,7 @@ describe('folder view', () => {
         mockFetchWorkspaceFolders.mockResolvedValue([
             { id: 'folder-1', name: 'Engineering', workspaceId: '12345' },
         ])
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        consoleSpy = mockConsoleLog()
     })
 
     it('shows folder details and contained projects', async () => {
@@ -428,7 +415,6 @@ describe('folder view', () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Engineering'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Backend'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Frontend'))
-        consoleSpy.mockRestore()
     })
 
     it('shows "No projects in this folder." when empty', async () => {
@@ -439,7 +425,6 @@ describe('folder view', () => {
         await program.parseAsync(['node', 'td', 'folder', 'view', 'id:folder-1'])
 
         expect(consoleSpy).toHaveBeenCalledWith('No projects in this folder.')
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json flag', async () => {
@@ -454,7 +439,6 @@ describe('folder view', () => {
         expect(parsed.folder).toBeDefined()
         expect(parsed.folder.id).toBe('folder-1')
         expect(parsed.projects).toBeDefined()
-        consoleSpy.mockRestore()
     })
 })
 
@@ -471,7 +455,7 @@ describe('folder workspace auto-detection', () => {
 
     it('auto-detects single workspace for folder resolution', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
         mockFetchWorkspaces.mockResolvedValue([mockWorkspace])
         mockApi.getFolder.mockResolvedValue(mockFolder)
         mockApi.getProjects.mockResolvedValue({ results: [], nextCursor: null })
@@ -479,7 +463,6 @@ describe('folder workspace auto-detection', () => {
         await program.parseAsync(['node', 'td', 'folder', 'view', 'Engineering'])
 
         expect(mockApi.getFolder).toHaveBeenCalledWith('folder-1')
-        consoleSpy.mockRestore()
     })
 
     it('errors when multiple workspaces and no --workspace', async () => {

--- a/src/commands/goal.test.ts
+++ b/src/commands/goal.test.ts
@@ -5,6 +5,7 @@ vi.mock('../lib/api/core.js', () => ({
 }))
 
 import { setupApiMock } from '../test-support/api-mock.js'
+import { mockConsoleLog } from '../test-support/console-spy.js'
 import { fixtures } from '../test-support/fixtures.js'
 import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
@@ -24,17 +25,16 @@ describe('goal list', () => {
 
     it('shows "No goals found" when empty', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync(['node', 'td', 'goal', 'list'])
 
         expect(consoleSpy).toHaveBeenCalledWith('No goals found.')
-        consoleSpy.mockRestore()
     })
 
     it('lists goals with progress', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getGoals.mockResolvedValue({
             results: [fixtures.goals.shipV2, fixtures.goals.learnRust],
@@ -45,12 +45,11 @@ describe('goal list', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Ship v2'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Learn Rust'))
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getGoals.mockResolvedValue({
             results: [fixtures.goals.shipV2],
@@ -63,7 +62,6 @@ describe('goal list', () => {
         const parsed = JSON.parse(output)
         expect(parsed.results).toBeDefined()
         expect(parsed.results[0].name).toBe('Ship v2')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -77,7 +75,7 @@ describe('goal view', () => {
 
     it('shows goal details and linked tasks', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getGoal.mockResolvedValue(fixtures.goals.shipV2)
         mockApi.getTasks.mockResolvedValue({
@@ -96,12 +94,11 @@ describe('goal view', () => {
         const rendered = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n')
         expect(rendered).toContain('Buy milk')
         expect(rendered).not.toContain('[object Promise]')
-        consoleSpy.mockRestore()
     })
 
     it('includes description in JSON output', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getGoal.mockResolvedValue(fixtures.goals.shipV2)
         mockApi.getTasks.mockResolvedValue({ results: [], nextCursor: null })
@@ -118,12 +115,11 @@ describe('goal view', () => {
         const output = consoleSpy.mock.calls[0][0]
         const parsed = JSON.parse(output)
         expect(parsed.goal.description).toBe('Launch the new version')
-        consoleSpy.mockRestore()
     })
 
     it('is the default subcommand', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getGoal.mockResolvedValue(fixtures.goals.shipV2)
         mockApi.getTasks.mockResolvedValue({ results: [], nextCursor: null })
@@ -131,7 +127,6 @@ describe('goal view', () => {
         await program.parseAsync(['node', 'td', 'goal', `id:${fixtures.goals.shipV2.id}`])
 
         expect(mockApi.getGoal).toHaveBeenCalled()
-        consoleSpy.mockRestore()
     })
 })
 
@@ -145,7 +140,7 @@ describe('goal create', () => {
 
     it('creates a goal', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.addGoal.mockResolvedValue(fixtures.goals.shipV2)
 
@@ -153,12 +148,11 @@ describe('goal create', () => {
 
         expect(mockApi.addGoal).toHaveBeenCalledWith(expect.objectContaining({ name: 'Ship v2' }))
         expect(consoleSpy).toHaveBeenCalledWith('Created: Ship v2')
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.addGoal.mockResolvedValue(fixtures.goals.shipV2)
 
@@ -167,18 +161,16 @@ describe('goal create', () => {
         const output = consoleSpy.mock.calls[0][0]
         const parsed = JSON.parse(output)
         expect(parsed.name).toBe('Ship v2')
-        consoleSpy.mockRestore()
     })
 
     it('--dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync(['node', 'td', 'goal', 'create', '--name', 'Ship v2', '--dry-run'])
 
         expect(mockApi.addGoal).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would create goal'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -192,7 +184,7 @@ describe('goal update', () => {
 
     it('updates name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getGoal.mockResolvedValue(fixtures.goals.shipV2)
         mockApi.updateGoal.mockResolvedValue({ ...fixtures.goals.shipV2, name: 'Ship v3' })
@@ -212,12 +204,11 @@ describe('goal update', () => {
             expect.objectContaining({ name: 'Ship v3' }),
         )
         expect(consoleSpy).toHaveBeenCalledWith('Updated: Ship v2 → Ship v3')
-        consoleSpy.mockRestore()
     })
 
     it('clears description with empty string', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getGoal.mockResolvedValue(fixtures.goals.shipV2)
         mockApi.updateGoal.mockResolvedValue({ ...fixtures.goals.shipV2, description: '' })
@@ -235,7 +226,6 @@ describe('goal update', () => {
         expect(mockApi.updateGoal).toHaveBeenCalledWith(fixtures.goals.shipV2.id, {
             description: '',
         })
-        consoleSpy.mockRestore()
     })
 
     it('throws CliError when no update fields specified', async () => {
@@ -252,7 +242,7 @@ describe('goal update', () => {
 
     it('--dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync([
             'node',
@@ -267,12 +257,11 @@ describe('goal update', () => {
 
         expect(mockApi.updateGoal).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would update goal'))
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getGoal.mockResolvedValue(fixtures.goals.shipV2)
         mockApi.updateGoal.mockResolvedValue({ ...fixtures.goals.shipV2, name: 'Ship v3' })
@@ -291,7 +280,6 @@ describe('goal update', () => {
         const output = consoleSpy.mock.calls[0][0]
         const parsed = JSON.parse(output)
         expect(parsed.name).toBe('Ship v3')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -305,7 +293,7 @@ describe('goal delete', () => {
 
     it('shows dry-run without --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getGoal.mockResolvedValue(fixtures.goals.shipV2)
 
@@ -313,12 +301,11 @@ describe('goal delete', () => {
 
         expect(mockApi.deleteGoal).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Would delete goal: Ship v2')
-        consoleSpy.mockRestore()
     })
 
     it('deletes with --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getGoal.mockResolvedValue(fixtures.goals.shipV2)
         mockApi.deleteGoal.mockResolvedValue(true)
@@ -333,7 +320,6 @@ describe('goal delete', () => {
         ])
 
         expect(mockApi.deleteGoal).toHaveBeenCalledWith(fixtures.goals.shipV2.id)
-        consoleSpy.mockRestore()
     })
 })
 
@@ -347,7 +333,7 @@ describe('goal complete/uncomplete', () => {
 
     it('completes a goal', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getGoal.mockResolvedValue(fixtures.goals.shipV2)
         mockApi.completeGoal.mockResolvedValue({ ...fixtures.goals.shipV2, isCompleted: true })
@@ -362,12 +348,11 @@ describe('goal complete/uncomplete', () => {
 
         expect(mockApi.completeGoal).toHaveBeenCalledWith(fixtures.goals.shipV2.id)
         expect(consoleSpy).toHaveBeenCalledWith('Completed: Ship v2')
-        consoleSpy.mockRestore()
     })
 
     it('uncompletes a goal', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getGoal.mockResolvedValue(fixtures.goals.learnRust)
         mockApi.uncompleteGoal.mockResolvedValue({
@@ -385,6 +370,5 @@ describe('goal complete/uncomplete', () => {
 
         expect(mockApi.uncompleteGoal).toHaveBeenCalledWith(fixtures.goals.learnRust.id)
         expect(consoleSpy).toHaveBeenCalledWith('Reopened: Learn Rust')
-        consoleSpy.mockRestore()
     })
 })

--- a/src/commands/goal.test.ts
+++ b/src/commands/goal.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/api/core.js', () => ({
@@ -8,15 +7,13 @@ vi.mock('../lib/api/core.js', () => ({
 import { getApi } from '../lib/api/core.js'
 import { fixtures } from '../test-support/fixtures.js'
 import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { createTestProgram } from '../test-support/program.js'
 import { registerGoalCommand } from './goal.js'
 
 const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerGoalCommand(program)
-    return program
+    return createTestProgram(registerGoalCommand)
 }
 
 describe('goal list', () => {

--- a/src/commands/goal.test.ts
+++ b/src/commands/goal.test.ts
@@ -4,13 +4,11 @@ vi.mock('../lib/api/core.js', () => ({
     getApi: vi.fn(),
 }))
 
-import { getApi } from '../lib/api/core.js'
+import { setupApiMock } from '../test-support/api-mock.js'
 import { fixtures } from '../test-support/fixtures.js'
-import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerGoalCommand } from './goal.js'
-
-const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
     return createTestProgram(registerGoalCommand)
@@ -21,8 +19,7 @@ describe('goal list', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('shows "No goals found" when empty', async () => {
@@ -75,8 +72,7 @@ describe('goal view', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('shows goal details and linked tasks', async () => {
@@ -144,8 +140,7 @@ describe('goal create', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('creates a goal', async () => {
@@ -192,8 +187,7 @@ describe('goal update', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('updates name', async () => {
@@ -306,8 +300,7 @@ describe('goal delete', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('shows dry-run without --yes', async () => {
@@ -349,8 +342,7 @@ describe('goal complete/uncomplete', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('completes a goal', async () => {

--- a/src/commands/hc/hc.test.ts
+++ b/src/commands/hc/hc.test.ts
@@ -12,6 +12,7 @@ vi.mock('../../lib/config.js', () => ({
 
 import { openInBrowser } from '../../lib/browser.js'
 import { readConfig, writeConfig } from '../../lib/config.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerHelpCenterCommand } from './index.js'
 
@@ -35,7 +36,7 @@ describe('hc command', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        consoleSpy = mockConsoleLog()
         fetchSpy = vi.fn()
         vi.stubGlobal('fetch', fetchSpy)
         mockReadConfig.mockResolvedValue({})
@@ -497,7 +498,6 @@ describe('hc command', () => {
         await program.parseAsync(['node', 'td', 'hc', 'view', 'id:205348301', '--html'])
 
         expect(stdoutSpy).toHaveBeenCalledWith('<p>Full <strong>HTML</strong> body.</p>')
-        stdoutSpy.mockRestore()
     })
 
     it('returns normalized article JSON with --json', async () => {

--- a/src/commands/hc/hc.test.ts
+++ b/src/commands/hc/hc.test.ts
@@ -12,7 +12,7 @@ vi.mock('../../lib/config.js', () => ({
 
 import { openInBrowser } from '../../lib/browser.js'
 import { readConfig, writeConfig } from '../../lib/config.js'
-import { mockConsoleLog } from '../../test-support/console-spy.js'
+import { mockConsoleLog, mockProcessStdout } from '../../test-support/console-spy.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerHelpCenterCommand } from './index.js'
 
@@ -482,7 +482,7 @@ describe('hc command', () => {
     })
 
     it('outputs the raw HTML body with --html', async () => {
-        const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+        const stdoutSpy = mockProcessStdout()
         fetchSpy.mockResolvedValue(
             createJsonResponse({
                 article: {

--- a/src/commands/hc/hc.test.ts
+++ b/src/commands/hc/hc.test.ts
@@ -1,5 +1,4 @@
 import { describeEmptyMachineOutput } from '@doist/cli-core/testing'
-import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/browser.js', () => ({
@@ -13,13 +12,11 @@ vi.mock('../../lib/config.js', () => ({
 
 import { openInBrowser } from '../../lib/browser.js'
 import { readConfig, writeConfig } from '../../lib/config.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerHelpCenterCommand } from './index.js'
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerHelpCenterCommand(program)
-    return program
+    return createTestProgram(registerHelpCenterCommand)
 }
 
 function createJsonResponse(body: unknown, status = 200, statusText = 'OK'): Response {

--- a/src/commands/inbox.test.ts
+++ b/src/commands/inbox.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/api/core.js', () => ({
     getApi: vi.fn(),
 }))
 
 import { setupApiMock } from '../test-support/api-mock.js'
+import { mockConsoleLog } from '../test-support/console-spy.js'
 import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerInboxCommand } from './inbox.js'
@@ -20,11 +21,7 @@ describe('inbox command', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('fetches user to get inboxProjectId', async () => {

--- a/src/commands/inbox.test.ts
+++ b/src/commands/inbox.test.ts
@@ -4,12 +4,10 @@ vi.mock('../lib/api/core.js', () => ({
     getApi: vi.fn(),
 }))
 
-import { getApi } from '../lib/api/core.js'
-import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { setupApiMock } from '../test-support/api-mock.js'
+import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerInboxCommand } from './inbox.js'
-
-const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
     return createTestProgram(registerInboxCommand)
@@ -21,8 +19,7 @@ describe('inbox command', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 

--- a/src/commands/inbox.test.ts
+++ b/src/commands/inbox.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/api/core.js', () => ({
@@ -7,15 +6,13 @@ vi.mock('../lib/api/core.js', () => ({
 
 import { getApi } from '../lib/api/core.js'
 import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { createTestProgram } from '../test-support/program.js'
 import { registerInboxCommand } from './inbox.js'
 
 const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerInboxCommand(program)
-    return program
+    return createTestProgram(registerInboxCommand)
 }
 
 describe('inbox command', () => {

--- a/src/commands/label/label.test.ts
+++ b/src/commands/label/label.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
@@ -7,15 +6,13 @@ vi.mock('../../lib/api/core.js', () => ({
 
 import { getApi } from '../../lib/api/core.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerLabelCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerLabelCommand(program)
-    return program
+    return createTestProgram(registerLabelCommand)
 }
 
 describe('label list', () => {

--- a/src/commands/label/label.test.ts
+++ b/src/commands/label/label.test.ts
@@ -5,7 +5,7 @@ vi.mock('../../lib/api/core.js', () => ({
 }))
 
 import { setupApiMock } from '../../test-support/api-mock.js'
-import { mockConsoleLog } from '../../test-support/console-spy.js'
+import { mockConsoleLog, mockProcessStdout } from '../../test-support/console-spy.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerLabelCommand } from './index.js'
@@ -1166,7 +1166,7 @@ describe('shared labels', () => {
 describe('label (no args)', () => {
     it('shows parent help listing all subcommands', async () => {
         const program = createProgram()
-        const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+        const stdoutSpy = mockProcessStdout()
 
         try {
             await program.parseAsync(['node', 'td', 'label'])

--- a/src/commands/label/label.test.ts
+++ b/src/commands/label/label.test.ts
@@ -5,6 +5,7 @@ vi.mock('../../lib/api/core.js', () => ({
 }))
 
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerLabelCommand } from './index.js'
@@ -23,7 +24,7 @@ describe('label list', () => {
 
     it('lists all labels', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [
@@ -37,24 +38,22 @@ describe('label list', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('@urgent'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('@home'))
-        consoleSpy.mockRestore()
     })
 
     it('shows "No labels found" when empty', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({ results: [], nextCursor: null })
 
         await program.parseAsync(['node', 'td', 'label', 'list'])
 
         expect(consoleSpy).toHaveBeenCalledWith('No labels found.')
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'urgent', color: 'red', isFavorite: true }],
@@ -67,12 +66,11 @@ describe('label list', () => {
         const parsed = JSON.parse(output)
         expect(parsed.results).toBeDefined()
         expect(parsed.results[0].name).toBe('urgent')
-        consoleSpy.mockRestore()
     })
 
     it('outputs NDJSON with --ndjson flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [
@@ -87,7 +85,6 @@ describe('label list', () => {
         const output = consoleSpy.mock.calls[0][0]
         const lines = output.split('\n')
         expect(lines).toHaveLength(2)
-        consoleSpy.mockRestore()
     })
 })
 
@@ -101,7 +98,7 @@ describe('label list --search', () => {
 
     it('searches labels by name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.searchLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'bugfix', color: 'red', isFavorite: false }],
@@ -113,12 +110,11 @@ describe('label list --search', () => {
         expect(mockApi.searchLabels).toHaveBeenCalledWith(expect.objectContaining({ query: 'bug' }))
         expect(mockApi.getLabels).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('@bugfix'))
-        consoleSpy.mockRestore()
     })
 
     it('includes matching shared labels in search results', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.searchLabels.mockResolvedValue({ results: [], nextCursor: null })
         mockApi.getSharedLabels.mockResolvedValue({
@@ -130,12 +126,11 @@ describe('label list --search', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('@team-bug'))
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('@team-review'))
-        consoleSpy.mockRestore()
     })
 
     it('outputs search results as JSON', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.searchLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'bugfix', color: 'red', isFavorite: false }],
@@ -148,19 +143,17 @@ describe('label list --search', () => {
         const parsed = JSON.parse(output)
         expect(parsed.results).toBeDefined()
         expect(parsed.results[0].name).toBe('bugfix')
-        consoleSpy.mockRestore()
     })
 
     it('shows "No labels found" when search has no results', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.searchLabels.mockResolvedValue({ results: [], nextCursor: null })
 
         await program.parseAsync(['node', 'td', 'label', 'list', '--search', 'nonexistent'])
 
         expect(consoleSpy).toHaveBeenCalledWith('No labels found.')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -174,7 +167,7 @@ describe('label rename-shared', () => {
 
     it('renames a shared label', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
         mockApi.getSharedLabels.mockResolvedValue({
             results: ['oldname'],
             nextCursor: null,
@@ -195,12 +188,11 @@ describe('label rename-shared', () => {
             newName: 'newname',
         })
         expect(consoleSpy).toHaveBeenCalledWith('Renamed: @oldname → @newname')
-        consoleSpy.mockRestore()
     })
 
     it('strips @ prefix from name', async () => {
         const program = createProgram()
-        vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
         mockApi.getSharedLabels.mockResolvedValue({
             results: ['oldname'],
             nextCursor: null,
@@ -224,7 +216,7 @@ describe('label rename-shared', () => {
 
     it('previews rename with --dry-run', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
         mockApi.getSharedLabels.mockResolvedValue({
             results: ['oldname'],
             nextCursor: null,
@@ -243,12 +235,11 @@ describe('label rename-shared', () => {
 
         expect(mockApi.renameSharedLabel).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[dry-run]'))
-        consoleSpy.mockRestore()
     })
 
     it('throws when shared label not found', async () => {
         const program = createProgram()
-        vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         await expect(
             program.parseAsync([
@@ -274,7 +265,7 @@ describe('label remove-shared', () => {
 
     it('removes a shared label with --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
         mockApi.getSharedLabels.mockResolvedValue({
             results: ['oldname'],
             nextCursor: null,
@@ -284,12 +275,11 @@ describe('label remove-shared', () => {
 
         expect(mockApi.removeSharedLabel).toHaveBeenCalledWith({ name: 'oldname' })
         expect(consoleSpy).toHaveBeenCalledWith('Removed shared label: @oldname')
-        consoleSpy.mockRestore()
     })
 
     it('strips @ prefix from name', async () => {
         const program = createProgram()
-        vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
         mockApi.getSharedLabels.mockResolvedValue({
             results: ['oldname'],
             nextCursor: null,
@@ -302,7 +292,7 @@ describe('label remove-shared', () => {
 
     it('shows confirmation prompt without --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
         mockApi.getSharedLabels.mockResolvedValue({
             results: ['oldname'],
             nextCursor: null,
@@ -313,12 +303,11 @@ describe('label remove-shared', () => {
         expect(mockApi.removeSharedLabel).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Would remove shared label: @oldname')
         expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
-        consoleSpy.mockRestore()
     })
 
     it('previews removal with --dry-run', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
         mockApi.getSharedLabels.mockResolvedValue({
             results: ['oldname'],
             nextCursor: null,
@@ -328,12 +317,11 @@ describe('label remove-shared', () => {
 
         expect(mockApi.removeSharedLabel).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[dry-run]'))
-        consoleSpy.mockRestore()
     })
 
     it('throws when shared label not found', async () => {
         const program = createProgram()
-        vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         await expect(
             program.parseAsync(['node', 'td', 'label', 'remove-shared', 'nonexistent', '--yes']),
@@ -351,7 +339,7 @@ describe('label create --json', () => {
 
     it('outputs created label as JSON', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.addLabel.mockResolvedValue({
             id: 'label-new',
@@ -367,7 +355,6 @@ describe('label create --json', () => {
         expect(parsed.id).toBe('label-new')
         expect(parsed.name).toBe('work')
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Created:'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -381,7 +368,7 @@ describe('label update --json', () => {
 
     it('outputs updated label as JSON', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'work', color: 'charcoal', isFavorite: false }],
@@ -410,7 +397,6 @@ describe('label update --json', () => {
         expect(parsed.id).toBe('label-1')
         expect(parsed.name).toBe('renamed')
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Updated:'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -424,7 +410,7 @@ describe('label create', () => {
 
     it('creates label with name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.addLabel.mockResolvedValue({ id: 'label-new', name: 'work' })
 
@@ -432,12 +418,11 @@ describe('label create', () => {
 
         expect(mockApi.addLabel).toHaveBeenCalledWith(expect.objectContaining({ name: 'work' }))
         expect(consoleSpy).toHaveBeenCalledWith('Created: @work')
-        consoleSpy.mockRestore()
     })
 
     it('creates label with --color', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.addLabel.mockResolvedValue({
             id: 'label-new',
@@ -459,12 +444,11 @@ describe('label create', () => {
         expect(mockApi.addLabel).toHaveBeenCalledWith(
             expect.objectContaining({ name: 'urgent', color: 'red' }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('creates label with --favorite', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.addLabel.mockResolvedValue({
             id: 'label-new',
@@ -485,19 +469,17 @@ describe('label create', () => {
         expect(mockApi.addLabel).toHaveBeenCalledWith(
             expect.objectContaining({ name: 'important', isFavorite: true }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('shows label ID after creation', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.addLabel.mockResolvedValue({ id: 'label-xyz', name: 'test' })
 
         await program.parseAsync(['node', 'td', 'label', 'create', '--name', 'test'])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('label-xyz'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -511,7 +493,7 @@ describe('label delete', () => {
 
     it('shows dry-run without --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'urgent' }],
@@ -523,12 +505,11 @@ describe('label delete', () => {
         expect(mockApi.deleteLabel).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Would delete: @urgent')
         expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
-        consoleSpy.mockRestore()
     })
 
     it('deletes by name with --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'urgent' }],
@@ -540,12 +521,11 @@ describe('label delete', () => {
 
         expect(mockApi.deleteLabel).toHaveBeenCalledWith('label-1')
         expect(consoleSpy).toHaveBeenCalledWith('Deleted: @urgent (id:label-1)')
-        consoleSpy.mockRestore()
     })
 
     it('deletes by id: prefix with --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-123', name: 'urgent' }],
@@ -557,12 +537,11 @@ describe('label delete', () => {
 
         expect(mockApi.deleteLabel).toHaveBeenCalledWith('label-123')
         expect(consoleSpy).toHaveBeenCalledWith('Deleted: @urgent (id:label-123)')
-        consoleSpy.mockRestore()
     })
 
     it('handles @-prefixed name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'home' }],
@@ -573,7 +552,6 @@ describe('label delete', () => {
         await program.parseAsync(['node', 'td', 'label', 'delete', '@home', '--yes'])
 
         expect(mockApi.deleteLabel).toHaveBeenCalledWith('label-1')
-        consoleSpy.mockRestore()
     })
 
     it('throws for non-existent label', async () => {
@@ -597,7 +575,7 @@ describe('label update', () => {
 
     it('updates label name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'old-name' }],
@@ -619,12 +597,11 @@ describe('label update', () => {
             name: 'new-name',
         })
         expect(consoleSpy).toHaveBeenCalledWith('Updated: @old-name → @new-name (id:label-1)')
-        consoleSpy.mockRestore()
     })
 
     it('updates label color and favorite', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'work' }],
@@ -652,12 +629,11 @@ describe('label update', () => {
             color: 'red',
             isFavorite: true,
         })
-        consoleSpy.mockRestore()
     })
 
     it('removes favorite with --no-favorite', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'work', isFavorite: true }],
@@ -674,12 +650,11 @@ describe('label update', () => {
         expect(mockApi.updateLabel).toHaveBeenCalledWith('label-1', {
             isFavorite: false,
         })
-        consoleSpy.mockRestore()
     })
 
     it('updates by id: prefix', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-123', name: 'existing' }],
@@ -704,12 +679,11 @@ describe('label update', () => {
         expect(mockApi.updateLabel).toHaveBeenCalledWith('label-123', {
             color: 'blue',
         })
-        consoleSpy.mockRestore()
     })
 
     it('handles @-prefixed name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'home' }],
@@ -726,7 +700,6 @@ describe('label update', () => {
         expect(mockApi.updateLabel).toHaveBeenCalledWith('label-1', {
             color: 'green',
         })
-        consoleSpy.mockRestore()
     })
 
     it('throws when no changes specified', async () => {
@@ -771,7 +744,7 @@ describe('label URL resolution', () => {
 
     it('resolves label by URL in delete command', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label1', name: 'urgent' }],
@@ -789,12 +762,11 @@ describe('label URL resolution', () => {
         ])
 
         expect(mockApi.deleteLabel).toHaveBeenCalledWith('label1')
-        consoleSpy.mockRestore()
     })
 
     it('resolves label by URL in update command', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label1', name: 'urgent' }],
@@ -813,7 +785,6 @@ describe('label URL resolution', () => {
         ])
 
         expect(mockApi.updateLabel).toHaveBeenCalledWith('label1', { color: 'blue' })
-        consoleSpy.mockRestore()
     })
 
     it('throws entity type mismatch for task URL in label command', async () => {
@@ -867,7 +838,7 @@ describe('label view', () => {
 
     it('shows label metadata and tasks', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'urgent', color: 'red', isFavorite: false }],
@@ -899,12 +870,11 @@ describe('label view', () => {
         )
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('@urgent'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Fix bug'))
-        consoleSpy.mockRestore()
     })
 
     it('shows "No tasks with this label" when empty', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'unused', color: 'red', isFavorite: false }],
@@ -919,12 +889,11 @@ describe('label view', () => {
         await program.parseAsync(['node', 'td', 'label', 'view', 'unused'])
 
         expect(consoleSpy).toHaveBeenCalledWith('No tasks with this label.')
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'urgent', color: 'red', isFavorite: false }],
@@ -950,12 +919,11 @@ describe('label view', () => {
         const parsed = JSON.parse(output)
         expect(parsed.results).toBeDefined()
         expect(parsed.results[0].content).toBe('Fix bug')
-        consoleSpy.mockRestore()
     })
 
     it('defaults to view subcommand (td label <ref>)', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'urgent', color: 'red', isFavorite: false }],
@@ -970,12 +938,11 @@ describe('label view', () => {
         await program.parseAsync(['node', 'td', 'label', 'urgent'])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('@urgent'))
-        consoleSpy.mockRestore()
     })
 
     it('resolves label by URL in view command', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label1', name: 'urgent', color: 'red', isFavorite: false }],
@@ -996,12 +963,11 @@ describe('label view', () => {
         ])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('@urgent'))
-        consoleSpy.mockRestore()
     })
 
     it('shows favorite indicator', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [{ id: 'label-1', name: 'urgent', color: 'red', isFavorite: true }],
@@ -1016,7 +982,6 @@ describe('label view', () => {
         await program.parseAsync(['node', 'td', 'label', 'view', 'urgent'])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Favorite'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1031,7 +996,7 @@ describe('shared labels', () => {
     describe('label list', () => {
         it('shows shared labels after personal labels', async () => {
             const program = createProgram()
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+            const consoleSpy = mockConsoleLog()
 
             mockApi.getLabels.mockResolvedValue({
                 results: [{ id: 'label-1', name: 'urgent', color: 'red', isFavorite: false }],
@@ -1050,12 +1015,11 @@ describe('shared labels', () => {
             expect(urgentIdx).toBeGreaterThanOrEqual(0)
             expect(sharedIdx).toBeGreaterThan(urgentIdx)
             expect(calls[sharedIdx]).toContain('(shared)')
-            consoleSpy.mockRestore()
         })
 
         it('shows only shared labels when no personal labels exist', async () => {
             const program = createProgram()
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+            const consoleSpy = mockConsoleLog()
 
             mockApi.getLabels.mockResolvedValue({ results: [], nextCursor: null })
             mockApi.getSharedLabels.mockResolvedValue({
@@ -1067,12 +1031,11 @@ describe('shared labels', () => {
 
             expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('@team-review'))
             expect(consoleSpy).not.toHaveBeenCalledWith('No labels found.')
-            consoleSpy.mockRestore()
         })
 
         it('fetches shared labels with omitPersonal: true', async () => {
             const program = createProgram()
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+            mockConsoleLog()
 
             mockApi.getLabels.mockResolvedValue({ results: [], nextCursor: null })
             mockApi.getSharedLabels.mockResolvedValue({ results: [], nextCursor: null })
@@ -1082,12 +1045,11 @@ describe('shared labels', () => {
             expect(mockApi.getSharedLabels).toHaveBeenCalledWith(
                 expect.objectContaining({ omitPersonal: true }),
             )
-            consoleSpy.mockRestore()
         })
 
         it('includes sharedLabels array in JSON output', async () => {
             const program = createProgram()
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+            const consoleSpy = mockConsoleLog()
 
             mockApi.getLabels.mockResolvedValue({
                 results: [{ id: 'label-1', name: 'urgent', color: 'red', isFavorite: false }],
@@ -1104,14 +1066,13 @@ describe('shared labels', () => {
             const parsed = JSON.parse(output)
             expect(parsed.sharedLabels).toEqual(['team-review', 'external'])
             expect(parsed.results[0].name).toBe('urgent')
-            consoleSpy.mockRestore()
         })
     })
 
     describe('label view', () => {
         it('resolves shared-only label by name', async () => {
             const program = createProgram()
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+            const consoleSpy = mockConsoleLog()
 
             mockApi.getLabels.mockResolvedValue({ results: [], nextCursor: null })
             mockApi.getSharedLabels.mockResolvedValue({
@@ -1126,12 +1087,11 @@ describe('shared labels', () => {
                 expect.objectContaining({ query: '@team-review' }),
             )
             expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('@team-review'))
-            consoleSpy.mockRestore()
         })
 
         it('prefers personal label over shared with same name', async () => {
             const program = createProgram()
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+            const consoleSpy = mockConsoleLog()
 
             mockApi.getLabels.mockResolvedValue({
                 results: [{ id: 'label-1', name: 'review', color: 'blue', isFavorite: false }],
@@ -1145,12 +1105,11 @@ describe('shared labels', () => {
             expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('label-1'))
             // Should NOT call getSharedLabels (personal match found first)
             expect(mockApi.getSharedLabels).not.toHaveBeenCalled()
-            consoleSpy.mockRestore()
         })
 
         it('shows "shared label" type for shared-only labels', async () => {
             const program = createProgram()
-            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+            const consoleSpy = mockConsoleLog()
 
             mockApi.getLabels.mockResolvedValue({ results: [], nextCursor: null })
             mockApi.getSharedLabels.mockResolvedValue({
@@ -1162,7 +1121,6 @@ describe('shared labels', () => {
             await program.parseAsync(['node', 'td', 'label', 'view', 'team-review'])
 
             expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('shared label'))
-            consoleSpy.mockRestore()
         })
     })
 
@@ -1223,7 +1181,6 @@ describe('label (no args)', () => {
         expect(output).toContain('update')
         expect(output).toContain('view')
         expect(output).toContain('Examples:')
-        stdoutSpy.mockRestore()
     })
 })
 
@@ -1237,18 +1194,17 @@ describe('label --dry-run', () => {
 
     it('label create --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync(['node', 'td', 'label', 'create', '--name', 'urgent', '--dry-run'])
 
         expect(mockApi.addLabel).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would create label'))
-        consoleSpy.mockRestore()
     })
 
     it('label delete --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [
@@ -1268,12 +1224,11 @@ describe('label --dry-run', () => {
 
         expect(mockApi.deleteLabel).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would delete label'))
-        consoleSpy.mockRestore()
     })
 
     it('label update --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLabels.mockResolvedValue({
             results: [
@@ -1302,6 +1257,5 @@ describe('label --dry-run', () => {
 
         expect(mockApi.updateLabel).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would update label'))
-        consoleSpy.mockRestore()
     })
 })

--- a/src/commands/label/label.test.ts
+++ b/src/commands/label/label.test.ts
@@ -4,12 +4,10 @@ vi.mock('../../lib/api/core.js', () => ({
     getApi: vi.fn(),
 }))
 
-import { getApi } from '../../lib/api/core.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerLabelCommand } from './index.js'
-
-const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
     return createTestProgram(registerLabelCommand)
@@ -20,8 +18,7 @@ describe('label list', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('lists all labels', async () => {
@@ -99,8 +96,7 @@ describe('label list --search', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('searches labels by name', async () => {
@@ -173,8 +169,7 @@ describe('label rename-shared', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('renames a shared label', async () => {
@@ -274,8 +269,7 @@ describe('label remove-shared', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('removes a shared label with --yes', async () => {
@@ -352,8 +346,7 @@ describe('label create --json', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('outputs created label as JSON', async () => {
@@ -383,8 +376,7 @@ describe('label update --json', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('outputs updated label as JSON', async () => {
@@ -427,8 +419,7 @@ describe('label create', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('creates label with name', async () => {
@@ -515,8 +506,7 @@ describe('label delete', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('shows dry-run without --yes', async () => {
@@ -602,8 +592,7 @@ describe('label update', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('updates label name', async () => {
@@ -777,8 +766,7 @@ describe('label URL resolution', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('resolves label by URL in delete command', async () => {
@@ -874,8 +862,7 @@ describe('label view', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('shows label metadata and tasks', async () => {
@@ -1038,8 +1025,7 @@ describe('shared labels', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     describe('label list', () => {
@@ -1246,8 +1232,7 @@ describe('label --dry-run', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('label create --dry-run previews without calling API', async () => {

--- a/src/commands/notification/notification.test.ts
+++ b/src/commands/notification/notification.test.ts
@@ -17,6 +17,7 @@ import {
     markNotificationUnread,
     rejectInvitation,
 } from '../../lib/api/notifications.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerNotificationCommand } from './index.js'
 
@@ -66,7 +67,7 @@ describe('notification list', () => {
 
     it('lists notifications', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([createShareInvite(), createItemAssigned()])
 
@@ -74,24 +75,22 @@ describe('notification list', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('share_invitation_sent'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('item_assigned'))
-        consoleSpy.mockRestore()
     })
 
     it('shows "No notifications." when empty', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([])
 
         await program.parseAsync(['node', 'td', 'notification', 'list'])
 
         expect(consoleSpy).toHaveBeenCalledWith('No notifications.')
-        consoleSpy.mockRestore()
     })
 
     it('filters unread with --unread', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([
             createShareInvite({ isUnread: true }),
@@ -102,12 +101,11 @@ describe('notification list', () => {
 
         expect(consoleSpy).toHaveBeenCalledTimes(1)
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('share_invitation_sent'))
-        consoleSpy.mockRestore()
     })
 
     it('filters read with --read', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([
             createShareInvite({ isUnread: true }),
@@ -119,12 +117,11 @@ describe('notification list', () => {
         const output = consoleSpy.mock.calls[0][0]
         expect(output).toContain('item_assigned')
         expect(output).not.toContain('share_invitation_sent')
-        consoleSpy.mockRestore()
     })
 
     it('filters by type with --type', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([
             createShareInvite({ id: 'n1' }),
@@ -138,12 +135,11 @@ describe('notification list', () => {
         expect(output).toContain('id:n2')
         expect(output).not.toContain('id:n1')
         expect(output).not.toContain('id:n3')
-        consoleSpy.mockRestore()
     })
 
     it('filters by multiple types with --type', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([
             createShareInvite({ id: 'n1' }),
@@ -164,7 +160,6 @@ describe('notification list', () => {
         expect(output).toContain('id:n2')
         expect(output).toContain('id:n3')
         expect(output).not.toContain('id:n1')
-        consoleSpy.mockRestore()
     })
 
     it('throws when both --read and --unread specified', async () => {
@@ -177,7 +172,7 @@ describe('notification list', () => {
 
     it('respects --offset', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([
             createShareInvite({ id: 'n1' }),
@@ -200,12 +195,11 @@ describe('notification list', () => {
         expect(output).toContain('id:n2')
         expect(output).not.toContain('id:n1')
         expect(output).not.toContain('id:n3')
-        consoleSpy.mockRestore()
     })
 
     it('respects --limit', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([
             createShareInvite({ id: 'n1' }),
@@ -219,12 +213,11 @@ describe('notification list', () => {
         expect(output).toContain('id:n1')
         expect(output).toContain('id:n2')
         expect(output).not.toContain('id:n3')
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([createShareInvite()])
 
@@ -235,12 +228,11 @@ describe('notification list', () => {
         expect(parsed.results).toBeDefined()
         expect(parsed.results[0].type).toBe('share_invitation_sent')
         expect(parsed.results[0].invitationSecret).toBeUndefined()
-        consoleSpy.mockRestore()
     })
 
     it('outputs NDJSON with --ndjson', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([
             createShareInvite({ id: 'n1' }),
@@ -252,12 +244,11 @@ describe('notification list', () => {
         const output = consoleSpy.mock.calls[0][0]
         const lines = output.split('\n')
         expect(lines).toHaveLength(2)
-        consoleSpy.mockRestore()
     })
 
     it('does not expose invitationSecret in JSON', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([createShareInvite()])
 
@@ -266,7 +257,6 @@ describe('notification list', () => {
         const output = consoleSpy.mock.calls[0][0]
         expect(output).not.toContain('invitationSecret')
         expect(output).not.toContain('secret-abc')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -277,19 +267,18 @@ describe('notification view', () => {
 
     it('implicit view: td notification <ref> behaves like td notification view <ref>', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([createShareInvite()])
 
         await program.parseAsync(['node', 'td', 'notification', 'id:notif-1'])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('share_invitation_sent'))
-        consoleSpy.mockRestore()
     })
 
     it('shows notification details', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([createShareInvite()])
 
@@ -298,12 +287,11 @@ describe('notification view', () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('share_invitation_sent'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Jane'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Project X'))
-        consoleSpy.mockRestore()
     })
 
     it('shows actions for share invitation', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([createShareInvite()])
 
@@ -312,12 +300,11 @@ describe('notification view', () => {
         expect(consoleSpy).toHaveBeenCalledWith('Actions:')
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('td notification accept'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('td notification reject'))
-        consoleSpy.mockRestore()
     })
 
     it('does not show actions for non-invitation', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([createItemAssigned()])
 
@@ -325,12 +312,11 @@ describe('notification view', () => {
 
         const calls = consoleSpy.mock.calls.map((c) => c[0])
         expect(calls).not.toContainEqual('Actions:')
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([createShareInvite()])
 
@@ -340,7 +326,6 @@ describe('notification view', () => {
         const parsed = JSON.parse(output)
         expect(parsed.type).toBe('share_invitation_sent')
         expect(parsed.invitationSecret).toBeUndefined()
-        consoleSpy.mockRestore()
     })
 
     it('throws for non-existent notification', async () => {
@@ -361,7 +346,7 @@ describe('notification accept', () => {
 
     it('accepts share invitation', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([createShareInvite()])
         mockAccept.mockResolvedValue(undefined)
@@ -372,7 +357,6 @@ describe('notification accept', () => {
         expect(mockAccept).toHaveBeenCalledWith('inv-123', 'secret-abc')
         expect(mockMarkRead).toHaveBeenCalledWith('notif-1')
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Accepted invitation'))
-        consoleSpy.mockRestore()
     })
 
     it('throws for non-invitation type', async () => {
@@ -403,7 +387,7 @@ describe('notification reject', () => {
 
     it('rejects share invitation', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([createShareInvite()])
         mockReject.mockResolvedValue(undefined)
@@ -414,7 +398,6 @@ describe('notification reject', () => {
         expect(mockReject).toHaveBeenCalledWith('inv-123', 'secret-abc')
         expect(mockMarkRead).toHaveBeenCalledWith('notif-1')
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Rejected invitation'))
-        consoleSpy.mockRestore()
     })
 
     it('throws for non-invitation type', async () => {
@@ -435,7 +418,7 @@ describe('notification read', () => {
 
     it('marks single notification as read', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([createShareInvite()])
         mockMarkRead.mockResolvedValue(undefined)
@@ -444,12 +427,11 @@ describe('notification read', () => {
 
         expect(mockMarkRead).toHaveBeenCalledWith('notif-1')
         expect(consoleSpy).toHaveBeenCalledWith('Marked as read. (id:notif-1)')
-        consoleSpy.mockRestore()
     })
 
     it('warns without --yes for --all', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync(['node', 'td', 'notification', 'read', '--all'])
 
@@ -457,12 +439,11 @@ describe('notification read', () => {
         expect(consoleSpy).toHaveBeenCalledWith(
             'Use --all --yes to mark all notifications as read.',
         )
-        consoleSpy.mockRestore()
     })
 
     it('marks all as read with --all --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([
             createShareInvite({ isUnread: true }),
@@ -474,7 +455,6 @@ describe('notification read', () => {
 
         expect(mockMarkAllRead).toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Marked 2 notifications as read.')
-        consoleSpy.mockRestore()
     })
 
     it('throws when no id and no --all', async () => {
@@ -493,7 +473,7 @@ describe('notification unread', () => {
 
     it('marks notification as unread', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchNotifications.mockResolvedValue([createShareInvite({ isUnread: false })])
         mockMarkUnread.mockResolvedValue(undefined)
@@ -502,7 +482,6 @@ describe('notification unread', () => {
 
         expect(mockMarkUnread).toHaveBeenCalledWith('notif-1')
         expect(consoleSpy).toHaveBeenCalledWith('Marked as unread.')
-        consoleSpy.mockRestore()
     })
 
     it('throws for non-existent notification', async () => {

--- a/src/commands/notification/notification.test.ts
+++ b/src/commands/notification/notification.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/notifications.js', () => ({
@@ -18,6 +17,7 @@ import {
     markNotificationUnread,
     rejectInvitation,
 } from '../../lib/api/notifications.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerNotificationCommand } from './index.js'
 
 const mockFetchNotifications = vi.mocked(fetchNotifications)
@@ -28,10 +28,7 @@ const mockAccept = vi.mocked(acceptInvitation)
 const mockReject = vi.mocked(rejectInvitation)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerNotificationCommand(program)
-    return program
+    return createTestProgram(registerNotificationCommand)
 }
 
 function createShareInvite(overrides = {}) {

--- a/src/commands/project/project.test.ts
+++ b/src/commands/project/project.test.ts
@@ -16,6 +16,7 @@ vi.mock('../../lib/browser.js', () => ({
 import { getApi } from '../../lib/api/core.js'
 import { fetchWorkspaceFolders, fetchWorkspaces, type Workspace } from '../../lib/api/workspaces.js'
 import { openInBrowser } from '../../lib/browser.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerProjectCommand } from './index.js'
@@ -24,8 +25,6 @@ const mockOpenInBrowser = vi.mocked(openInBrowser)
 
 const mockFetchWorkspaces = vi.mocked(fetchWorkspaces)
 const mockFetchWorkspaceFolders = vi.mocked(fetchWorkspaceFolders)
-
-const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
     return createTestProgram(registerProjectCommand)
@@ -37,8 +36,7 @@ describe('project list', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -176,8 +174,7 @@ describe('project archived', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -257,8 +254,7 @@ describe('project view', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -470,8 +466,7 @@ describe('project list grouping', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -627,8 +622,7 @@ describe('project collaborators', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -803,8 +797,7 @@ describe('project delete', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('shows dry-run without --yes', async () => {
@@ -899,8 +892,7 @@ describe('project create', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -1025,8 +1017,7 @@ describe('project create --json', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -1068,8 +1059,7 @@ describe('project archive', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -1131,8 +1121,7 @@ describe('project unarchive', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -1194,8 +1183,7 @@ describe('project browse', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -1235,8 +1223,7 @@ describe('project move', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -1585,8 +1572,7 @@ describe('project --dry-run', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('project create --dry-run previews without calling API', async () => {
@@ -1996,8 +1982,7 @@ describe('project progress', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -2058,8 +2043,7 @@ describe('project health', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -2156,8 +2140,7 @@ describe('project health-context', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -2230,8 +2213,7 @@ describe('project activity-stats', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -2352,8 +2334,7 @@ describe('project analyze-health', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 

--- a/src/commands/project/project.test.ts
+++ b/src/commands/project/project.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
@@ -18,6 +17,7 @@ import { getApi } from '../../lib/api/core.js'
 import { fetchWorkspaceFolders, fetchWorkspaces, type Workspace } from '../../lib/api/workspaces.js'
 import { openInBrowser } from '../../lib/browser.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerProjectCommand } from './index.js'
 
 const mockOpenInBrowser = vi.mocked(openInBrowser)
@@ -28,10 +28,7 @@ const mockFetchWorkspaceFolders = vi.mocked(fetchWorkspaceFolders)
 const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerProjectCommand(program)
-    return program
+    return createTestProgram(registerProjectCommand)
 }
 
 describe('project list', () => {

--- a/src/commands/project/project.test.ts
+++ b/src/commands/project/project.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
     getApi: vi.fn(),
@@ -17,6 +17,7 @@ import { getApi } from '../../lib/api/core.js'
 import { fetchWorkspaceFolders, fetchWorkspaces, type Workspace } from '../../lib/api/workspaces.js'
 import { openInBrowser } from '../../lib/browser.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerProjectCommand } from './index.js'
@@ -37,11 +38,7 @@ describe('project list', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('lists all projects', async () => {
@@ -175,11 +172,7 @@ describe('project archived', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('lists archived projects', async () => {
@@ -255,11 +248,7 @@ describe('project view', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('resolves project by name', async () => {
@@ -467,11 +456,7 @@ describe('project list grouping', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('groups projects by workspace', async () => {
@@ -623,11 +608,7 @@ describe('project collaborators', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('lists workspace users for workspace project', async () => {
@@ -802,7 +783,7 @@ describe('project delete', () => {
 
     it('shows dry-run without --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getProjects.mockResolvedValue({
             results: [{ id: 'proj-1', name: 'Test Project' }],
@@ -815,12 +796,11 @@ describe('project delete', () => {
         expect(mockApi.deleteProject).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Would delete project: Test Project')
         expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
-        consoleSpy.mockRestore()
     })
 
     it('deletes project with --yes when no tasks', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getProjects.mockResolvedValue({
             results: [{ id: 'proj-1', name: 'Test Project' }],
@@ -833,7 +813,6 @@ describe('project delete', () => {
 
         expect(mockApi.deleteProject).toHaveBeenCalledWith('proj-1')
         expect(consoleSpy).toHaveBeenCalledWith('Deleted project: Test Project (id:proj-1)')
-        consoleSpy.mockRestore()
     })
 
     it('fails when project has uncompleted tasks', async () => {
@@ -893,11 +872,7 @@ describe('project create', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('creates project with name', async () => {
@@ -1018,11 +993,7 @@ describe('project create --json', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('outputs created project as JSON', async () => {
@@ -1060,11 +1031,7 @@ describe('project archive', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('archives project by name', async () => {
@@ -1122,11 +1089,7 @@ describe('project unarchive', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('unarchives project by name', async () => {
@@ -1179,16 +1142,11 @@ describe('project unarchive', () => {
 
 describe('project browse', () => {
     let mockApi: MockApi
-    let consoleSpy: ReturnType<typeof vi.spyOn>
 
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        mockConsoleLog()
     })
 
     it('opens project in browser by name', async () => {
@@ -1224,24 +1182,18 @@ describe('project move', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('shows help when no ref provided', async () => {
         const program = createProgram()
-        const helpSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+        vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
 
         try {
             await program.parseAsync(['node', 'td', 'project', 'move'])
         } catch {
             // exitOverride throws
         }
-
-        helpSpy.mockRestore()
     })
 
     it('errors when neither --to-workspace nor --to-personal specified', async () => {
@@ -1563,7 +1515,6 @@ describe('project (no args)', () => {
         expect(output).toContain('update')
         expect(output).toContain('view')
         expect(output).toContain('Examples:')
-        stdoutSpy.mockRestore()
     })
 })
 
@@ -1577,7 +1528,7 @@ describe('project --dry-run', () => {
 
     it('project create --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync([
             'node',
@@ -1591,12 +1542,11 @@ describe('project --dry-run', () => {
 
         expect(mockApi.addProject).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would create project'))
-        consoleSpy.mockRestore()
     })
 
     it('project update --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getProjects.mockResolvedValue({
             results: [{ id: 'proj-1', name: 'Old Name' }],
@@ -1616,12 +1566,11 @@ describe('project --dry-run', () => {
 
         expect(mockApi.updateProject).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would update project'))
-        consoleSpy.mockRestore()
     })
 
     it('project archive --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getProjects.mockResolvedValue({
             results: [{ id: 'proj-1', name: 'Test', isArchived: false }],
@@ -1632,12 +1581,11 @@ describe('project --dry-run', () => {
 
         expect(mockApi.archiveProject).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would archive project'))
-        consoleSpy.mockRestore()
     })
 
     it('project delete --dry-run --yes still does not execute', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getProjects.mockResolvedValue({
             results: [{ id: 'proj-1', name: 'Empty Project' }],
@@ -1657,7 +1605,6 @@ describe('project --dry-run', () => {
 
         expect(mockApi.deleteProject).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would delete project'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1669,11 +1616,7 @@ describe('project archived-count', () => {
         vi.clearAllMocks()
         mockApi = createMockApi()
         vi.mocked(getApi).mockResolvedValue(mockApi)
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('shows count in human-readable format', async () => {
@@ -1720,11 +1663,7 @@ describe('project permissions', () => {
         vi.clearAllMocks()
         mockApi = createMockApi()
         vi.mocked(getApi).mockResolvedValue(mockApi)
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('shows permissions in human-readable format', async () => {
@@ -1771,11 +1710,7 @@ describe('project view --detailed', () => {
         vi.clearAllMocks()
         mockApi = createMockApi()
         vi.mocked(getApi).mockResolvedValue(mockApi)
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('uses getFullProject and shows sections and collaborators', async () => {
@@ -1847,11 +1782,7 @@ describe('project join', () => {
         vi.clearAllMocks()
         mockApi = createMockApi()
         vi.mocked(getApi).mockResolvedValue(mockApi)
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('joins project and shows workspace name', async () => {
@@ -1983,11 +1914,7 @@ describe('project progress', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('shows progress for a project', async () => {
@@ -2044,11 +1971,7 @@ describe('project health', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('shows health status and description', async () => {
@@ -2141,11 +2064,7 @@ describe('project health-context', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('shows project metrics', async () => {
@@ -2214,11 +2133,7 @@ describe('project activity-stats', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('shows daily activity', async () => {
@@ -2335,11 +2250,7 @@ describe('project analyze-health', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('triggers analysis and shows confirmation', async () => {

--- a/src/commands/project/project.test.ts
+++ b/src/commands/project/project.test.ts
@@ -17,7 +17,7 @@ import { getApi } from '../../lib/api/core.js'
 import { fetchWorkspaceFolders, fetchWorkspaces, type Workspace } from '../../lib/api/workspaces.js'
 import { openInBrowser } from '../../lib/browser.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
-import { mockConsoleLog } from '../../test-support/console-spy.js'
+import { mockConsoleLog, mockProcessStdout } from '../../test-support/console-spy.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerProjectCommand } from './index.js'
@@ -1187,7 +1187,7 @@ describe('project move', () => {
 
     it('shows help when no ref provided', async () => {
         const program = createProgram()
-        vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+        mockProcessStdout()
 
         try {
             await program.parseAsync(['node', 'td', 'project', 'move'])
@@ -1500,7 +1500,7 @@ describe('project move', () => {
 describe('project (no args)', () => {
     it('shows parent help listing all subcommands', async () => {
         const program = createProgram()
-        const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+        const stdoutSpy = mockProcessStdout()
 
         try {
             await program.parseAsync(['node', 'td', 'project'])

--- a/src/commands/project/reorder.test.ts
+++ b/src/commands/project/reorder.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
     getApi: vi.fn(),
@@ -11,6 +11,7 @@ vi.mock('../../lib/api/projects-sync.js', () => ({
 
 import { reorderProjects } from '../../lib/api/projects-sync.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerProjectCommand } from './index.js'
@@ -41,11 +42,7 @@ describe('project reorder', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     function primeProjects(target: (typeof siblings)[number], all = siblings) {

--- a/src/commands/project/reorder.test.ts
+++ b/src/commands/project/reorder.test.ts
@@ -9,13 +9,12 @@ vi.mock('../../lib/api/projects-sync.js', () => ({
     reorderProjects: vi.fn().mockResolvedValue(undefined),
 }))
 
-import { getApi } from '../../lib/api/core.js'
 import { reorderProjects } from '../../lib/api/projects-sync.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerProjectCommand } from './index.js'
 
-const mockGetApi = vi.mocked(getApi)
 const mockReorderProjects = vi.mocked(reorderProjects)
 
 function createProgram() {
@@ -41,8 +40,7 @@ describe('project reorder', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 

--- a/src/commands/project/reorder.test.ts
+++ b/src/commands/project/reorder.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
@@ -13,16 +12,14 @@ vi.mock('../../lib/api/projects-sync.js', () => ({
 import { getApi } from '../../lib/api/core.js'
 import { reorderProjects } from '../../lib/api/projects-sync.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerProjectCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
 const mockReorderProjects = vi.mocked(reorderProjects)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerProjectCommand(program)
-    return program
+    return createTestProgram(registerProjectCommand)
 }
 
 describe('project reorder', () => {

--- a/src/commands/project/update.test.ts
+++ b/src/commands/project/update.test.ts
@@ -8,13 +8,12 @@ vi.mock('../../lib/api/projects-sync.js', () => ({
     moveProjectParent: vi.fn().mockResolvedValue(undefined),
 }))
 
-import { getApi } from '../../lib/api/core.js'
 import { moveProjectParent } from '../../lib/api/projects-sync.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerProjectCommand } from './index.js'
 
-const mockGetApi = vi.mocked(getApi)
 const mockMoveProjectParent = vi.mocked(moveProjectParent)
 
 function createProgram() {
@@ -27,8 +26,7 @@ describe('project update', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -217,8 +215,7 @@ describe('project update --json', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
@@ -261,8 +258,7 @@ describe('project update --parent / --no-parent', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 

--- a/src/commands/project/update.test.ts
+++ b/src/commands/project/update.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
@@ -12,16 +11,14 @@ vi.mock('../../lib/api/projects-sync.js', () => ({
 import { getApi } from '../../lib/api/core.js'
 import { moveProjectParent } from '../../lib/api/projects-sync.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerProjectCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
 const mockMoveProjectParent = vi.mocked(moveProjectParent)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerProjectCommand(program)
-    return program
+    return createTestProgram(registerProjectCommand)
 }
 
 describe('project update', () => {

--- a/src/commands/project/update.test.ts
+++ b/src/commands/project/update.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
     getApi: vi.fn(),
@@ -10,6 +10,7 @@ vi.mock('../../lib/api/projects-sync.js', () => ({
 
 import { moveProjectParent } from '../../lib/api/projects-sync.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerProjectCommand } from './index.js'
@@ -27,11 +28,7 @@ describe('project update', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('updates project name', async () => {
@@ -216,11 +213,7 @@ describe('project update --json', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('outputs updated project as JSON', async () => {
@@ -259,11 +252,7 @@ describe('project update --parent / --no-parent', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('re-parents under another personal project (sync only, no updateProject)', async () => {

--- a/src/commands/reminder/reminder.test.ts
+++ b/src/commands/reminder/reminder.test.ts
@@ -16,7 +16,6 @@ vi.mock('../../lib/api/reminders.js', () => ({
     deleteLocationReminder: vi.fn(),
 }))
 
-import { getApi } from '../../lib/api/core.js'
 import {
     addLocationReminder,
     addReminder,
@@ -30,10 +29,10 @@ import {
 } from '../../lib/api/reminders.js'
 import { registerReminderCommand } from './index.js'
 
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 
-const mockGetApi = vi.mocked(getApi)
 const mockFetchReminders = vi.mocked(fetchReminders)
 const mockAddReminder = vi.mocked(addReminder)
 const mockUpdateReminder = vi.mocked(updateReminder)
@@ -53,8 +52,7 @@ describe('reminder list', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('lists reminders for a task', async () => {
@@ -354,8 +352,7 @@ describe('reminder add --json', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('outputs created reminder as JSON with --before', async () => {
@@ -421,8 +418,7 @@ describe('reminder add', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('adds reminder with --before offset', async () => {
@@ -873,8 +869,7 @@ describe('reminder --dry-run', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('reminder add --dry-run previews without calling API', async () => {
@@ -1045,8 +1040,7 @@ describe('reminder location add', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     function setupTask() {

--- a/src/commands/reminder/reminder.test.ts
+++ b/src/commands/reminder/reminder.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
@@ -32,6 +31,7 @@ import {
 import { registerReminderCommand } from './index.js'
 
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 
 const mockGetApi = vi.mocked(getApi)
 const mockFetchReminders = vi.mocked(fetchReminders)
@@ -45,10 +45,7 @@ const mockUpdateLocationReminder = vi.mocked(updateLocationReminder)
 const mockDeleteLocationReminder = vi.mocked(deleteLocationReminder)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerReminderCommand(program)
-    return program
+    return createTestProgram(registerReminderCommand)
 }
 
 describe('reminder list', () => {

--- a/src/commands/reminder/reminder.test.ts
+++ b/src/commands/reminder/reminder.test.ts
@@ -27,6 +27,7 @@ import {
     updateLocationReminder,
     updateReminder,
 } from '../../lib/api/reminders.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { registerReminderCommand } from './index.js'
 
 import { setupApiMock } from '../../test-support/api-mock.js'
@@ -57,7 +58,7 @@ describe('reminder list', () => {
 
     it('lists reminders for a task', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Buy milk' })
         mockApi.getReminders.mockResolvedValue({
@@ -94,12 +95,11 @@ describe('reminder list', () => {
         )
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('30m before due'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('at 2024-01-15 10:00'))
-        consoleSpy.mockRestore()
     })
 
     it('lists all reminders when no task specified', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getReminders.mockResolvedValue({
             results: [
@@ -123,12 +123,11 @@ describe('reminder list', () => {
         )
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('15m before due'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('task:task-1'))
-        consoleSpy.mockRestore()
     })
 
     it('shows location reminders alongside time reminders', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getReminders.mockResolvedValue({ results: [], nextCursor: null })
         mockApi.getLocationReminders.mockResolvedValue({
@@ -153,12 +152,11 @@ describe('reminder list', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Office'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('on enter'))
-        consoleSpy.mockRestore()
     })
 
     it('shows "No reminders." when empty', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Test' })
         mockApi.getReminders.mockResolvedValue({ results: [], nextCursor: null })
@@ -167,12 +165,11 @@ describe('reminder list', () => {
         await program.parseAsync(['node', 'td', 'reminder', 'list', 'id:task-1'])
 
         expect(consoleSpy).toHaveBeenCalledWith('No reminders.')
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Test' })
         mockApi.getReminders.mockResolvedValue({
@@ -196,12 +193,11 @@ describe('reminder list', () => {
         const parsed = JSON.parse(output)
         expect(parsed.results).toBeDefined()
         expect(parsed.results[0].minuteOffset).toBe(60)
-        consoleSpy.mockRestore()
     })
 
     it('accepts --task flag instead of positional arg', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Buy milk' })
         mockApi.getReminders.mockResolvedValue({ results: [], nextCursor: null })
@@ -210,7 +206,6 @@ describe('reminder list', () => {
         await program.parseAsync(['node', 'td', 'reminder', 'list', '--task', 'id:task-1'])
 
         expect(mockApi.getTask).toHaveBeenCalledWith('task-1')
-        consoleSpy.mockRestore()
     })
 
     it('errors when both positional and --task are provided', async () => {
@@ -231,7 +226,7 @@ describe('reminder list', () => {
 
     it('filters to time-based reminders with --type time', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getReminders.mockResolvedValue({
             results: [
@@ -252,12 +247,11 @@ describe('reminder list', () => {
         expect(mockApi.getReminders).toHaveBeenCalled()
         expect(mockApi.getLocationReminders).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('15m before due'))
-        consoleSpy.mockRestore()
     })
 
     it('filters to location reminders with --type location', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getLocationReminders.mockResolvedValue({
             results: [
@@ -282,7 +276,6 @@ describe('reminder list', () => {
         expect(mockApi.getLocationReminders).toHaveBeenCalled()
         expect(mockApi.getReminders).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Home'))
-        consoleSpy.mockRestore()
     })
 
     it('errors when --cursor is used without --type', async () => {
@@ -295,7 +288,7 @@ describe('reminder list', () => {
 
     it('shows [urgent] badge for urgent reminders', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getReminders.mockResolvedValue({
             results: [
@@ -316,12 +309,11 @@ describe('reminder list', () => {
         await program.parseAsync(['node', 'td', 'reminder', 'list'])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[urgent]'))
-        consoleSpy.mockRestore()
     })
 
     it('does not show task context when filtered by task', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Buy milk' })
         mockApi.getReminders.mockResolvedValue({
@@ -343,7 +335,6 @@ describe('reminder list', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('10m before due'))
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('task:'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -357,7 +348,7 @@ describe('reminder add --json', () => {
 
     it('outputs created reminder as JSON with --before', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -384,12 +375,11 @@ describe('reminder add --json', () => {
         expect(parsed.type).toBe('relative')
         expect(parsed.minuteOffset).toBe(30)
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Added reminder:'))
-        consoleSpy.mockRestore()
     })
 
     it('outputs created reminder as JSON with --at', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Buy milk' })
         mockAddReminder.mockResolvedValue('rem-new')
@@ -409,7 +399,6 @@ describe('reminder add --json', () => {
         const parsed = JSON.parse(output)
         expect(parsed.id).toBe('rem-new')
         expect(parsed.type).toBe('absolute')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -423,7 +412,7 @@ describe('reminder add', () => {
 
     it('adds reminder with --before offset', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -440,12 +429,11 @@ describe('reminder add', () => {
             due: undefined,
         })
         expect(consoleSpy).toHaveBeenCalledWith('Added reminder: 30m before due')
-        consoleSpy.mockRestore()
     })
 
     it('adds reminder with --at datetime', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Buy milk' })
         mockAddReminder.mockResolvedValue('rem-new')
@@ -466,12 +454,11 @@ describe('reminder add', () => {
             due: { date: '2024-01-15T10:00:00' },
         })
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('at 2024-01-15'))
-        consoleSpy.mockRestore()
     })
 
     it('parses hour durations', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -487,12 +474,11 @@ describe('reminder add', () => {
             minuteOffset: 60,
             due: undefined,
         })
-        consoleSpy.mockRestore()
     })
 
     it('shows ID after creation', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -504,7 +490,6 @@ describe('reminder add', () => {
         await program.parseAsync(['node', 'td', 'reminder', 'add', 'id:task-1', '--before', '15m'])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('rem-xyz'))
-        consoleSpy.mockRestore()
     })
 
     it('errors when neither --before nor --at specified', async () => {
@@ -590,7 +575,7 @@ describe('reminder add', () => {
 
     it('accepts --task flag instead of positional arg', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -615,7 +600,6 @@ describe('reminder add', () => {
             minuteOffset: 30,
             due: undefined,
         })
-        consoleSpy.mockRestore()
     })
 
     it('errors when both positional and --task are provided for add', async () => {
@@ -638,7 +622,7 @@ describe('reminder add', () => {
 
     it('passes --urgent through and shows [urgent] in output', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Buy milk' })
         mockAddReminder.mockResolvedValue('rem-new')
@@ -658,7 +642,6 @@ describe('reminder add', () => {
             expect.objectContaining({ itemId: 'task-1', isUrgent: true }),
         )
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[urgent]'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -669,7 +652,7 @@ describe('reminder update', () => {
 
     it('updates reminder with new offset', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockUpdateReminder.mockResolvedValue(undefined)
 
@@ -680,12 +663,11 @@ describe('reminder update', () => {
             due: undefined,
         })
         expect(consoleSpy).toHaveBeenCalledWith('Updated reminder: 1h before due (id:rem-1)')
-        consoleSpy.mockRestore()
     })
 
     it('updates reminder with new datetime', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockUpdateReminder.mockResolvedValue(undefined)
 
@@ -704,7 +686,6 @@ describe('reminder update', () => {
             due: { date: '2024-01-16T09:00:00' },
         })
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('at 2024-01-16'))
-        consoleSpy.mockRestore()
     })
 
     it('rejects plain text references', async () => {
@@ -725,7 +706,7 @@ describe('reminder update', () => {
 
     it('toggles urgency alone without --before or --at', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockUpdateReminder.mockResolvedValue(undefined)
 
@@ -736,12 +717,11 @@ describe('reminder update', () => {
             expect.objectContaining({ isUrgent: false }),
         )
         expect(consoleSpy).toHaveBeenCalledWith('Updated reminder: marked not urgent (id:rem-1)')
-        consoleSpy.mockRestore()
     })
 
     it('shows [urgent] in confirmation when time and --urgent are combined', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockUpdateReminder.mockResolvedValue(undefined)
 
@@ -758,12 +738,11 @@ describe('reminder update', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('1h before due'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[urgent]'))
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockUpdateReminder.mockResolvedValue(undefined)
         mockGetReminderById.mockResolvedValue({
@@ -791,7 +770,6 @@ describe('reminder update', () => {
         const parsed = JSON.parse(firstCall)
         expect(parsed.id).toBe('rem-1')
         expect(parsed.isUrgent).toBe(true)
-        consoleSpy.mockRestore()
     })
 })
 
@@ -802,7 +780,7 @@ describe('reminder delete', () => {
 
     it('shows dry-run without --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchReminders.mockResolvedValue([
             {
@@ -819,12 +797,11 @@ describe('reminder delete', () => {
         expect(mockDeleteReminder).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Would delete reminder: 30m before due')
         expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
-        consoleSpy.mockRestore()
     })
 
     it('deletes reminder with --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchReminders.mockResolvedValue([
             {
@@ -841,7 +818,6 @@ describe('reminder delete', () => {
 
         expect(mockDeleteReminder).toHaveBeenCalledWith('rem-123')
         expect(consoleSpy).toHaveBeenCalledWith('Deleted reminder: 1h before due (id:rem-123)')
-        consoleSpy.mockRestore()
     })
 
     it('rejects plain text references', async () => {
@@ -874,7 +850,7 @@ describe('reminder --dry-run', () => {
 
     it('reminder add --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Test task' })
 
@@ -891,12 +867,11 @@ describe('reminder --dry-run', () => {
 
         expect(mockAddReminder).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would add reminder'))
-        consoleSpy.mockRestore()
     })
 
     it('reminder delete --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchReminders.mockResolvedValue([
             {
@@ -912,12 +887,11 @@ describe('reminder --dry-run', () => {
 
         expect(mockDeleteReminder).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would delete reminder'))
-        consoleSpy.mockRestore()
     })
 
     it('reminder update --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync([
             'node',
@@ -932,7 +906,6 @@ describe('reminder --dry-run', () => {
 
         expect(mockUpdateReminder).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would update reminder'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -943,7 +916,7 @@ describe('reminder get', () => {
 
     it('fetches a time-based reminder by id', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockGetReminderById.mockResolvedValue({
             id: 'rem-1',
@@ -959,12 +932,11 @@ describe('reminder get', () => {
 
         expect(mockGetReminderById).toHaveBeenCalledWith('rem-1')
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('30m before due'))
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockGetReminderById.mockResolvedValue({
             id: 'rem-1',
@@ -981,7 +953,6 @@ describe('reminder get', () => {
         const firstCall = consoleSpy.mock.calls[0]?.[0] as string
         expect(firstCall).toContain('"id": "rem-1"')
         expect(firstCall).toContain('"type": "absolute"')
-        consoleSpy.mockRestore()
     })
 
     it('rejects invalid id ref', async () => {
@@ -993,7 +964,7 @@ describe('reminder get', () => {
 
     it('shows [urgent] badge for urgent reminders', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockGetReminderById.mockResolvedValue({
             id: 'rem-1',
@@ -1009,12 +980,11 @@ describe('reminder get', () => {
         await program.parseAsync(['node', 'td', 'reminder', 'get', 'id:rem-1'])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[urgent]'))
-        consoleSpy.mockRestore()
     })
 
     it('includes isUrgent in default --json output', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockGetReminderById.mockResolvedValue({
             id: 'rem-1',
@@ -1031,7 +1001,6 @@ describe('reminder get', () => {
 
         const firstCall = consoleSpy.mock.calls[0]?.[0] as string
         expect(firstCall).toContain('"isUrgent": true')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1053,7 +1022,7 @@ describe('reminder location add', () => {
 
     it('adds a location reminder', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
         setupTask()
 
         mockAddLocationReminder.mockResolvedValue({
@@ -1100,7 +1069,6 @@ describe('reminder location add', () => {
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('Added location reminder: Grocery'),
         )
-        consoleSpy.mockRestore()
     })
 
     it('requires --name', async () => {
@@ -1201,7 +1169,7 @@ describe('reminder location add', () => {
 
     it('--dry-run does not call the API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
         setupTask()
 
         await program.parseAsync([
@@ -1226,7 +1194,6 @@ describe('reminder location add', () => {
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('Would add location reminder'),
         )
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1237,7 +1204,7 @@ describe('reminder location update', () => {
 
     it('updates a subset of fields', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockUpdateLocationReminder.mockResolvedValue({
             id: 'loc-1',
@@ -1268,7 +1235,6 @@ describe('reminder location update', () => {
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('Updated location reminder'),
         )
-        consoleSpy.mockRestore()
     })
 
     it('errors when no fields provided', async () => {
@@ -1280,7 +1246,7 @@ describe('reminder location update', () => {
 
     it('outputs JSON with --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockUpdateLocationReminder.mockResolvedValue({
             id: 'loc-1',
@@ -1311,12 +1277,11 @@ describe('reminder location update', () => {
         const firstCall = consoleSpy.mock.calls[0]?.[0] as string
         expect(firstCall).toContain('"id": "loc-1"')
         expect(firstCall).toContain('"radius": 300')
-        consoleSpy.mockRestore()
     })
 
     it('--dry-run does not call the API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync([
             'node',
@@ -1334,7 +1299,6 @@ describe('reminder location update', () => {
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('Would update location reminder'),
         )
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1361,7 +1325,7 @@ describe('reminder location delete', () => {
 
     it('requires --yes to delete', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
         mockLocationReminder()
 
         await program.parseAsync(['node', 'td', 'reminder', 'location', 'delete', 'id:loc-1'])
@@ -1370,12 +1334,11 @@ describe('reminder location delete', () => {
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('Would delete location reminder'),
         )
-        consoleSpy.mockRestore()
     })
 
     it('deletes with --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
         mockLocationReminder()
 
         await program.parseAsync([
@@ -1392,12 +1355,11 @@ describe('reminder location delete', () => {
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('Deleted location reminder'),
         )
-        consoleSpy.mockRestore()
     })
 
     it('--dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
         mockLocationReminder()
 
         await program.parseAsync([
@@ -1414,7 +1376,6 @@ describe('reminder location delete', () => {
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('Would delete location reminder'),
         )
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1425,7 +1386,7 @@ describe('reminder location get', () => {
 
     it('fetches a location reminder by id', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockGetLocationReminderById.mockResolvedValue({
             id: 'loc-1',
@@ -1445,12 +1406,11 @@ describe('reminder location get', () => {
 
         expect(mockGetLocationReminderById).toHaveBeenCalledWith('loc-1')
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Grocery'))
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockGetLocationReminderById.mockResolvedValue({
             id: 'loc-1',
@@ -1479,6 +1439,5 @@ describe('reminder location get', () => {
         const firstCall = consoleSpy.mock.calls[0]?.[0] as string
         expect(firstCall).toContain('"id": "loc-1"')
         expect(firstCall).toContain('"name": "Grocery"')
-        consoleSpy.mockRestore()
     })
 })

--- a/src/commands/section/section.test.ts
+++ b/src/commands/section/section.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
     getApi: vi.fn(),
 }))
 
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { fixtures } from '../../test-support/fixtures.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
@@ -39,7 +40,7 @@ describe('section list', () => {
 
     it('resolves project and lists sections', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getProjects.mockResolvedValue({
             results: [{ id: 'proj-1', name: 'Work' }],
@@ -60,12 +61,11 @@ describe('section list', () => {
         )
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Planning'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('In Progress'))
-        consoleSpy.mockRestore()
     })
 
     it('shows "No sections" when empty', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Work' })
         mockApi.getSections.mockResolvedValue({ results: [], nextCursor: null })
@@ -73,12 +73,11 @@ describe('section list', () => {
         await program.parseAsync(['node', 'td', 'section', 'list', 'id:proj-1'])
 
         expect(consoleSpy).toHaveBeenCalledWith('No sections.')
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Work' })
         mockApi.getSections.mockResolvedValue({
@@ -92,12 +91,11 @@ describe('section list', () => {
         const parsed = JSON.parse(output)
         expect(parsed.results).toBeDefined()
         expect(parsed.results[0].name).toBe('Planning')
-        consoleSpy.mockRestore()
     })
 
     it('accepts --project flag instead of positional arg', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getProjects.mockResolvedValue({
             results: [{ id: 'proj-1', name: 'Work' }],
@@ -110,7 +108,6 @@ describe('section list', () => {
         expect(mockApi.getSections).toHaveBeenCalledWith(
             expect.objectContaining({ projectId: 'proj-1' }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('errors when both positional and --project are provided', async () => {
@@ -123,7 +120,7 @@ describe('section list', () => {
 
     it('searches sections by name with --search', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.searchSections.mockResolvedValue({
             results: [
@@ -140,12 +137,11 @@ describe('section list', () => {
         )
         expect(mockApi.getSections).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Planning'))
-        consoleSpy.mockRestore()
     })
 
     it('searches sections scoped to a project with --search and --project', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getProjects.mockResolvedValue({
             results: [{ id: 'proj-1', name: 'Work' }],
@@ -170,12 +166,11 @@ describe('section list', () => {
         expect(mockApi.searchSections).toHaveBeenCalledWith(
             expect.objectContaining({ query: 'Plan', projectId: 'proj-1' }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --search and --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.searchSections.mockResolvedValue({
             results: [{ id: 'sec-1', name: 'Planning', projectId: 'proj-1' }],
@@ -187,7 +182,6 @@ describe('section list', () => {
         const output = consoleSpy.mock.calls[0][0]
         const parsed = JSON.parse(output)
         expect(parsed.results[0].name).toBe('Planning')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -201,7 +195,7 @@ describe('section create --json', () => {
 
     it('outputs created section as JSON', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Work' })
         mockApi.addSection.mockResolvedValue({
@@ -228,7 +222,6 @@ describe('section create --json', () => {
         expect(parsed.id).toBe('sec-new')
         expect(parsed.name).toBe('New Section')
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Created:'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -242,7 +235,7 @@ describe('section update --json', () => {
 
     it('outputs updated section as JSON', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getSection.mockResolvedValue({ id: 'sec-1', name: 'Old Name', projectId: 'proj-1' })
         mockApi.updateSection.mockResolvedValue({
@@ -268,7 +261,6 @@ describe('section update --json', () => {
         expect(parsed.id).toBe('sec-1')
         expect(parsed.name).toBe('New Name')
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Updated:'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -293,11 +285,7 @@ describe('section reorder', () => {
             results: [...sections],
             nextCursor: null,
         }))
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('requires --project', async () => {
@@ -613,7 +601,7 @@ describe('section create', () => {
 
     it('creates section in project', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getProjects.mockResolvedValue({
             results: [{ id: 'proj-1', name: 'Work' }],
@@ -637,12 +625,11 @@ describe('section create', () => {
             projectId: 'proj-1',
         })
         expect(consoleSpy).toHaveBeenCalledWith('Created: Review')
-        consoleSpy.mockRestore()
     })
 
     it('shows section ID after creation', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Work' })
         mockApi.addSection.mockResolvedValue({ id: 'sec-xyz', name: 'Test' })
@@ -659,7 +646,6 @@ describe('section create', () => {
         ])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('sec-xyz'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -681,7 +667,7 @@ describe('section delete', () => {
 
     it('shows dry-run without --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getSection.mockResolvedValue({ id: 'sec-1', name: 'My Section' })
         mockApi.getTasks.mockResolvedValue({ results: [], nextCursor: null })
@@ -691,12 +677,11 @@ describe('section delete', () => {
         expect(mockApi.deleteSection).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Would delete section: My Section')
         expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
-        consoleSpy.mockRestore()
     })
 
     it('deletes section with id: prefix and --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getSection.mockResolvedValue({ id: 'sec-123', name: 'My Section' })
         mockApi.getTasks.mockResolvedValue({ results: [], nextCursor: null })
@@ -706,7 +691,6 @@ describe('section delete', () => {
 
         expect(mockApi.deleteSection).toHaveBeenCalledWith('sec-123')
         expect(consoleSpy).toHaveBeenCalledWith('Deleted section: My Section (id:sec-123)')
-        consoleSpy.mockRestore()
     })
 
     it('fails when section has uncompleted tasks', async () => {
@@ -750,7 +734,7 @@ describe('section update', () => {
 
     it('updates section name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getSection.mockResolvedValue({ id: 'sec-1', name: 'Old Name' })
         mockApi.updateSection.mockResolvedValue({ id: 'sec-1', name: 'New Name' })
@@ -769,7 +753,6 @@ describe('section update', () => {
             name: 'New Name',
         })
         expect(consoleSpy).toHaveBeenCalledWith('Updated: Old Name → New Name (id:sec-1)')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -783,7 +766,7 @@ describe('section --dry-run', () => {
 
     it('section create --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync([
             'node',
@@ -799,12 +782,11 @@ describe('section --dry-run', () => {
 
         expect(mockApi.addSection).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would create section'))
-        consoleSpy.mockRestore()
     })
 
     it('section delete --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getSection.mockResolvedValue({
             id: 'sec-1',
@@ -818,12 +800,11 @@ describe('section --dry-run', () => {
 
         expect(mockApi.deleteSection).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would delete section'))
-        consoleSpy.mockRestore()
     })
 
     it('section update --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync([
             'node',
@@ -838,12 +819,11 @@ describe('section --dry-run', () => {
 
         expect(mockApi.updateSection).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would update section'))
-        consoleSpy.mockRestore()
     })
 
     it('section archive --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getSection.mockResolvedValue({
             id: 'sec-1',
@@ -857,12 +837,11 @@ describe('section --dry-run', () => {
 
         expect(mockApi.archiveSection).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would archive section'))
-        consoleSpy.mockRestore()
     })
 
     it('section unarchive --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getSection.mockResolvedValue({
             id: 'sec-1',
@@ -876,7 +855,6 @@ describe('section --dry-run', () => {
 
         expect(mockApi.unarchiveSection).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would unarchive section'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -898,7 +876,7 @@ describe('section archive', () => {
 
     it('archives section with id: prefix', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getSection.mockResolvedValue({
             id: 'sec-123',
@@ -917,12 +895,11 @@ describe('section archive', () => {
 
         expect(mockApi.archiveSection).toHaveBeenCalledWith('sec-123')
         expect(consoleSpy).toHaveBeenCalledWith('Archived: My Section (id:sec-123)')
-        consoleSpy.mockRestore()
     })
 
     it('shows message for already archived section', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getSection.mockResolvedValue({
             id: 'sec-123',
@@ -936,7 +913,6 @@ describe('section archive', () => {
 
         expect(mockApi.archiveSection).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Section already archived.')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -958,7 +934,7 @@ describe('section unarchive', () => {
 
     it('unarchives section with id: prefix', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getSection.mockResolvedValue({
             id: 'sec-123',
@@ -977,12 +953,11 @@ describe('section unarchive', () => {
 
         expect(mockApi.unarchiveSection).toHaveBeenCalledWith('sec-123')
         expect(consoleSpy).toHaveBeenCalledWith('Unarchived: My Section (id:sec-123)')
-        consoleSpy.mockRestore()
     })
 
     it('shows message for non-archived section', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getSection.mockResolvedValue({
             id: 'sec-123',
@@ -996,6 +971,5 @@ describe('section unarchive', () => {
 
         expect(mockApi.unarchiveSection).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Section is not archived.')
-        consoleSpy.mockRestore()
     })
 })

--- a/src/commands/section/section.test.ts
+++ b/src/commands/section/section.test.ts
@@ -4,13 +4,11 @@ vi.mock('../../lib/api/core.js', () => ({
     getApi: vi.fn(),
 }))
 
-import { getApi } from '../../lib/api/core.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
 import { fixtures } from '../../test-support/fixtures.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerSectionCommand } from './index.js'
-
-const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
     return createTestProgram(registerSectionCommand)
@@ -36,8 +34,7 @@ describe('section list', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('resolves project and lists sections', async () => {
@@ -199,8 +196,7 @@ describe('section create --json', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('outputs created section as JSON', async () => {
@@ -241,8 +237,7 @@ describe('section update --json', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('outputs updated section as JSON', async () => {
@@ -292,8 +287,7 @@ describe('section reorder', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockApi.getProject.mockResolvedValue(fixtures.projects.work)
         mockApi.getSections.mockImplementation(async () => ({
             results: [...sections],
@@ -614,8 +608,7 @@ describe('section create', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('creates section in project', async () => {
@@ -675,8 +668,7 @@ describe('section delete', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('rejects plain text references', async () => {
@@ -737,8 +729,7 @@ describe('section update', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('rejects plain text references', async () => {
@@ -787,8 +778,7 @@ describe('section --dry-run', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('section create --dry-run previews without calling API', async () => {
@@ -895,8 +885,7 @@ describe('section archive', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('rejects plain text references', async () => {
@@ -956,8 +945,7 @@ describe('section unarchive', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('rejects plain text references', async () => {

--- a/src/commands/section/section.test.ts
+++ b/src/commands/section/section.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
@@ -8,15 +7,13 @@ vi.mock('../../lib/api/core.js', () => ({
 import { getApi } from '../../lib/api/core.js'
 import { fixtures } from '../../test-support/fixtures.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerSectionCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerSectionCommand(program)
-    return program
+    return createTestProgram(registerSectionCommand)
 }
 
 function expectSectionReorderCommand(

--- a/src/commands/settings/settings.test.ts
+++ b/src/commands/settings/settings.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/user-settings.js', () => ({
@@ -27,6 +26,7 @@ import {
 } from '../../lib/api/user-settings.js'
 import { makeFilter } from '../../test-support/fixtures.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import {
     DATE_FORMAT_CHOICES,
     DAY_CHOICES,
@@ -45,10 +45,7 @@ const mockGetApi = vi.mocked(getApi)
 const mockFetchFilters = vi.mocked(fetchFilters)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerSettingsCommand(program)
-    return program
+    return createTestProgram(registerSettingsCommand)
 }
 
 const defaultSettings: UserSettings = {

--- a/src/commands/settings/settings.test.ts
+++ b/src/commands/settings/settings.test.ts
@@ -25,7 +25,7 @@ import {
     updateUserSettings,
 } from '../../lib/api/user-settings.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
-import { mockConsoleLog } from '../../test-support/console-spy.js'
+import { mockConsoleLog, mockProcessStdout } from '../../test-support/console-spy.js'
 import { makeFilter } from '../../test-support/fixtures.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
@@ -427,7 +427,7 @@ describe('settings update', () => {
 
     it('shows help when no settings specified', async () => {
         const program = createProgram()
-        const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+        const stdoutSpy = mockProcessStdout()
 
         try {
             await program.parseAsync(['node', 'td', 'settings', 'update'])

--- a/src/commands/settings/settings.test.ts
+++ b/src/commands/settings/settings.test.ts
@@ -25,6 +25,7 @@ import {
     updateUserSettings,
 } from '../../lib/api/user-settings.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { makeFilter } from '../../test-support/fixtures.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
@@ -72,7 +73,7 @@ describe('settings view', () => {
 
     it('displays settings in human-readable format', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchUserSettings.mockResolvedValue(defaultSettings)
 
@@ -84,12 +85,11 @@ describe('settings view', () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('24h'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Monday'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Notifications'))
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json flag using human-friendly values', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchUserSettings.mockResolvedValue(defaultSettings)
 
@@ -103,12 +103,11 @@ describe('settings view', () => {
         expect(parsed.startDay).toBe('monday')
         expect(parsed.theme).toBe('blueberry')
         expect(parsed.reminderPush).toBe(true)
-        consoleSpy.mockRestore()
     })
 
     it('formats 12h time format correctly', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchUserSettings.mockResolvedValue({
             ...defaultSettings,
@@ -118,12 +117,11 @@ describe('settings view', () => {
         await program.parseAsync(['node', 'td', 'settings', 'view'])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('12h'))
-        consoleSpy.mockRestore()
     })
 
     it('formats US date format correctly', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchUserSettings.mockResolvedValue({
             ...defaultSettings,
@@ -133,7 +131,6 @@ describe('settings view', () => {
         await program.parseAsync(['node', 'td', 'settings', 'view'])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('MM/DD/YYYY'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -147,7 +144,7 @@ describe('settings view - start page name resolution', () => {
 
     it('resolves project name in text output', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchUserSettings.mockResolvedValue({
             ...defaultSettings,
@@ -161,12 +158,11 @@ describe('settings view - start page name resolution', () => {
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('project?id=abc123 (My Project)'),
         )
-        consoleSpy.mockRestore()
     })
 
     it('resolves project name in JSON output', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchUserSettings.mockResolvedValue({
             ...defaultSettings,
@@ -180,12 +176,11 @@ describe('settings view - start page name resolution', () => {
         const parsed = JSON.parse(output)
         expect(parsed.startPage).toBe('project?id=abc123')
         expect(parsed.startPageName).toBe('My Project')
-        consoleSpy.mockRestore()
     })
 
     it('resolves label name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchUserSettings.mockResolvedValue({
             ...defaultSettings,
@@ -199,12 +194,11 @@ describe('settings view - start page name resolution', () => {
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('label?id=label-1 (Urgent)'),
         )
-        consoleSpy.mockRestore()
     })
 
     it('resolves filter name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchUserSettings.mockResolvedValue({
             ...defaultSettings,
@@ -221,12 +215,11 @@ describe('settings view - start page name resolution', () => {
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('filter?id=filter-1 (Work tasks)'),
         )
-        consoleSpy.mockRestore()
     })
 
     it('does not call API for simple start page values', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockFetchUserSettings.mockResolvedValue(defaultSettings) // startPage: 'today'
 
@@ -234,12 +227,11 @@ describe('settings view - start page name resolution', () => {
 
         expect(mockGetApi).not.toHaveBeenCalled()
         expect(mockFetchFilters).not.toHaveBeenCalled()
-        consoleSpy.mockRestore()
     })
 
     it('has null startPageName in JSON for simple values', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchUserSettings.mockResolvedValue(defaultSettings) // startPage: 'today'
 
@@ -249,12 +241,11 @@ describe('settings view - start page name resolution', () => {
         const parsed = JSON.parse(output)
         expect(parsed.startPage).toBe('today')
         expect(parsed.startPageName).toBeNull()
-        consoleSpy.mockRestore()
     })
 
     it('gracefully handles API failure', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchUserSettings.mockResolvedValue({
             ...defaultSettings,
@@ -269,7 +260,6 @@ describe('settings view - start page name resolution', () => {
         // Should show raw value without resolved name
         const output = consoleSpy.mock.calls[0][0] as string
         expect(output).not.toContain('project?id=abc123 (')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -280,7 +270,7 @@ describe('settings update', () => {
 
     it('updates timezone', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockUpdateUserSettings.mockResolvedValue(undefined)
 
@@ -297,132 +287,121 @@ describe('settings update', () => {
             timezone: 'America/New_York',
         })
         expect(consoleSpy).toHaveBeenCalledWith('Settings updated.')
-        consoleSpy.mockRestore()
     })
 
     it('updates time format to 24h', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockUpdateUserSettings.mockResolvedValue(undefined)
 
         await program.parseAsync(['node', 'td', 'settings', 'update', '--time-format', '24'])
 
         expect(mockUpdateUserSettings).toHaveBeenCalledWith({ timeFormat: '24h' })
-        consoleSpy.mockRestore()
     })
 
     it('updates time format to 12h', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockUpdateUserSettings.mockResolvedValue(undefined)
 
         await program.parseAsync(['node', 'td', 'settings', 'update', '--time-format', '12'])
 
         expect(mockUpdateUserSettings).toHaveBeenCalledWith({ timeFormat: '12h' })
-        consoleSpy.mockRestore()
     })
 
     it('updates date format to US', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockUpdateUserSettings.mockResolvedValue(undefined)
 
         await program.parseAsync(['node', 'td', 'settings', 'update', '--date-format', 'us'])
 
         expect(mockUpdateUserSettings).toHaveBeenCalledWith({ dateFormat: 'MM/DD/YYYY' })
-        consoleSpy.mockRestore()
     })
 
     it('updates date format to international', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockUpdateUserSettings.mockResolvedValue(undefined)
 
         await program.parseAsync(['node', 'td', 'settings', 'update', '--date-format', 'intl'])
 
         expect(mockUpdateUserSettings).toHaveBeenCalledWith({ dateFormat: 'DD/MM/YYYY' })
-        consoleSpy.mockRestore()
     })
 
     it('updates start day with day name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockUpdateUserSettings.mockResolvedValue(undefined)
 
         await program.parseAsync(['node', 'td', 'settings', 'update', '--start-day', 'Sunday'])
 
         expect(mockUpdateUserSettings).toHaveBeenCalledWith({ startDay: 'Sunday' })
-        consoleSpy.mockRestore()
     })
 
     it('updates start day with short day name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockUpdateUserSettings.mockResolvedValue(undefined)
 
         await program.parseAsync(['node', 'td', 'settings', 'update', '--start-day', 'Mon'])
 
         expect(mockUpdateUserSettings).toHaveBeenCalledWith({ startDay: 'Monday' })
-        consoleSpy.mockRestore()
     })
 
     it('updates theme by name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockUpdateUserSettings.mockResolvedValue(undefined)
 
         await program.parseAsync(['node', 'td', 'settings', 'update', '--theme', 'kale'])
 
         expect(mockUpdateUserSettings).toHaveBeenCalledWith({ theme: 5 })
-        consoleSpy.mockRestore()
     })
 
     it('updates auto reminder', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockUpdateUserSettings.mockResolvedValue(undefined)
 
         await program.parseAsync(['node', 'td', 'settings', 'update', '--auto-reminder', '60'])
 
         expect(mockUpdateUserSettings).toHaveBeenCalledWith({ autoReminder: 60 })
-        consoleSpy.mockRestore()
     })
 
     it('updates notification settings', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockUpdateUserSettings.mockResolvedValue(undefined)
 
         await program.parseAsync(['node', 'td', 'settings', 'update', '--reminder-email', 'on'])
 
         expect(mockUpdateUserSettings).toHaveBeenCalledWith({ reminderEmail: true })
-        consoleSpy.mockRestore()
     })
 
     it('parses boolean values correctly', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockUpdateUserSettings.mockResolvedValue(undefined)
 
         await program.parseAsync(['node', 'td', 'settings', 'update', '--reminder-push', 'off'])
 
         expect(mockUpdateUserSettings).toHaveBeenCalledWith({ reminderPush: false })
-        consoleSpy.mockRestore()
     })
 
     it('updates multiple settings at once', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockUpdateUserSettings.mockResolvedValue(undefined)
 
@@ -444,7 +423,6 @@ describe('settings update', () => {
             timeFormat: '24h',
             reminderDesktop: true,
         })
-        consoleSpy.mockRestore()
     })
 
     it('shows help when no settings specified', async () => {
@@ -459,7 +437,6 @@ describe('settings update', () => {
         }
 
         expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('Usage:'))
-        stdoutSpy.mockRestore()
     })
 
     it('errors on invalid time format', async () => {

--- a/src/commands/settings/settings.test.ts
+++ b/src/commands/settings/settings.test.ts
@@ -24,8 +24,9 @@ import {
     type UserSettings,
     updateUserSettings,
 } from '../../lib/api/user-settings.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
 import { makeFilter } from '../../test-support/fixtures.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import {
     DATE_FORMAT_CHOICES,
@@ -141,8 +142,7 @@ describe('settings view - start page name resolution', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('resolves project name in text output', async () => {

--- a/src/commands/skill/skill.test.ts
+++ b/src/commands/skill/skill.test.ts
@@ -1,7 +1,6 @@
 import { access, mkdir, mkdtemp, readFile, rm, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('chalk')
@@ -13,13 +12,11 @@ vi.mock('../../lib/skills/update-installed.js', () => ({
 import { createInstaller } from '../../lib/skills/create-installer.js'
 import { getInstaller, listAgents, skillInstallers } from '../../lib/skills/index.js'
 import { updateAllInstalledSkills } from '../../lib/skills/update-installed.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerSkillCommand } from './index.js'
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerSkillCommand(program)
-    return program
+    return createTestProgram(registerSkillCommand)
 }
 
 describe('skill command', () => {

--- a/src/commands/skill/skill.test.ts
+++ b/src/commands/skill/skill.test.ts
@@ -12,6 +12,7 @@ vi.mock('../../lib/skills/update-installed.js', () => ({
 import { createInstaller } from '../../lib/skills/create-installer.js'
 import { getInstaller, listAgents, skillInstallers } from '../../lib/skills/index.js'
 import { updateAllInstalledSkills } from '../../lib/skills/update-installed.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerSkillCommand } from './index.js'
 
@@ -24,11 +25,7 @@ describe('skill command', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     describe('list subcommand', () => {

--- a/src/commands/stats/stats.test.ts
+++ b/src/commands/stats/stats.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/stats.js', () => ({
@@ -7,16 +6,14 @@ vi.mock('../../lib/api/stats.js', () => ({
 }))
 
 import { fetchProductivityStats, updateGoals } from '../../lib/api/stats.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerStatsCommand } from './index.js'
 
 const mockFetchProductivityStats = vi.mocked(fetchProductivityStats)
 const mockUpdateGoals = vi.mocked(updateGoals)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerStatsCommand(program)
-    return program
+    return createTestProgram(registerStatsCommand)
 }
 
 const defaultStats = {

--- a/src/commands/stats/stats.test.ts
+++ b/src/commands/stats/stats.test.ts
@@ -6,6 +6,7 @@ vi.mock('../../lib/api/stats.js', () => ({
 }))
 
 import { fetchProductivityStats, updateGoals } from '../../lib/api/stats.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerStatsCommand } from './index.js'
 
@@ -50,7 +51,7 @@ describe('stats view', () => {
 
     it('displays stats in human-readable format', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchProductivityStats.mockResolvedValue(defaultStats)
 
@@ -62,12 +63,11 @@ describe('stats view', () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Daily:'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Weekly:'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Completed:'))
-        consoleSpy.mockRestore()
     })
 
     it('shows vacation mode warning when enabled', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         const vacationStats = {
             ...defaultStats,
@@ -78,12 +78,11 @@ describe('stats view', () => {
         await program.parseAsync(['node', 'td', 'stats'])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Vacation mode'))
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchProductivityStats.mockResolvedValue(defaultStats)
 
@@ -96,12 +95,11 @@ describe('stats view', () => {
         expect(parsed.completedCount).toBe(4521)
         expect(parsed.goals.dailyGoal).toBe(5)
         expect(parsed.goals.currentDailyStreak.count).toBe(42)
-        consoleSpy.mockRestore()
     })
 
     it('outputs full JSON with --json --full flags', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchProductivityStats.mockResolvedValue(defaultStats)
 
@@ -113,12 +111,11 @@ describe('stats view', () => {
         expect(parsed.daysItems).toBeDefined()
         expect(parsed.weekItems).toBeDefined()
         expect(parsed.goals.ignoreDays).toBeDefined()
-        consoleSpy.mockRestore()
     })
 
     it('shows streak information', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockFetchProductivityStats.mockResolvedValue(defaultStats)
 
@@ -127,7 +124,6 @@ describe('stats view', () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('streak:'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('42'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('best: 67'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -138,7 +134,7 @@ describe('stats goals', () => {
 
     it('updates daily goal', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockUpdateGoals.mockResolvedValue(undefined)
 
@@ -146,12 +142,11 @@ describe('stats goals', () => {
 
         expect(mockUpdateGoals).toHaveBeenCalledWith({ dailyGoal: 10 })
         expect(consoleSpy).toHaveBeenCalledWith('Goals updated.')
-        consoleSpy.mockRestore()
     })
 
     it('updates weekly goal', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockUpdateGoals.mockResolvedValue(undefined)
 
@@ -159,12 +154,11 @@ describe('stats goals', () => {
 
         expect(mockUpdateGoals).toHaveBeenCalledWith({ weeklyGoal: 50 })
         expect(consoleSpy).toHaveBeenCalledWith('Goals updated.')
-        consoleSpy.mockRestore()
     })
 
     it('updates both daily and weekly goals', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockUpdateGoals.mockResolvedValue(undefined)
 
@@ -174,7 +168,6 @@ describe('stats goals', () => {
             dailyGoal: 5,
             weeklyGoal: 25,
         })
-        consoleSpy.mockRestore()
     })
 
     it('shows help when no options specified', async () => {
@@ -188,7 +181,6 @@ describe('stats goals', () => {
         }
 
         expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('Usage:'))
-        stdoutSpy.mockRestore()
     })
 
     it('errors on invalid daily goal', async () => {
@@ -215,7 +207,7 @@ describe('stats vacation', () => {
 
     it('enables vacation mode with --on', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockUpdateGoals.mockResolvedValue(undefined)
 
@@ -223,12 +215,11 @@ describe('stats vacation', () => {
 
         expect(mockUpdateGoals).toHaveBeenCalledWith({ vacationMode: true })
         expect(consoleSpy).toHaveBeenCalledWith('Vacation mode enabled.')
-        consoleSpy.mockRestore()
     })
 
     it('disables vacation mode with --off', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockUpdateGoals.mockResolvedValue(undefined)
 
@@ -236,7 +227,6 @@ describe('stats vacation', () => {
 
         expect(mockUpdateGoals).toHaveBeenCalledWith({ vacationMode: false })
         expect(consoleSpy).toHaveBeenCalledWith('Vacation mode disabled.')
-        consoleSpy.mockRestore()
     })
 
     it('errors when both --on and --off specified', async () => {
@@ -258,6 +248,5 @@ describe('stats vacation', () => {
         }
 
         expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('Usage:'))
-        stdoutSpy.mockRestore()
     })
 })

--- a/src/commands/stats/stats.test.ts
+++ b/src/commands/stats/stats.test.ts
@@ -6,7 +6,7 @@ vi.mock('../../lib/api/stats.js', () => ({
 }))
 
 import { fetchProductivityStats, updateGoals } from '../../lib/api/stats.js'
-import { mockConsoleLog } from '../../test-support/console-spy.js'
+import { mockConsoleLog, mockProcessStdout } from '../../test-support/console-spy.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerStatsCommand } from './index.js'
 
@@ -172,7 +172,7 @@ describe('stats goals', () => {
 
     it('shows help when no options specified', async () => {
         const program = createProgram()
-        const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+        const stdoutSpy = mockProcessStdout()
 
         try {
             await program.parseAsync(['node', 'td', 'stats', 'goals'])
@@ -239,7 +239,7 @@ describe('stats vacation', () => {
 
     it('shows help when no options specified', async () => {
         const program = createProgram()
-        const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+        const stdoutSpy = mockProcessStdout()
 
         try {
             await program.parseAsync(['node', 'td', 'stats', 'vacation'])

--- a/src/commands/task/quickadd.test.ts
+++ b/src/commands/task/quickadd.test.ts
@@ -13,6 +13,7 @@ vi.mock('../../lib/stdin.js', () => ({
 import { resetGlobalArgs } from '../../lib/global-args.js'
 import { readStdin } from '../../lib/stdin.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerTaskCommand } from './index.js'
@@ -34,7 +35,7 @@ describe('task quickadd command', () => {
 
     it('calls quickAddTask with positional text', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.quickAddTask.mockResolvedValue({
             id: 'task-1',
@@ -45,12 +46,11 @@ describe('task quickadd command', () => {
         await program.parseAsync(['node', 'td', 'task', 'quickadd', 'Buy milk tomorrow p1'])
 
         expect(mockApi.quickAddTask).toHaveBeenCalledWith({ text: 'Buy milk tomorrow p1' })
-        consoleSpy.mockRestore()
     })
 
     it('works via qa alias', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.quickAddTask.mockResolvedValue({
             id: 'task-1',
@@ -61,12 +61,11 @@ describe('task quickadd command', () => {
         await program.parseAsync(['node', 'td', 'task', 'qa', 'Buy milk'])
 
         expect(mockApi.quickAddTask).toHaveBeenCalledWith({ text: 'Buy milk' })
-        consoleSpy.mockRestore()
     })
 
     it('reads text from stdin with --stdin', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockReadStdin.mockResolvedValue('Buy milk tomorrow\n')
         mockApi.quickAddTask.mockResolvedValue({
@@ -79,7 +78,6 @@ describe('task quickadd command', () => {
 
         expect(mockReadStdin).toHaveBeenCalled()
         expect(mockApi.quickAddTask).toHaveBeenCalledWith({ text: 'Buy milk tomorrow' })
-        consoleSpy.mockRestore()
     })
 
     it('errors when both text and --stdin are provided', async () => {
@@ -120,18 +118,17 @@ describe('task quickadd command', () => {
 
     it('--dry-run skips API call and prints preview', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync(['node', 'td', 'task', 'qa', 'Buy milk', '--dry-run'])
 
         expect(mockApi.quickAddTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would quick add task'))
-        consoleSpy.mockRestore()
     })
 
     it('--json outputs task as JSON', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.quickAddTask.mockResolvedValue({
             id: 'task-1',
@@ -144,12 +141,11 @@ describe('task quickadd command', () => {
         const output = consoleSpy.mock.calls[0][0] as string
         expect(() => JSON.parse(output)).not.toThrow()
         expect(JSON.parse(output)).toMatchObject({ id: 'task-1', content: 'Buy milk' })
-        consoleSpy.mockRestore()
     })
 
     it('displays due date when present', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.quickAddTask.mockResolvedValue({
             id: 'task-1',
@@ -160,6 +156,5 @@ describe('task quickadd command', () => {
         await program.parseAsync(['node', 'td', 'task', 'qa', 'Meeting tomorrow'])
 
         expect(consoleSpy).toHaveBeenCalledWith('Due: tomorrow')
-        consoleSpy.mockRestore()
     })
 })

--- a/src/commands/task/quickadd.test.ts
+++ b/src/commands/task/quickadd.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
@@ -15,16 +14,14 @@ import { getApi } from '../../lib/api/core.js'
 import { resetGlobalArgs } from '../../lib/global-args.js'
 import { readStdin } from '../../lib/stdin.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerTaskCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
 const mockReadStdin = vi.mocked(readStdin)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerTaskCommand(program)
-    return program
+    return createTestProgram(registerTaskCommand)
 }
 
 describe('task quickadd command', () => {

--- a/src/commands/task/quickadd.test.ts
+++ b/src/commands/task/quickadd.test.ts
@@ -10,14 +10,13 @@ vi.mock('../../lib/stdin.js', () => ({
     readStdin: vi.fn(),
 }))
 
-import { getApi } from '../../lib/api/core.js'
 import { resetGlobalArgs } from '../../lib/global-args.js'
 import { readStdin } from '../../lib/stdin.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerTaskCommand } from './index.js'
 
-const mockGetApi = vi.mocked(getApi)
 const mockReadStdin = vi.mocked(readStdin)
 
 function createProgram() {
@@ -30,8 +29,7 @@ describe('task quickadd command', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         resetGlobalArgs()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('calls quickAddTask with positional text', async () => {

--- a/src/commands/task/task.test.ts
+++ b/src/commands/task/task.test.ts
@@ -11,13 +11,13 @@ vi.mock('../../lib/browser.js', () => ({
     openInBrowser: vi.fn(),
 }))
 
-import { completeTaskForever, getApi, rescheduleTask } from '../../lib/api/core.js'
+import { completeTaskForever, rescheduleTask } from '../../lib/api/core.js'
 import { openInBrowser } from '../../lib/browser.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerTaskCommand } from './index.js'
 
-const mockGetApi = vi.mocked(getApi)
 const mockCompleteTaskForever = vi.mocked(completeTaskForever)
 const mockRescheduleTask = vi.mocked(rescheduleTask)
 const mockOpenInBrowser = vi.mocked(openInBrowser)
@@ -31,8 +31,7 @@ describe('task move command', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('throws error when no destination flags provided', async () => {
@@ -264,8 +263,7 @@ describe('task view', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('resolves task by name and shows details', async () => {
@@ -365,8 +363,7 @@ describe('task complete', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('marks task as complete', async () => {
@@ -484,8 +481,7 @@ describe('task uncomplete', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('reopens completed task', async () => {
@@ -537,8 +533,7 @@ describe('task delete', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('shows dry-run without --yes', async () => {
@@ -575,8 +570,7 @@ describe('task add', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('creates task with positional content', async () => {
@@ -1018,8 +1012,7 @@ describe('task update', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('updates task content', async () => {
@@ -1159,8 +1152,7 @@ describe('task list --label', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('filters tasks by label', async () => {
@@ -1272,8 +1264,7 @@ describe('task list --parent', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('filters subtasks by parent id', async () => {
@@ -1398,8 +1389,7 @@ describe('task add --assignee', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('creates task with assignee using id:', async () => {
@@ -1457,8 +1447,7 @@ describe('task update --assignee', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('updates task with assignee using id:', async () => {
@@ -1518,8 +1507,7 @@ describe('task add --deadline', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('creates task with deadline', async () => {
@@ -1592,8 +1580,7 @@ describe('task update --deadline', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('updates task with deadline', async () => {
@@ -1644,8 +1631,7 @@ describe('task update --no-due', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('removes due date with --no-due', async () => {
@@ -1673,8 +1659,7 @@ describe('task update --no-labels', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('removes all labels with --no-labels', async () => {
@@ -1727,8 +1712,7 @@ describe('task add/update --uncompletable', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('creates task with isUncompletable=true when --uncompletable flag is passed', async () => {
@@ -1827,8 +1811,7 @@ describe('task add/update --order', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('creates task with order=0 when --order 0 is passed', async () => {
@@ -1991,8 +1974,7 @@ describe('task list --filter', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('uses getTasksByFilter when --filter is provided', async () => {
@@ -2128,8 +2110,7 @@ describe('task browse', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('opens task in browser by name', async () => {
@@ -2169,8 +2150,7 @@ describe('task add with --stdin', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('reads description from stdin with --stdin flag', async () => {
@@ -2250,8 +2230,7 @@ describe('task update with --stdin', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('reads description from stdin with --stdin flag', async () => {
@@ -2350,8 +2329,7 @@ describe('task add --json', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('outputs created task as JSON', async () => {
@@ -2399,8 +2377,7 @@ describe('task update --json', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('outputs updated task as JSON', async () => {
@@ -2444,8 +2421,7 @@ describe('task reschedule', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('reschedules a task with a new date', async () => {
@@ -2595,8 +2571,7 @@ describe('task --dry-run', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
     })
 
     it('task add --dry-run previews without calling API', async () => {

--- a/src/commands/task/task.test.ts
+++ b/src/commands/task/task.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../lib/browser.js', () => ({
 import { completeTaskForever, rescheduleTask } from '../../lib/api/core.js'
 import { openInBrowser } from '../../lib/browser.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerTaskCommand } from './index.js'
@@ -51,7 +52,7 @@ describe('task move command', () => {
 
     it('moves task to project', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'Test task', projectId: 'proj-1' }],
@@ -76,12 +77,11 @@ describe('task move command', () => {
             projectId: 'proj-2',
         })
         expect(consoleSpy).toHaveBeenCalledWith('Moved: Test task')
-        consoleSpy.mockRestore()
     })
 
     it('moves task to section in current project', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'Test task', projectId: 'proj-1' }],
@@ -106,12 +106,11 @@ describe('task move command', () => {
         expect(mockApi.moveTask).toHaveBeenCalledWith('task-1', {
             sectionId: 'sec-1',
         })
-        consoleSpy.mockRestore()
     })
 
     it('moves task to section in specified project', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'Test task', projectId: 'proj-1' }],
@@ -141,12 +140,11 @@ describe('task move command', () => {
         expect(mockApi.moveTask).toHaveBeenCalledWith('task-1', {
             sectionId: 'sec-2',
         })
-        consoleSpy.mockRestore()
     })
 
     it('moves task to parent', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'Child task', projectId: 'proj-1' }],
@@ -174,12 +172,11 @@ describe('task move command', () => {
         expect(mockApi.moveTask).toHaveBeenCalledWith('task-1', {
             parentId: 'task-2',
         })
-        consoleSpy.mockRestore()
     })
 
     it('moves task to project root with --no-parent', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [
@@ -199,12 +196,11 @@ describe('task move command', () => {
         expect(mockApi.moveTask).toHaveBeenCalledWith('task-1', {
             projectId: 'proj-1',
         })
-        consoleSpy.mockRestore()
     })
 
     it('moves task to project root with --no-section', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [
@@ -224,12 +220,11 @@ describe('task move command', () => {
         expect(mockApi.moveTask).toHaveBeenCalledWith('task-1', {
             projectId: 'proj-1',
         })
-        consoleSpy.mockRestore()
     })
 
     it('moves task using id: prefix', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -254,7 +249,6 @@ describe('task move command', () => {
         expect(mockApi.moveTask).toHaveBeenCalledWith('task-1', {
             projectId: 'proj-2',
         })
-        consoleSpy.mockRestore()
     })
 })
 
@@ -268,7 +262,7 @@ describe('task view', () => {
 
     it('resolves task by name and shows details', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [
@@ -292,12 +286,11 @@ describe('task view', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Buy milk'))
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('ID:'))
-        consoleSpy.mockRestore()
     })
 
     it('resolves task by id: prefix', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -312,12 +305,11 @@ describe('task view', () => {
         await program.parseAsync(['node', 'td', 'task', 'view', 'id:task-1'])
 
         expect(mockApi.getTask).toHaveBeenCalledWith('task-1')
-        consoleSpy.mockRestore()
     })
 
     it('implicit view: td task <ref> behaves like td task view <ref>', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -332,12 +324,11 @@ describe('task view', () => {
         await program.parseAsync(['node', 'td', 'task', 'id:task-1'])
 
         expect(mockApi.getTask).toHaveBeenCalledWith('task-1')
-        consoleSpy.mockRestore()
     })
 
     it('shows full metadata with --full flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -354,7 +345,6 @@ describe('task view', () => {
         await program.parseAsync(['node', 'td', 'task', 'view', 'id:task-1', '--full'])
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Metadata'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -368,7 +358,7 @@ describe('task complete', () => {
 
     it('marks task as complete', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -381,12 +371,11 @@ describe('task complete', () => {
 
         expect(mockApi.closeTask).toHaveBeenCalledWith('task-1')
         expect(consoleSpy).toHaveBeenCalledWith('Completed: Buy milk (id:task-1)')
-        consoleSpy.mockRestore()
     })
 
     it('shows message for already completed task', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -398,12 +387,11 @@ describe('task complete', () => {
 
         expect(mockApi.closeTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Task already completed.')
-        consoleSpy.mockRestore()
     })
 
     it('resolves task by name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'Buy milk', checked: false }],
@@ -414,12 +402,11 @@ describe('task complete', () => {
         await program.parseAsync(['node', 'td', 'task', 'complete', 'Buy milk'])
 
         expect(mockApi.closeTask).toHaveBeenCalledWith('task-1')
-        consoleSpy.mockRestore()
     })
 
     it('blocks completion for uncompletable tasks', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -432,12 +419,11 @@ describe('task complete', () => {
 
         expect(mockApi.closeTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Task is uncompletable (reference item).')
-        consoleSpy.mockRestore()
     })
 
     it('completes recurring task forever with --forever flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -452,12 +438,11 @@ describe('task complete', () => {
         expect(mockCompleteTaskForever).toHaveBeenCalledWith('task-1')
         expect(mockApi.closeTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Completed forever: Recurring task (id:task-1)')
-        consoleSpy.mockRestore()
     })
 
     it('warns when --forever used on non-recurring task', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -472,7 +457,6 @@ describe('task complete', () => {
         expect(mockApi.closeTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Task is not recurring, completing normally.')
         expect(consoleSpy).toHaveBeenCalledWith('Completed forever: Normal task (id:task-1)')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -486,7 +470,7 @@ describe('task uncomplete', () => {
 
     it('reopens completed task', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -499,12 +483,11 @@ describe('task uncomplete', () => {
 
         expect(mockApi.reopenTask).toHaveBeenCalledWith('task-1')
         expect(consoleSpy).toHaveBeenCalledWith('Reopened: Buy milk (id:task-1)')
-        consoleSpy.mockRestore()
     })
 
     it('shows message for non-completed task', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -516,7 +499,6 @@ describe('task uncomplete', () => {
 
         expect(mockApi.reopenTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Task is not completed.')
-        consoleSpy.mockRestore()
     })
 
     it('requires id: prefix', async () => {
@@ -538,7 +520,7 @@ describe('task delete', () => {
 
     it('shows dry-run without --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Test task' })
 
@@ -547,12 +529,11 @@ describe('task delete', () => {
         expect(mockApi.deleteTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith('Would delete: Test task')
         expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
-        consoleSpy.mockRestore()
     })
 
     it('deletes task with --yes', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Test task' })
         mockApi.deleteTask.mockResolvedValue(undefined)
@@ -561,7 +542,6 @@ describe('task delete', () => {
 
         expect(mockApi.deleteTask).toHaveBeenCalledWith('task-1')
         expect(consoleSpy).toHaveBeenCalledWith('Deleted: Test task (id:task-1)')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -575,7 +555,7 @@ describe('task add', () => {
 
     it('creates task with positional content', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -589,12 +569,11 @@ describe('task add', () => {
             expect.objectContaining({ content: 'New task' }),
         )
         expect(consoleSpy).toHaveBeenCalledWith('Created: New task')
-        consoleSpy.mockRestore()
     })
 
     it('creates task with --content flag (backward compat)', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -608,7 +587,6 @@ describe('task add', () => {
             expect.objectContaining({ content: 'New task' }),
         )
         expect(consoleSpy).toHaveBeenCalledWith('Created: New task')
-        consoleSpy.mockRestore()
     })
 
     it('errors when both positional and --content are provided', async () => {
@@ -629,7 +607,7 @@ describe('task add', () => {
 
     it('creates task with positional content and --due', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -643,12 +621,11 @@ describe('task add', () => {
             expect.objectContaining({ dueString: 'tomorrow' }),
         )
         expect(consoleSpy).toHaveBeenCalledWith('Due: tomorrow')
-        consoleSpy.mockRestore()
     })
 
     it('creates task with --priority', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -668,12 +645,11 @@ describe('task add', () => {
         ])
 
         expect(mockApi.addTask).toHaveBeenCalledWith(expect.objectContaining({ priority: 4 }))
-        consoleSpy.mockRestore()
     })
 
     it('creates task with --project (resolves name)', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getProjects.mockResolvedValue({
             results: [{ id: 'proj-1', name: 'Work' }],
@@ -699,7 +675,6 @@ describe('task add', () => {
         expect(mockApi.addTask).toHaveBeenCalledWith(
             expect.objectContaining({ projectId: 'proj-1' }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('requires --project when --section is a name', async () => {
@@ -721,7 +696,7 @@ describe('task add', () => {
 
     it('creates task with --section using id: prefix', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -743,12 +718,11 @@ describe('task add', () => {
         expect(mockApi.addTask).toHaveBeenCalledWith(
             expect.objectContaining({ sectionId: 'sec-1' }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('resolves --section by name with digits when --project is provided', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getProjects.mockResolvedValue({
             results: [{ id: 'proj-1', name: 'Work' }],
@@ -780,12 +754,11 @@ describe('task add', () => {
         expect(mockApi.addTask).toHaveBeenCalledWith(
             expect.objectContaining({ sectionId: 'sec-q1' }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('creates task with --labels', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -807,12 +780,11 @@ describe('task add', () => {
         expect(mockApi.addTask).toHaveBeenCalledWith(
             expect.objectContaining({ labels: ['urgent', 'home'] }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('creates task with --description', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -834,12 +806,11 @@ describe('task add', () => {
         expect(mockApi.addTask).toHaveBeenCalledWith(
             expect.objectContaining({ description: 'Some notes' }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('shows task ID after creation', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-xyz',
@@ -850,12 +821,11 @@ describe('task add', () => {
         await program.parseAsync(['node', 'td', 'task', 'add', '--content', 'Task'])
 
         expect(consoleSpy).toHaveBeenCalledWith('ID: task-xyz')
-        consoleSpy.mockRestore()
     })
 
     it('adds task with duration', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-1',
@@ -881,7 +851,6 @@ describe('task add', () => {
                 durationUnit: 'minute',
             }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('throws error for invalid duration format', async () => {
@@ -903,7 +872,7 @@ describe('task add', () => {
 
     it('creates subtask with id:xxx parent format', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'child-1',
@@ -925,12 +894,11 @@ describe('task add', () => {
         expect(mockApi.addTask).toHaveBeenCalledWith(
             expect.objectContaining({ content: 'Child task', parentId: 'parent-1' }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('creates subtask with fuzzy parent name match', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getProjects.mockResolvedValue({
             results: [{ id: 'proj-1', name: 'Work' }],
@@ -962,7 +930,6 @@ describe('task add', () => {
         expect(mockApi.addTask).toHaveBeenCalledWith(
             expect.objectContaining({ content: 'Child task', parentId: 'parent-1' }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('throws error when using fuzzy parent without project', async () => {
@@ -1017,7 +984,7 @@ describe('task update', () => {
 
     it('updates task content', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Old content' })
         mockApi.updateTask.mockResolvedValue({
@@ -1039,12 +1006,11 @@ describe('task update', () => {
             content: 'New content',
         })
         expect(consoleSpy).toHaveBeenCalledWith('Updated: New content (id:task-1)')
-        consoleSpy.mockRestore()
     })
 
     it('updates task due date', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
         mockApi.updateTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
@@ -1062,12 +1028,11 @@ describe('task update', () => {
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', {
             dueString: 'next week',
         })
-        consoleSpy.mockRestore()
     })
 
     it('updates task priority', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
         mockApi.updateTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
@@ -1075,12 +1040,11 @@ describe('task update', () => {
         await program.parseAsync(['node', 'td', 'task', 'update', 'id:task-1', '--priority', 'p2'])
 
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', { priority: 3 })
-        consoleSpy.mockRestore()
     })
 
     it('updates task labels (replaces existing)', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
         mockApi.updateTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
@@ -1098,12 +1062,11 @@ describe('task update', () => {
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', {
             labels: ['work', 'urgent'],
         })
-        consoleSpy.mockRestore()
     })
 
     it('resolves task by name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'Buy milk' }],
@@ -1127,12 +1090,11 @@ describe('task update', () => {
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', {
             content: 'Buy oat milk',
         })
-        consoleSpy.mockRestore()
     })
 
     it('updates task duration', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
         mockApi.updateTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
@@ -1143,7 +1105,6 @@ describe('task update', () => {
             duration: 120,
             durationUnit: 'minute',
         })
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1157,7 +1118,7 @@ describe('task list --label', () => {
 
     it('filters tasks by label', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [
@@ -1189,12 +1150,11 @@ describe('task list --label', () => {
                 query: '@work',
             }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('filters tasks by multiple labels (OR)', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [
@@ -1226,12 +1186,11 @@ describe('task list --label', () => {
                 query: '(@work | @urgent)',
             }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('label filter is case-insensitive', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [
@@ -1255,7 +1214,6 @@ describe('task list --label', () => {
                 query: '@WORK',
             }),
         )
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1269,7 +1227,7 @@ describe('task list --parent', () => {
 
     it('filters subtasks by parent id', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'parent-1',
@@ -1312,12 +1270,11 @@ describe('task list --parent', () => {
                 parentId: 'parent-1',
             }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('resolves parent by name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         // First call: resolveTaskRef uses getTasksByFilter to find parent by name
         mockApi.getTasksByFilter.mockResolvedValueOnce({
@@ -1350,12 +1307,11 @@ describe('task list --parent', () => {
                 parentId: 'parent-1',
             }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('shows no tasks message when parent has no children', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'parent-1',
@@ -1380,7 +1336,6 @@ describe('task list --parent', () => {
                 parentId: 'parent-1',
             }),
         )
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1394,7 +1349,7 @@ describe('task add --assignee', () => {
 
     it('creates task with assignee using id:', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getProjects.mockResolvedValue({
             results: [{ id: 'proj-1', name: 'Work', isShared: true }],
@@ -1421,7 +1376,6 @@ describe('task add --assignee', () => {
         expect(mockApi.addTask).toHaveBeenCalledWith(
             expect.objectContaining({ assigneeId: 'user-123' }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('throws error when --assignee used without --project', async () => {
@@ -1452,7 +1406,7 @@ describe('task update --assignee', () => {
 
     it('updates task with assignee using id:', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -1479,12 +1433,11 @@ describe('task update --assignee', () => {
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', {
             assigneeId: 'user-123',
         })
-        consoleSpy.mockRestore()
     })
 
     it('unassigns task with --unassign flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -1498,7 +1451,6 @@ describe('task update --assignee', () => {
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', {
             assigneeId: null,
         })
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1512,7 +1464,7 @@ describe('task add --deadline', () => {
 
     it('creates task with deadline', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -1536,12 +1488,11 @@ describe('task add --deadline', () => {
             expect.objectContaining({ deadlineDate: '2026-06-15' }),
         )
         expect(consoleSpy).toHaveBeenCalledWith('Deadline: 2026-06-15')
-        consoleSpy.mockRestore()
     })
 
     it('creates task with both due and deadline', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -1571,7 +1522,6 @@ describe('task add --deadline', () => {
         )
         expect(consoleSpy).toHaveBeenCalledWith('Due: Jun 10')
         expect(consoleSpy).toHaveBeenCalledWith('Deadline: 2026-06-15')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1585,7 +1535,7 @@ describe('task update --deadline', () => {
 
     it('updates task with deadline', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
         mockApi.updateTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
@@ -1603,12 +1553,11 @@ describe('task update --deadline', () => {
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', {
             deadlineDate: '2026-12-31',
         })
-        consoleSpy.mockRestore()
     })
 
     it('removes deadline with --no-deadline', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -1622,7 +1571,6 @@ describe('task update --deadline', () => {
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', {
             deadlineDate: null,
         })
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1636,7 +1584,7 @@ describe('task update --no-due', () => {
 
     it('removes due date with --no-due', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -1650,7 +1598,6 @@ describe('task update --no-due', () => {
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', {
             dueString: null,
         })
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1664,7 +1611,7 @@ describe('task update --no-labels', () => {
 
     it('removes all labels with --no-labels', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -1678,12 +1625,11 @@ describe('task update --no-labels', () => {
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', {
             labels: [],
         })
-        consoleSpy.mockRestore()
     })
 
     it('previews --no-labels with --dry-run without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -1703,7 +1649,6 @@ describe('task update --no-labels', () => {
 
         expect(mockApi.updateTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('(remove all)'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1717,7 +1662,7 @@ describe('task add/update --uncompletable', () => {
 
     it('creates task with isUncompletable=true when --uncompletable flag is passed', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -1739,12 +1684,11 @@ describe('task add/update --uncompletable', () => {
         expect(mockApi.addTask).toHaveBeenCalledWith(
             expect.objectContaining({ isUncompletable: true }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('does not set isUncompletable when no flag is passed', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -1758,12 +1702,11 @@ describe('task add/update --uncompletable', () => {
         expect(mockApi.addTask).toHaveBeenCalledWith(
             expect.not.objectContaining({ isUncompletable: expect.anything() }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('updates task with isUncompletable=true when --uncompletable flag is passed', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
         mockApi.updateTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
@@ -1771,12 +1714,11 @@ describe('task add/update --uncompletable', () => {
         await program.parseAsync(['node', 'td', 'task', 'update', 'id:task-1', '--uncompletable'])
 
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', { isUncompletable: true })
-        consoleSpy.mockRestore()
     })
 
     it('updates task with isUncompletable=false when --completable flag is passed', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
         mockApi.updateTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
@@ -1784,7 +1726,6 @@ describe('task add/update --uncompletable', () => {
         await program.parseAsync(['node', 'td', 'task', 'update', 'id:task-1', '--completable'])
 
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', { isUncompletable: false })
-        consoleSpy.mockRestore()
     })
 
     it('throws when both --uncompletable and --completable are passed together', async () => {
@@ -1816,7 +1757,7 @@ describe('task add/update --order', () => {
 
     it('creates task with order=0 when --order 0 is passed', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -1828,12 +1769,11 @@ describe('task add/update --order', () => {
         await program.parseAsync(['node', 'td', 'task', 'add', '--content', 'Task', '--order', '0'])
 
         expect(mockApi.addTask).toHaveBeenCalledWith(expect.objectContaining({ order: 0 }))
-        consoleSpy.mockRestore()
     })
 
     it('creates task with order=5 when --order 5 is passed', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -1845,12 +1785,11 @@ describe('task add/update --order', () => {
         await program.parseAsync(['node', 'td', 'task', 'add', '--content', 'Task', '--order', '5'])
 
         expect(mockApi.addTask).toHaveBeenCalledWith(expect.objectContaining({ order: 5 }))
-        consoleSpy.mockRestore()
     })
 
     it('does not set order when no --order flag is passed', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -1864,7 +1803,6 @@ describe('task add/update --order', () => {
         expect(mockApi.addTask).toHaveBeenCalledWith(
             expect.not.objectContaining({ order: expect.anything() }),
         )
-        consoleSpy.mockRestore()
     })
 
     it('rejects --order -1 with invalid order error', async () => {
@@ -1928,7 +1866,7 @@ describe('task add/update --order', () => {
 
     it('updates task with order=0 when --order 0 is passed', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
         mockApi.updateTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
@@ -1936,12 +1874,11 @@ describe('task add/update --order', () => {
         await program.parseAsync(['node', 'td', 'task', 'update', 'id:task-1', '--order', '0'])
 
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', { order: 0 })
-        consoleSpy.mockRestore()
     })
 
     it('updates task with order=3 when --order 3 is passed', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
         mockApi.updateTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
@@ -1949,12 +1886,11 @@ describe('task add/update --order', () => {
         await program.parseAsync(['node', 'td', 'task', 'update', 'id:task-1', '--order', '3'])
 
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', { order: 3 })
-        consoleSpy.mockRestore()
     })
 
     it('does not set order when no --order flag is passed to update', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
         mockApi.updateTask.mockResolvedValue({ id: 'task-1', content: 'Task' })
@@ -1965,7 +1901,6 @@ describe('task add/update --order', () => {
             'task-1',
             expect.not.objectContaining({ order: expect.anything() }),
         )
-        consoleSpy.mockRestore()
     })
 })
 
@@ -1979,7 +1914,7 @@ describe('task list --filter', () => {
 
     it('uses getTasksByFilter when --filter is provided', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [
@@ -2005,12 +1940,11 @@ describe('task list --filter', () => {
         )
         expect(mockApi.getTasks).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Overdue task'))
-        consoleSpy.mockRestore()
     })
 
     it('does not use getTasksByFilter when --filter is not provided', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTasks.mockResolvedValue({
             results: [
@@ -2033,12 +1967,11 @@ describe('task list --filter', () => {
 
         expect(mockApi.getTasks).toHaveBeenCalled()
         expect(mockApi.getTasksByFilter).not.toHaveBeenCalled()
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --filter and --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [
@@ -2059,12 +1992,11 @@ describe('task list --filter', () => {
         const parsed = JSON.parse(output)
         expect(parsed.results).toBeDefined()
         expect(parsed.results[0].content).toBe('Filtered task')
-        consoleSpy.mockRestore()
     })
 
     it('can combine --filter with other local filters like --priority', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [
@@ -2101,7 +2033,6 @@ describe('task list --filter', () => {
                 query: '(@work) & (p1)',
             }),
         )
-        consoleSpy.mockRestore()
     })
 })
 
@@ -2115,7 +2046,7 @@ describe('task browse', () => {
 
     it('opens task in browser by name', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'Buy milk', projectId: 'proj-1' }],
@@ -2125,12 +2056,11 @@ describe('task browse', () => {
         await program.parseAsync(['node', 'td', 'task', 'browse', 'Buy milk'])
 
         expect(mockOpenInBrowser).toHaveBeenCalledWith('https://app.todoist.com/app/task/task-1')
-        consoleSpy.mockRestore()
     })
 
     it('opens task in browser by id:', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-123',
@@ -2141,7 +2071,6 @@ describe('task browse', () => {
         await program.parseAsync(['node', 'td', 'task', 'browse', 'id:task-123'])
 
         expect(mockOpenInBrowser).toHaveBeenCalledWith('https://app.todoist.com/app/task/task-123')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -2155,10 +2084,10 @@ describe('task add with --stdin', () => {
 
     it('reads description from stdin with --stdin flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         const mockStdin = new PassThrough()
-        const stdinSpy = vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as any)
+        vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as any)
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -2175,8 +2104,6 @@ describe('task add with --stdin', () => {
         expect(mockApi.addTask).toHaveBeenCalledWith(
             expect.objectContaining({ description: 'Description from stdin' }),
         )
-        consoleSpy.mockRestore()
-        stdinSpy.mockRestore()
     })
 
     it('errors when both --description and --stdin are provided', async () => {
@@ -2198,10 +2125,10 @@ describe('task add with --stdin', () => {
 
     it('works with multiline description from stdin', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         const mockStdin = new PassThrough()
-        const stdinSpy = vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as any)
+        vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as any)
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -2220,8 +2147,6 @@ describe('task add with --stdin', () => {
         expect(mockApi.addTask).toHaveBeenCalledWith(
             expect.objectContaining({ description: 'line1\nline2\nline3' }),
         )
-        consoleSpy.mockRestore()
-        stdinSpy.mockRestore()
     })
 })
 
@@ -2235,10 +2160,10 @@ describe('task update with --stdin', () => {
 
     it('reads description from stdin with --stdin flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         const mockStdin = new PassThrough()
-        const stdinSpy = vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as any)
+        vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as any)
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'My task', projectId: 'proj-1' }],
@@ -2262,8 +2187,6 @@ describe('task update with --stdin', () => {
             'task-1',
             expect.objectContaining({ description: 'Updated description' }),
         )
-        consoleSpy.mockRestore()
-        stdinSpy.mockRestore()
     })
 
     it('errors when both --description and --stdin are provided', async () => {
@@ -2290,10 +2213,10 @@ describe('task update with --stdin', () => {
 
     it('works with multiline description from stdin', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         const mockStdin = new PassThrough()
-        const stdinSpy = vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as any)
+        vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as any)
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'My task', projectId: 'proj-1' }],
@@ -2319,8 +2242,6 @@ describe('task update with --stdin', () => {
             'task-1',
             expect.objectContaining({ description: 'line1\nline2\nline3' }),
         )
-        consoleSpy.mockRestore()
-        stdinSpy.mockRestore()
     })
 })
 
@@ -2334,7 +2255,7 @@ describe('task add --json', () => {
 
     it('outputs created task as JSON', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -2350,12 +2271,11 @@ describe('task add --json', () => {
         const parsed = JSON.parse(output)
         expect(parsed.id).toBe('task-new')
         expect(parsed.content).toBe('Buy milk')
-        consoleSpy.mockRestore()
     })
 
     it('does not print plain-text confirmation with --json', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.addTask.mockResolvedValue({
             id: 'task-new',
@@ -2368,7 +2288,6 @@ describe('task add --json', () => {
         await program.parseAsync(['node', 'td', 'task', 'add', 'Buy milk', '--json'])
 
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Created:'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -2382,7 +2301,7 @@ describe('task update --json', () => {
 
     it('outputs updated task as JSON', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTask.mockResolvedValue({
             id: 'task-1',
@@ -2412,7 +2331,6 @@ describe('task update --json', () => {
         const parsed = JSON.parse(output)
         expect(parsed.id).toBe('task-1')
         expect(parsed.content).toBe('New content')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -2426,7 +2344,7 @@ describe('task reschedule', () => {
 
     it('reschedules a task with a new date', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         const due = { date: '2026-03-15', string: 'Mar 15', isRecurring: false }
         mockApi.getTask
@@ -2442,12 +2360,11 @@ describe('task reschedule', () => {
         expect(mockRescheduleTask).toHaveBeenCalledWith('task-1', '2026-03-20', due)
         expect(consoleSpy).toHaveBeenCalledWith('Rescheduled: My task (id:task-1)')
         expect(consoleSpy).toHaveBeenCalledWith('Due: Mar 20')
-        consoleSpy.mockRestore()
     })
 
     it('reschedules a recurring task and shows recurrence info', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         const due = {
             date: '2026-03-15',
@@ -2467,12 +2384,11 @@ describe('task reschedule', () => {
 
         expect(mockRescheduleTask).toHaveBeenCalledWith('task-1', '2026-03-20', due)
         expect(consoleSpy).toHaveBeenCalledWith('Due: Mar 20 (every 3 days)')
-        consoleSpy.mockRestore()
     })
 
     it('reschedules with a datetime', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         const due = {
             date: '2026-03-15',
@@ -2503,12 +2419,11 @@ describe('task reschedule', () => {
         ])
 
         expect(mockRescheduleTask).toHaveBeenCalledWith('task-1', '2026-03-20T10:00:00', due)
-        consoleSpy.mockRestore()
     })
 
     it('errors when task has no due date', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         mockApi.getTask.mockResolvedValueOnce({ id: 'task-1', content: 'No due', due: null })
 
@@ -2517,12 +2432,11 @@ describe('task reschedule', () => {
         ).rejects.toHaveProperty('code', 'NO_DUE_DATE')
 
         expect(mockRescheduleTask).not.toHaveBeenCalled()
-        consoleSpy.mockRestore()
     })
 
     it('errors on invalid date format', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockConsoleLog()
 
         const due = { date: '2026-03-15', string: 'Mar 15', isRecurring: false }
         mockApi.getTask.mockResolvedValueOnce({ id: 'task-1', content: 'Task', due })
@@ -2532,12 +2446,11 @@ describe('task reschedule', () => {
         ).rejects.toHaveProperty('code', 'INVALID_DATE')
 
         expect(mockRescheduleTask).not.toHaveBeenCalled()
-        consoleSpy.mockRestore()
     })
 
     it('outputs JSON with --json flag', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         const due = { date: '2026-03-15', string: 'Mar 15', isRecurring: false }
         const updatedTask = {
@@ -2562,7 +2475,6 @@ describe('task reschedule', () => {
         const output = consoleSpy.mock.calls[0][0]
         const parsed = JSON.parse(output)
         expect(parsed.id).toBe('task-1')
-        consoleSpy.mockRestore()
     })
 })
 
@@ -2576,7 +2488,7 @@ describe('task --dry-run', () => {
 
     it('task add --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         await program.parseAsync([
             'node',
@@ -2591,12 +2503,11 @@ describe('task --dry-run', () => {
 
         expect(mockApi.addTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would add task'))
-        consoleSpy.mockRestore()
     })
 
     it('task update --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'Old content', projectId: 'proj-1' }],
@@ -2616,12 +2527,11 @@ describe('task --dry-run', () => {
 
         expect(mockApi.updateTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would update task'))
-        consoleSpy.mockRestore()
     })
 
     it('task complete --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'Test task', checked: false }],
@@ -2632,12 +2542,11 @@ describe('task --dry-run', () => {
 
         expect(mockApi.closeTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would complete task'))
-        consoleSpy.mockRestore()
     })
 
     it('task delete --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'Test task' }],
@@ -2648,12 +2557,11 @@ describe('task --dry-run', () => {
 
         expect(mockApi.deleteTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would delete task'))
-        consoleSpy.mockRestore()
     })
 
     it('task delete --dry-run --yes still does not execute', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'Test task' }],
@@ -2672,12 +2580,11 @@ describe('task --dry-run', () => {
 
         expect(mockApi.deleteTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would delete task'))
-        consoleSpy.mockRestore()
     })
 
     it('task move --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         mockApi.getTasksByFilter.mockResolvedValue({
             results: [{ id: 'task-1', content: 'Test task', projectId: 'proj-1' }],
@@ -2697,12 +2604,11 @@ describe('task --dry-run', () => {
 
         expect(mockApi.moveTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would move task'))
-        consoleSpy.mockRestore()
     })
 
     it('task reschedule --dry-run previews without calling API', async () => {
         const program = createProgram()
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = mockConsoleLog()
 
         const due = { date: '2026-03-15', string: 'Mar 15', isRecurring: false }
         mockApi.getTask.mockResolvedValueOnce({ id: 'task-1', content: 'Task', due })
@@ -2719,7 +2625,6 @@ describe('task --dry-run', () => {
 
         expect(mockRescheduleTask).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would reschedule task'))
-        consoleSpy.mockRestore()
     })
 })
 
@@ -2737,7 +2642,6 @@ describe('task (no args)', () => {
         const output = stdoutSpy.mock.calls.map((c) => c[0]).join('')
         expect(output).toContain('Examples:')
         expect(output).toContain('td task add "Buy milk" --due tomorrow')
-        stdoutSpy.mockRestore()
     })
 })
 

--- a/src/commands/task/task.test.ts
+++ b/src/commands/task/task.test.ts
@@ -1,5 +1,4 @@
 import { PassThrough } from 'node:stream'
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
@@ -15,6 +14,7 @@ vi.mock('../../lib/browser.js', () => ({
 import { completeTaskForever, getApi, rescheduleTask } from '../../lib/api/core.js'
 import { openInBrowser } from '../../lib/browser.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerTaskCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
@@ -23,10 +23,7 @@ const mockRescheduleTask = vi.mocked(rescheduleTask)
 const mockOpenInBrowser = vi.mocked(openInBrowser)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerTaskCommand(program)
-    return program
+    return createTestProgram(registerTaskCommand)
 }
 
 describe('task move command', () => {

--- a/src/commands/task/task.test.ts
+++ b/src/commands/task/task.test.ts
@@ -14,7 +14,7 @@ vi.mock('../../lib/browser.js', () => ({
 import { completeTaskForever, rescheduleTask } from '../../lib/api/core.js'
 import { openInBrowser } from '../../lib/browser.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
-import { mockConsoleLog } from '../../test-support/console-spy.js'
+import { mockConsoleLog, mockProcessStdout } from '../../test-support/console-spy.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerTaskCommand } from './index.js'
@@ -2631,7 +2631,7 @@ describe('task --dry-run', () => {
 describe('task (no args)', () => {
     it('shows parent help with examples', async () => {
         const program = createProgram()
-        const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+        const stdoutSpy = mockProcessStdout()
 
         try {
             await program.parseAsync(['node', 'td', 'task'])
@@ -2648,7 +2648,7 @@ describe('task (no args)', () => {
 describe('task add/update --due help text', () => {
     async function captureHelp(args: string[]): Promise<string> {
         const program = createProgram()
-        const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+        const stdoutSpy = mockProcessStdout()
 
         await expect(program.parseAsync(['node', 'td', ...args])).rejects.toThrow()
 

--- a/src/commands/template/template.test.ts
+++ b/src/commands/template/template.test.ts
@@ -21,7 +21,7 @@ vi.mock('../../lib/refs.js', async (importOriginal) => {
 import { getApi } from '../../lib/api/core.js'
 import { resolveProjectRef, resolveWorkspaceRef } from '../../lib/refs.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
-import { mockConsoleLog } from '../../test-support/console-spy.js'
+import { mockConsoleLog, mockProcessStdout } from '../../test-support/console-spy.js'
 import { fixtures } from '../../test-support/fixtures.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
@@ -50,7 +50,7 @@ describe('template', () => {
         it('exports template as CSV to stdout', async () => {
             const program = createProgram()
             mockApi.exportTemplateAsFile.mockResolvedValue('task,priority\nBuy milk,4')
-            const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+            const stdoutSpy = mockProcessStdout()
 
             await program.parseAsync(['node', 'td', 'template', 'export-file', 'Work'])
 
@@ -87,7 +87,7 @@ describe('template', () => {
         it('passes --relative-dates flag', async () => {
             const program = createProgram()
             mockApi.exportTemplateAsFile.mockResolvedValue('content')
-            vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+            mockProcessStdout()
 
             await program.parseAsync([
                 'node',
@@ -118,7 +118,7 @@ describe('template', () => {
         it('accepts --project flag', async () => {
             const program = createProgram()
             mockApi.exportTemplateAsFile.mockResolvedValue('content')
-            vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+            mockProcessStdout()
 
             await program.parseAsync(['node', 'td', 'template', 'export-file', '--project', 'Work'])
 

--- a/src/commands/template/template.test.ts
+++ b/src/commands/template/template.test.ts
@@ -20,8 +20,9 @@ vi.mock('../../lib/refs.js', async (importOriginal) => {
 
 import { getApi } from '../../lib/api/core.js'
 import { resolveProjectRef, resolveWorkspaceRef } from '../../lib/refs.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
 import { fixtures } from '../../test-support/fixtures.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerTemplateCommand } from './index.js'
 
@@ -39,8 +40,7 @@ describe('template', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
         mockResolveProjectRef.mockResolvedValue(fixtures.projects.work)
     })

--- a/src/commands/template/template.test.ts
+++ b/src/commands/template/template.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import { open } from 'node:fs/promises'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('node:fs')
 vi.mock('node:fs/promises', () => ({
@@ -21,6 +21,7 @@ vi.mock('../../lib/refs.js', async (importOriginal) => {
 import { getApi } from '../../lib/api/core.js'
 import { resolveProjectRef, resolveWorkspaceRef } from '../../lib/refs.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { fixtures } from '../../test-support/fixtures.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
@@ -41,12 +42,8 @@ describe('template', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        consoleSpy = mockConsoleLog()
         mockResolveProjectRef.mockResolvedValue(fixtures.projects.work)
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
     })
 
     describe('export-file', () => {
@@ -63,7 +60,6 @@ describe('template', () => {
                 useRelativeDates: undefined,
             })
             expect(stdoutSpy).toHaveBeenCalledWith('task,priority\nBuy milk,4')
-            stdoutSpy.mockRestore()
         })
 
         it('writes template to file with --output', async () => {
@@ -91,7 +87,7 @@ describe('template', () => {
         it('passes --relative-dates flag', async () => {
             const program = createProgram()
             mockApi.exportTemplateAsFile.mockResolvedValue('content')
-            const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+            vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
 
             await program.parseAsync([
                 'node',
@@ -106,7 +102,6 @@ describe('template', () => {
                 projectId: fixtures.projects.work.id,
                 useRelativeDates: true,
             })
-            stdoutSpy.mockRestore()
         })
 
         it('outputs JSON with --json', async () => {
@@ -123,12 +118,11 @@ describe('template', () => {
         it('accepts --project flag', async () => {
             const program = createProgram()
             mockApi.exportTemplateAsFile.mockResolvedValue('content')
-            const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+            vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
 
             await program.parseAsync(['node', 'td', 'template', 'export-file', '--project', 'Work'])
 
             expect(mockResolveProjectRef).toHaveBeenCalledWith(mockApi, 'Work')
-            stdoutSpy.mockRestore()
         })
     })
 

--- a/src/commands/template/template.test.ts
+++ b/src/commands/template/template.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs'
 import { open } from 'node:fs/promises'
-import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('node:fs')
@@ -23,6 +22,7 @@ import { getApi } from '../../lib/api/core.js'
 import { resolveProjectRef, resolveWorkspaceRef } from '../../lib/refs.js'
 import { fixtures } from '../../test-support/fixtures.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerTemplateCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
@@ -30,10 +30,7 @@ const mockResolveProjectRef = vi.mocked(resolveProjectRef)
 const mockResolveWorkspaceRef = vi.mocked(resolveWorkspaceRef)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerTemplateCommand(program)
-    return program
+    return createTestProgram(registerTemplateCommand)
 }
 
 describe('template', () => {

--- a/src/commands/today.test.ts
+++ b/src/commands/today.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/api/core.js', () => ({
@@ -19,6 +18,7 @@ import { getApi } from '../lib/api/core.js'
 import { fetchWorkspaces, type Workspace } from '../lib/api/workspaces.js'
 import { preloadMarkdown } from '../lib/markdown.js'
 import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { createTestProgram } from '../test-support/program.js'
 import { registerTodayCommand } from './today.js'
 
 const mockGetApi = vi.mocked(getApi)
@@ -26,10 +26,7 @@ const mockPreloadMarkdown = vi.mocked(preloadMarkdown)
 const mockFetchWorkspaces = vi.mocked(fetchWorkspaces)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerTodayCommand(program)
-    return program
+    return createTestProgram(registerTodayCommand)
 }
 
 function getToday(): string {

--- a/src/commands/today.test.ts
+++ b/src/commands/today.test.ts
@@ -14,14 +14,13 @@ vi.mock('../lib/markdown.js', () => ({
     renderMarkdown: vi.fn((text: string) => Promise.resolve(text)),
 }))
 
-import { getApi } from '../lib/api/core.js'
 import { fetchWorkspaces, type Workspace } from '../lib/api/workspaces.js'
 import { preloadMarkdown } from '../lib/markdown.js'
-import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { setupApiMock } from '../test-support/api-mock.js'
+import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerTodayCommand } from './today.js'
 
-const mockGetApi = vi.mocked(getApi)
 const mockPreloadMarkdown = vi.mocked(preloadMarkdown)
 const mockFetchWorkspaces = vi.mocked(fetchWorkspaces)
 
@@ -46,8 +45,7 @@ describe('today command', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 

--- a/src/commands/today.test.ts
+++ b/src/commands/today.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/api/core.js', () => ({
     getApi: vi.fn(),
@@ -17,6 +17,7 @@ vi.mock('../lib/markdown.js', () => ({
 import { fetchWorkspaces, type Workspace } from '../lib/api/workspaces.js'
 import { preloadMarkdown } from '../lib/markdown.js'
 import { setupApiMock } from '../test-support/api-mock.js'
+import { mockConsoleLog } from '../test-support/console-spy.js'
 import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerTodayCommand } from './today.js'
@@ -46,11 +47,7 @@ describe('today command', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('shows overdue tasks in Overdue section', async () => {

--- a/src/commands/upcoming.test.ts
+++ b/src/commands/upcoming.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/api/core.js', () => ({
@@ -8,15 +7,13 @@ vi.mock('../lib/api/core.js', () => ({
 
 import { getApi } from '../lib/api/core.js'
 import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { createTestProgram } from '../test-support/program.js'
 import { registerUpcomingCommand } from './upcoming.js'
 
 const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerUpcomingCommand(program)
-    return program
+    return createTestProgram(registerUpcomingCommand)
 }
 
 function getDateOffset(days: number): string {

--- a/src/commands/upcoming.test.ts
+++ b/src/commands/upcoming.test.ts
@@ -5,12 +5,10 @@ vi.mock('../lib/api/core.js', () => ({
     getCurrentUserId: vi.fn().mockResolvedValue('current-user-123'),
 }))
 
-import { getApi } from '../lib/api/core.js'
-import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { setupApiMock } from '../test-support/api-mock.js'
+import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerUpcomingCommand } from './upcoming.js'
-
-const mockGetApi = vi.mocked(getApi)
 
 function createProgram() {
     return createTestProgram(registerUpcomingCommand)
@@ -28,8 +26,7 @@ describe('upcoming command', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 

--- a/src/commands/upcoming.test.ts
+++ b/src/commands/upcoming.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/api/core.js', () => ({
     getApi: vi.fn(),
@@ -6,6 +6,7 @@ vi.mock('../lib/api/core.js', () => ({
 }))
 
 import { setupApiMock } from '../test-support/api-mock.js'
+import { mockConsoleError, mockConsoleLog } from '../test-support/console-spy.js'
 import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerUpcomingCommand } from './upcoming.js'
@@ -27,11 +28,7 @@ describe('upcoming command', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('defaults to 7 days', async () => {
@@ -262,12 +259,11 @@ describe('upcoming command', () => {
 
     it('rejects invalid days argument', async () => {
         const program = createProgram()
-        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        const errorSpy = mockConsoleError()
 
         await program.parseAsync(['node', 'td', 'upcoming', 'invalid'])
 
         expect(errorSpy).toHaveBeenCalledWith('Days must be a positive number')
-        errorSpy.mockRestore()
     })
 
     it('uses server-side assignee scoping by default', async () => {

--- a/src/commands/user/user.test.ts
+++ b/src/commands/user/user.test.ts
@@ -1,5 +1,5 @@
 import { describeEmptyMachineOutput } from '@doist/cli-core/testing'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/auth.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../../lib/auth.js')>()
@@ -33,6 +33,7 @@ vi.mock('../../lib/auth-store.js', async (importOriginal) => {
 vi.mock('chalk')
 
 import { listStoredUsers, readConfig, resolveActiveUser } from '../../lib/auth.js'
+import { mockConsoleError, mockConsoleLog } from '../../test-support/console-spy.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerUserCommand } from './index.js'
 
@@ -46,18 +47,12 @@ function createProgram() {
 
 describe('user command', () => {
     let consoleSpy: ReturnType<typeof vi.spyOn>
-    let errorSpy: ReturnType<typeof vi.spyOn>
 
     beforeEach(() => {
         vi.clearAllMocks()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-        errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        consoleSpy = mockConsoleLog()
+        mockConsoleError()
         mockReadConfig.mockResolvedValue({})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
-        errorSpy.mockRestore()
     })
 
     describe('list', () => {

--- a/src/commands/user/user.test.ts
+++ b/src/commands/user/user.test.ts
@@ -1,5 +1,4 @@
 import { describeEmptyMachineOutput } from '@doist/cli-core/testing'
-import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/auth.js', async (importOriginal) => {
@@ -34,6 +33,7 @@ vi.mock('../../lib/auth-store.js', async (importOriginal) => {
 vi.mock('chalk')
 
 import { listStoredUsers, readConfig, resolveActiveUser } from '../../lib/auth.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerUserCommand } from './index.js'
 
 const mockListStoredUsers = vi.mocked(listStoredUsers)
@@ -41,10 +41,7 @@ const mockReadConfig = vi.mocked(readConfig)
 const mockResolveActiveUser = vi.mocked(resolveActiveUser)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerUserCommand(program)
-    return program
+    return createTestProgram(registerUserCommand)
 }
 
 describe('user command', () => {

--- a/src/commands/view.test.ts
+++ b/src/commands/view.test.ts
@@ -21,14 +21,13 @@ vi.mock('../lib/browser.js', () => ({
     openInBrowser: vi.fn(),
 }))
 
-import { getApi } from '../lib/api/core.js'
 import { fetchFilters } from '../lib/api/filters.js'
+import { setupApiMock } from '../test-support/api-mock.js'
 import { makeFilter } from '../test-support/fixtures.js'
-import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
 import { registerViewCommand } from './view.js'
 
-const mockGetApi = vi.mocked(getApi)
 const mockFetchFilters = vi.mocked(fetchFilters)
 
 function createProgram() {
@@ -41,8 +40,7 @@ describe('view command', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 

--- a/src/commands/view.test.ts
+++ b/src/commands/view.test.ts
@@ -23,7 +23,7 @@ vi.mock('../lib/browser.js', () => ({
 
 import { fetchFilters } from '../lib/api/filters.js'
 import { setupApiMock } from '../test-support/api-mock.js'
-import { mockConsoleLog } from '../test-support/console-spy.js'
+import { mockConsoleLog, mockProcessStdout } from '../test-support/console-spy.js'
 import { makeFilter } from '../test-support/fixtures.js'
 import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
@@ -314,7 +314,7 @@ describe('view command', () => {
 
     it('shows route mapping and passthrough examples in view help', async () => {
         const program = createProgram()
-        const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+        const stdoutSpy = mockProcessStdout()
 
         await expect(program.parseAsync(['node', 'td', 'view', '--help'])).rejects.toThrow()
         const help = stdoutSpy.mock.calls.map((call) => String(call[0])).join('')

--- a/src/commands/view.test.ts
+++ b/src/commands/view.test.ts
@@ -23,6 +23,7 @@ vi.mock('../lib/browser.js', () => ({
 
 import { fetchFilters } from '../lib/api/filters.js'
 import { setupApiMock } from '../test-support/api-mock.js'
+import { mockConsoleLog } from '../test-support/console-spy.js'
 import { makeFilter } from '../test-support/fixtures.js'
 import { type MockApi } from '../test-support/mock-api.js'
 import { createTestProgram } from '../test-support/program.js'
@@ -41,7 +42,7 @@ describe('view command', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        consoleSpy = mockConsoleLog()
     })
 
     it('routes task URL to task view', async () => {

--- a/src/commands/view.test.ts
+++ b/src/commands/view.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/api/core.js', async (importOriginal) => {
@@ -26,16 +25,14 @@ import { getApi } from '../lib/api/core.js'
 import { fetchFilters } from '../lib/api/filters.js'
 import { makeFilter } from '../test-support/fixtures.js'
 import { createMockApi, type MockApi } from '../test-support/mock-api.js'
+import { createTestProgram } from '../test-support/program.js'
 import { registerViewCommand } from './view.js'
 
 const mockGetApi = vi.mocked(getApi)
 const mockFetchFilters = vi.mocked(fetchFilters)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerViewCommand(program)
-    return program
+    return createTestProgram(registerViewCommand)
 }
 
 describe('view command', () => {

--- a/src/commands/workspace/workspace.test.ts
+++ b/src/commands/workspace/workspace.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
     getApi: vi.fn(),
@@ -18,6 +18,7 @@ vi.mock('../../lib/config.js', () => ({
 import { fetchWorkspaceFolders, fetchWorkspaces } from '../../lib/api/workspaces.js'
 import { readConfig, writeConfig } from '../../lib/config.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
+import { mockConsoleLog } from '../../test-support/console-spy.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerWorkspaceCommand } from './index.js'
@@ -62,11 +63,7 @@ describe('workspace list', () => {
         setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
         mockFetchWorkspaceFolders.mockResolvedValue([])
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('lists all workspaces', async () => {
@@ -138,11 +135,7 @@ describe('workspace view', () => {
         setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
         mockFetchWorkspaceFolders.mockResolvedValue([])
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('resolves workspace by name', async () => {
@@ -246,11 +239,7 @@ describe('workspace projects', () => {
             { id: 'folder-1', name: 'Engineering', workspaceId: 'ws-1' },
             { id: 'folder-2', name: 'Marketing', workspaceId: 'ws-1' },
         ])
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('lists projects grouped by folder', async () => {
@@ -444,11 +433,7 @@ describe('workspace users', () => {
         mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
         mockFetchWorkspaceFolders.mockResolvedValue([])
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('lists workspace users', async () => {
@@ -657,11 +642,7 @@ describe('workspace insights', () => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces as never)
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('shows insights for workspace projects', async () => {
@@ -779,11 +760,7 @@ describe('workspace create', () => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('creates a workspace with --name', async () => {
@@ -892,11 +869,7 @@ describe('workspace update', () => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('updates an admin-owned workspace', async () => {
@@ -1012,11 +985,7 @@ describe('workspace delete', () => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('throws NOT_ADMIN on non-admin workspace (even on --dry-run)', async () => {
@@ -1075,11 +1044,7 @@ describe('workspace user-tasks', () => {
             ],
             hasMore: false,
         })
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('resolves user by email and calls API', async () => {
@@ -1198,11 +1163,7 @@ describe('workspace activity', () => {
         vi.clearAllMocks()
         mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('calls API with workspace id and passes through filters', async () => {
@@ -1254,11 +1215,7 @@ describe('workspace use (default workspace)', () => {
         mockFetchWorkspaceFolders.mockResolvedValue([])
         mockReadConfig.mockResolvedValue({})
         mockWriteConfig.mockResolvedValue(undefined)
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-        consoleSpy.mockRestore()
+        consoleSpy = mockConsoleLog()
     })
 
     it('stores the resolved workspace id under workspace.defaultWorkspace', async () => {

--- a/src/commands/workspace/workspace.test.ts
+++ b/src/commands/workspace/workspace.test.ts
@@ -15,14 +15,13 @@ vi.mock('../../lib/config.js', () => ({
     writeConfig: vi.fn().mockResolvedValue(undefined),
 }))
 
-import { getApi } from '../../lib/api/core.js'
 import { fetchWorkspaceFolders, fetchWorkspaces } from '../../lib/api/workspaces.js'
 import { readConfig, writeConfig } from '../../lib/config.js'
-import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { setupApiMock } from '../../test-support/api-mock.js'
+import { type MockApi } from '../../test-support/mock-api.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerWorkspaceCommand } from './index.js'
 
-const mockGetApi = vi.mocked(getApi)
 const mockFetchWorkspaces = vi.mocked(fetchWorkspaces)
 const mockFetchWorkspaceFolders = vi.mocked(fetchWorkspaceFolders)
 const mockReadConfig = vi.mocked(readConfig)
@@ -56,13 +55,11 @@ const mockWorkspaces = [
 ]
 
 describe('workspace list', () => {
-    let mockApi: MockApi
     let consoleSpy: ReturnType<typeof vi.spyOn>
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
         mockFetchWorkspaceFolders.mockResolvedValue([])
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
@@ -134,13 +131,11 @@ describe('workspace list', () => {
 })
 
 describe('workspace view', () => {
-    let mockApi: MockApi
     let consoleSpy: ReturnType<typeof vi.spyOn>
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
         mockFetchWorkspaceFolders.mockResolvedValue([])
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
@@ -245,8 +240,7 @@ describe('workspace projects', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
         mockFetchWorkspaceFolders.mockResolvedValue([
             { id: 'folder-1', name: 'Engineering', workspaceId: 'ws-1' },
@@ -447,8 +441,7 @@ describe('workspace users', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
         mockFetchWorkspaceFolders.mockResolvedValue([])
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
@@ -662,8 +655,7 @@ describe('workspace insights', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces as never)
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
@@ -785,8 +777,7 @@ describe('workspace create', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
@@ -899,8 +890,7 @@ describe('workspace update', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
@@ -1020,8 +1010,7 @@ describe('workspace delete', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
@@ -1069,8 +1058,7 @@ describe('workspace user-tasks', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
         mockApi.getWorkspaceUsers.mockResolvedValue({
             workspaceUsers: [
@@ -1208,8 +1196,7 @@ describe('workspace activity', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     })
@@ -1262,8 +1249,7 @@ describe('workspace use (default workspace)', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = createMockApi()
-        mockGetApi.mockResolvedValue(mockApi)
+        mockApi = setupApiMock()
         mockFetchWorkspaces.mockResolvedValue(mockWorkspaces)
         mockFetchWorkspaceFolders.mockResolvedValue([])
         mockReadConfig.mockResolvedValue({})

--- a/src/commands/workspace/workspace.test.ts
+++ b/src/commands/workspace/workspace.test.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
@@ -20,6 +19,7 @@ import { getApi } from '../../lib/api/core.js'
 import { fetchWorkspaceFolders, fetchWorkspaces } from '../../lib/api/workspaces.js'
 import { readConfig, writeConfig } from '../../lib/config.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
+import { createTestProgram } from '../../test-support/program.js'
 import { registerWorkspaceCommand } from './index.js'
 
 const mockGetApi = vi.mocked(getApi)
@@ -29,10 +29,7 @@ const mockReadConfig = vi.mocked(readConfig)
 const mockWriteConfig = vi.mocked(writeConfig)
 
 function createProgram() {
-    const program = new Command()
-    program.exitOverride()
-    registerWorkspaceCommand(program)
-    return program
+    return createTestProgram(registerWorkspaceCommand)
 }
 
 const mockWorkspaces = [

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mockConsoleError } from '../test-support/console-spy.js'
 
 const TEST_HOME = '/tmp/todoist-cli-tests'
 const TEST_CONFIG_PATH = `${TEST_HOME}/.config/todoist-cli/config.json`
@@ -143,7 +144,7 @@ describe('lib/auth', () => {
             }
         })
 
-        errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        errorSpy = mockConsoleError()
     })
 
     afterEach(() => {

--- a/src/lib/migrate-auth.test.ts
+++ b/src/lib/migrate-auth.test.ts
@@ -7,7 +7,7 @@ import type { MigrateAuthResult, MigrateLegacyAuthOptions } from '@doist/cli-cor
  * plaintext loader, the `/api/v1/user` identifier callback, and the
  * legacy-config cleanup hook.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TodoistAccount } from './auth-store.js'
 
 const TEST_HOME = '/tmp/todoist-cli-tests-migrate'
@@ -75,10 +75,6 @@ describe('migrateLegacyAuth (todoist-cli wrapper)', () => {
                 ),
             }
         })
-    })
-
-    afterEach(() => {
-        vi.restoreAllMocks()
     })
 
     function setConfig(config: unknown): void {

--- a/src/lib/progress.test.ts
+++ b/src/lib/progress.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mockConsoleError } from '../test-support/console-spy.js'
 import { resetGlobalArgs } from './global-args.js'
 import type { ProgressEvent } from './progress.js'
 import { getProgressTracker, ProgressTracker, resetProgressTracker } from './progress.js'
@@ -115,7 +116,7 @@ describe('ProgressTracker', () => {
                 throw new Error('Permission denied')
             })
 
-            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+            const consoleSpy = mockConsoleError()
 
             const tracker = new ProgressTracker()
             tracker.emit({ type: 'start', command: 'today' })
@@ -124,8 +125,6 @@ describe('ProgressTracker', () => {
                 expect.stringContaining('Warning: Could not create progress file'),
             )
             expect(mockStderr.write).toHaveBeenCalled()
-
-            consoleSpy.mockRestore()
         })
     })
 

--- a/src/lib/task-list.test.ts
+++ b/src/lib/task-list.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mockConsoleLog } from '../test-support/console-spy.js'
 import { createMockApi, type MockApi } from '../test-support/mock-api.js'
 import { PRIORITY_CHOICES, parsePriority } from './task-list.js'
 
@@ -70,7 +71,7 @@ describe('listTasksForProject', () => {
 
     beforeEach(async () => {
         vi.resetModules()
-        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        consoleSpy = mockConsoleLog()
 
         mockApi = createMockApi()
 
@@ -81,7 +82,6 @@ describe('listTasksForProject', () => {
 
     afterEach(() => {
         vi.clearAllMocks()
-        consoleSpy.mockRestore()
     })
 
     it('fetches tasks for specified projectId', async () => {

--- a/src/lib/user-records.test.ts
+++ b/src/lib/user-records.test.ts
@@ -5,7 +5,7 @@
  * adapter, so the REPLACE-not-merge contract, the legacy-fields strip, and
  * the default-pointer cleanup on remove all need direct coverage.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const TEST_HOME = '/tmp/todoist-cli-user-records-tests'
 const TEST_CONFIG_PATH = `${TEST_HOME}/.config/todoist-cli/config.json`
@@ -43,10 +43,6 @@ describe('createTodoistUserRecordStore', () => {
             const actual = await importOriginal<typeof import('@doist/cli-core')>()
             return { ...actual, getConfigPath: () => TEST_CONFIG_PATH }
         })
-    })
-
-    afterEach(() => {
-        vi.restoreAllMocks()
     })
 
     function setConfig(config: unknown): void {

--- a/src/test-support/api-mock.ts
+++ b/src/test-support/api-mock.ts
@@ -1,0 +1,9 @@
+import { vi } from 'vitest'
+import { getApi } from '../lib/api/core.js'
+import { createMockApi, type MockApi } from './mock-api.js'
+
+export function setupApiMock(): MockApi {
+    const mockApi = createMockApi()
+    vi.mocked(getApi).mockResolvedValue(mockApi)
+    return mockApi
+}

--- a/src/test-support/console-spy.ts
+++ b/src/test-support/console-spy.ts
@@ -1,0 +1,10 @@
+import type { MockInstance } from 'vitest'
+import { vi } from 'vitest'
+
+export function mockConsoleLog(): MockInstance {
+    return vi.spyOn(console, 'log').mockImplementation(() => {})
+}
+
+export function mockConsoleError(): MockInstance {
+    return vi.spyOn(console, 'error').mockImplementation(() => {})
+}

--- a/src/test-support/console-spy.ts
+++ b/src/test-support/console-spy.ts
@@ -8,3 +8,11 @@ export function mockConsoleLog(): MockInstance {
 export function mockConsoleError(): MockInstance {
     return vi.spyOn(console, 'error').mockImplementation(() => {})
 }
+
+export function mockProcessStdout(): MockInstance {
+    return vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+}
+
+export function mockProcessStderr(): MockInstance {
+    return vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+}

--- a/src/test-support/program.ts
+++ b/src/test-support/program.ts
@@ -1,0 +1,8 @@
+import { Command } from 'commander'
+
+export function createTestProgram(register: (program: Command) => void): Command {
+    const program = new Command()
+    program.exitOverride()
+    register(program)
+    return program
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
         globals: true,
         root: 'src',
         include: ['**/*.test.ts'],
+        restoreMocks: true,
         // Inline @doist/cli-core so vitest's module mocks (e.g. vi.doMock for
         // 'node:fs/promises' in auth.test.ts) reach its compiled imports.
         // Without this, vitest treats it as external and Node's native


### PR DESCRIPTION
## Summary
Audit of the test suite found heavy duplication in setup/boilerplate. This extracts three shared helpers in `src/test-support/` and adopts them across the suite, cutting ~877 net lines with no behavior change.

- **`createTestProgram(register)`** — replaces 33 byte-identical local `createProgram` functions (and their now-unused `commander` imports).
- **`setupApiMock()`** — collapses 131 `createMockApi()` + `getApi.mockResolvedValue()` beforeEach pairs across 25 files into one call.
- **`restoreMocks: true` + `mockConsoleLog`/`mockConsoleError`** — auto-restores spies between tests so the 489 inline console spies shrink to a helper call and 532 manual `.mockRestore()` calls + 46 now-empty hooks are removed.

Two audited items were investigated and intentionally skipped: adopting shared fixtures (remaining inline literals use bespoke asserted values — ~0 dedup) and centralizing submodule `vi.mock` factories (genuinely differ per file; centralizing needs `vi.hoisted` indirection for little gain).

## Test plan
- [x] `npm test` — 1616 tests pass (63 files)
- [x] `npm run check` — oxlint + oxfmt clean
- [x] `npm run type-check` — clean
- [x] pre-commit hooks pass on every commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)