### PR TITLE
feat: rename `td user` to `td accounts` and adopt cli-core account attachers

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -127,6 +127,12 @@ New subcommand? Copy a sibling in the target group, wire it in that group's
 - **`auth.ts`** — read-side resolver: `resolveActiveUser`, `getApiToken`,
   `probeApiToken`, `getAuthMetadata`, `listStoredUsers`, `NoTokenError`. All
   write/clear paths go through `auth-store.ts`.
+- **`users.ts`** — config-side account helpers shared across commands:
+  `matchUserRef`/`findUserByRef`/`requireUserByRef`, the stored-user mutators
+  (`upsert`/`remove`/`set`/`clearDefaultUser`), `getDefaultUserId` (raw pinned
+  pointer) and `getEffectiveDefaultUserId` (pinned-else-sole-account, used for
+  the `(default)` marker in `accounts list`/`current`, `auth status`,
+  `config view`).
 - **`auth-flags.ts`** — `buildReloginCommand()` (rebuilds `td auth login`
   with `--read-only` / `--additional-scopes=...` preserved)
 - **`config.ts`** — `~/.config/todoist-cli/config.json` read/write,

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -109,9 +109,10 @@ lives in `src/lib/skills/content.ts` (SKILL_CONTENT) — don't duplicate here.
 - **Notifications** — list/view/accept/reject/dismiss
 - **Productivity & activity** — `activity`, `stats`, `completed`
 - **Top-level views** — `today`, `upcoming`, `inbox`, `view` (URL router)
-- **Infra** — `auth` (login/logout/token/status), `settings`, `apps`,
-  `backup`, `attachment`, `hc` (Help Center), `skill`, `completion`, `update`,
-  `doctor`, `changelog`
+- **Infra** — `auth` (login/logout/token/status), `accounts`
+  (multi-user list/use/current/remove; aliases `user`/`users`), `settings`,
+  `apps`, `backup`, `attachment`, `hc` (Help Center), `skill`, `completion`,
+  `update`, `doctor`, `changelog`
 
 New subcommand? Copy a sibling in the target group, wire it in that group's
 `index.ts`, update `SKILL_CONTENT`, run `npm run sync:skill`. See AGENTS.md.
@@ -219,9 +220,11 @@ All live in `src/lib/refs.ts`:
 ## Auth & token storage
 
 `@doist/cli-core/auth` owns the keyring, multi-user `TokenStore`, OAuth flow,
-and the `login` / `logout` / `status` / `token view` registrars. todoist-cli
-supplies a `UserRecordStore<TodoistAccount>` adapter (`user-records.ts`) over
-its config file plus a Todoist-specific `validateToken` (`auth-provider.ts`).
+and the `login` / `logout` / `status` / `token view` registrars, plus the
+`account list` / `account use` attachers that back `td accounts list` and
+`td accounts use` (`commands/user/{list,use}.ts`). todoist-cli supplies a
+`UserRecordStore<TodoistAccount>` adapter (`user-records.ts`) over its config
+file plus a Todoist-specific `validateToken` (`auth-provider.ts`).
 
 Read path (`auth.ts` — `resolveActiveUser` / `getApiToken` / `probeApiToken`):
 env `TODOIST_API_TOKEN` first, then a config-derived target user, then either

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@doist/cli-core": "0.21.0",
+        "@doist/cli-core": "0.22.0",
         "@doist/todoist-sdk": "10.3.0",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
@@ -137,9 +137,9 @@
       }
     },
     "node_modules/@doist/cli-core": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.21.0.tgz",
-      "integrity": "sha512-K+MevAVxo1gNe0AvyMqMnRswVzpCjmJj+7ufLE6AA7CM26Dc6EeZ2Lbqe1va47ofPr4WYfOK0n2qsUDrMPFncA==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.22.0.tgz",
+      "integrity": "sha512-u23lFHCa4UUSvgrsEVacuN/MAW+QtW0cwNqn2svNDl85wmL3/h7DN0BBN1WlnMxrCKxwp+7wwIPL0QTKMuTi7w==",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@doist/cli-core": "0.22.0",
+        "@doist/cli-core": "0.23.0",
         "@doist/todoist-sdk": "10.3.0",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
@@ -137,9 +137,9 @@
       }
     },
     "node_modules/@doist/cli-core": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.22.0.tgz",
-      "integrity": "sha512-u23lFHCa4UUSvgrsEVacuN/MAW+QtW0cwNqn2svNDl85wmL3/h7DN0BBN1WlnMxrCKxwp+7wwIPL0QTKMuTi7w==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.23.0.tgz",
+      "integrity": "sha512-SzqbFi7m5AGQYsgX2U+1zIcKAGsiORk5IJvtfalBuKVlRXT6xdVoQtL8HgsOHli+GqRtAm6xqQlxMHBJqfwAEg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@doist/cli-core": "0.21.0",
+    "@doist/cli-core": "0.22.0",
     "@doist/todoist-sdk": "10.3.0",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@doist/cli-core": "0.22.0",
+    "@doist/cli-core": "0.23.0",
     "@doist/todoist-sdk": "10.3.0",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -72,17 +72,19 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 The CLI can hold credentials for multiple Todoist accounts at once.
 
 ```bash
-td auth login                       # adds the account; first one becomes default
-td user list                        # all stored accounts (with default marker)
-td user list --json                 # array of accounts with auth metadata (--ndjson also supported)
-td user use <id|email>              # set the default account (alias: td user default)
-td user current                     # show the active account
-td user remove <id|email>           # delete an account (and its token)
-td --user <id|email> task list      # one-off override for any command
-td auth logout --user <id|email>    # log out a specific account
+td auth login                          # adds the account; first one becomes default
+td accounts list                       # all stored accounts (with default marker)
+td accounts list --json                # { accounts: [...], default } envelope; --ndjson streams one account per line
+td accounts use <id|email>             # set the default account (alias: td accounts default; --json/--ndjson supported)
+td accounts current                    # show the active account
+td accounts remove <id|email>          # delete an account (and its token)
+td --user <id|email> task list         # one-off override for any command
+td auth logout --user <id|email>       # log out a specific account
 ```
 
-Resolution order: `--user <ref>` > `user.defaultUser` from config > the only stored account. With multiple accounts and no default, commands error and ask for `--user` (or `td user use`). `<ref>` matches an exact id or email (case-insensitive on email). `TODOIST_API_TOKEN` still bypasses the resolver entirely.
+`td accounts` is also available as `td user` / `td users` (back-compat aliases).
+
+Resolution order: `--user <ref>` > `user.defaultUser` from config > the only stored account. With multiple accounts and no default, commands error and ask for `--user` (or `td accounts use`). `<ref>` matches an exact id or email (case-insensitive on email). `TODOIST_API_TOKEN` still bypasses the resolver entirely.
 
 ## Quick Reference
 
@@ -95,7 +97,7 @@ Resolution order: `--user <ref>` > `user.defaultUser` from config > the only sto
 - Collaboration: `td comment ...`, `td notification ...`, `td reminder ...`
 - Templates and files: `td template ...`, `td attachment view <file-url>`, `td backup ...`
 - Help Center: `td hc locales/search/view`
-- Account and tooling: `td stats`, `td settings ...`, `td config view`, `td user ...`, `td completion ...`, `td view <todoist-url>`, `td doctor`, `td update`, `td changelog`
+- Account and tooling: `td stats`, `td settings ...`, `td config view`, `td accounts ...`, `td completion ...`, `td view <todoist-url>`, `td doctor`, `td update`, `td changelog`
 - Developer apps: `td apps list/view` (requires `td auth login --additional-scopes=app-management`)
 - Backups: `td backup list/download` (requires `td auth login --additional-scopes=backups`)
 - Billing: `td billing subscription/plan/prices/pricing` (requires `td auth login --additional-scopes=billing`)

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -76,8 +76,8 @@ td auth login                          # adds the account; first one becomes def
 td accounts list                       # all stored accounts (with default marker)
 td accounts list --json                # { accounts: [...], default } envelope; --ndjson streams one account per line
 td accounts use <id|email>             # set the default account (alias: td accounts default; --json/--ndjson supported)
-td accounts current                    # show the active account
-td accounts remove <id|email>          # delete an account (and its token)
+td accounts current                    # show the active account (--json/--ndjson supported)
+td accounts remove <id|email>          # delete an account and its token (--json/--ndjson supported)
 td --user <id|email> task list         # one-off override for any command
 td auth logout --user <id|email>       # log out a specific account
 ```

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -521,7 +521,7 @@ describe('auth command', () => {
             try {
                 await expect(
                     program.parseAsync(['node', 'td', 'auth', 'logout']),
-                ).rejects.toHaveProperty('code', 'USER_NOT_FOUND')
+                ).rejects.toHaveProperty('code', 'ACCOUNT_NOT_FOUND')
                 expect(clearMock).not.toHaveBeenCalled()
             } finally {
                 process.argv = originalArgv
@@ -584,7 +584,7 @@ describe('auth command', () => {
             try {
                 await expect(
                     program.parseAsync(['node', 'td', 'auth', 'token', 'view']),
-                ).rejects.toHaveProperty('code', 'USER_NOT_FOUND')
+                ).rejects.toHaveProperty('code', 'ACCOUNT_NOT_FOUND')
                 expect(activeMock).not.toHaveBeenCalled()
             } finally {
                 process.argv = originalArgv

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -372,7 +372,12 @@ describe('auth command', () => {
                             bundle: { accessToken: 'snapshot_token' },
                         }
                     },
-                    async clear() {},
+                    async activeAccount() {
+                        return { account: SNAPSHOT_ACCOUNT, isDefault: true }
+                    },
+                    async clear() {
+                        return null
+                    },
                     async list() {
                         return [{ account: SNAPSHOT_ACCOUNT, isDefault: true }]
                     },

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -250,7 +250,29 @@ describe('auth command', () => {
                 authMode: 'read-write',
                 source: 'secure-store',
             })
-            mockReadConfig.mockResolvedValue({ user: { defaultUser: TEST_USER.id } })
+            mockReadConfig.mockResolvedValue({
+                user: { defaultUser: TEST_USER.id },
+                users: [{ id: TEST_USER.id, email: TEST_USER.email }],
+            })
+
+            await program.parseAsync(['node', 'td', 'auth', 'status'])
+
+            expect(consoleSpy).toHaveBeenCalledWith('✓ Authenticated (default)')
+        })
+
+        it('marks a lone account as default with no pinned defaultUser', async () => {
+            // Effective-default rule: a single stored account is implicitly the
+            // default, so the marker matches `accounts list` even with no pin.
+            const program = createProgram()
+            const mockApi = createMockApi({ getUser: vi.fn().mockResolvedValue(TEST_USER) })
+            mockGetApi.mockResolvedValue(mockApi)
+            mockGetAuthMetadata.mockResolvedValue({
+                authMode: 'read-write',
+                source: 'secure-store',
+            })
+            mockReadConfig.mockResolvedValue({
+                users: [{ id: TEST_USER.id, email: TEST_USER.email }],
+            })
 
             await program.parseAsync(['node', 'td', 'auth', 'status'])
 
@@ -287,7 +309,10 @@ describe('auth command', () => {
                 source: 'secure-store',
             })
             mockListStoredUsers.mockResolvedValue([{ id: TEST_USER.id, email: TEST_USER.email }])
-            mockReadConfig.mockResolvedValue({ user: { defaultUser: TEST_USER.id } })
+            mockReadConfig.mockResolvedValue({
+                user: { defaultUser: TEST_USER.id },
+                users: [{ id: TEST_USER.id, email: TEST_USER.email }],
+            })
 
             await program.parseAsync(['node', 'td', 'auth', 'status', '--json'])
 
@@ -370,7 +395,10 @@ describe('auth command', () => {
                 mockListStoredUsers.mockResolvedValue([
                     { id: TEST_USER.id, email: TEST_USER.email },
                 ])
-                mockReadConfig.mockResolvedValue({ user: { defaultUser: TEST_USER.id } })
+                mockReadConfig.mockResolvedValue({
+                    user: { defaultUser: TEST_USER.id },
+                    users: [{ id: TEST_USER.id, email: TEST_USER.email }],
+                })
             })
 
             it('renders text status from the snapshot (no --user override)', async () => {

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -84,7 +84,7 @@ function buildStatusText(data: StatusData): readonly string[] {
         }
         lines.push(
             chalk.dim(
-                'Use `td user use <id|email>` to switch default, or `--user <ref>` per command.',
+                'Use `td accounts use <id|email>` to switch default, or `--user <ref>` per command.',
             ),
         )
     }

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -17,7 +17,7 @@ import {
     type StoredUser,
 } from '../../lib/auth.js'
 import { getRequestedUserRef } from '../../lib/global-args.js'
-import { getDefaultUserId } from '../../lib/users.js'
+import { getEffectiveDefaultUserId } from '../../lib/users.js'
 
 type StatusData = {
     user: { id: string; email: string; fullName: string }
@@ -50,7 +50,7 @@ async function gatherStatusData(token?: string): Promise<StatusData> {
         listStoredUsers(),
         readConfig(),
     ])
-    return { user, metadata, storedUsers, defaultUserId: getDefaultUserId(config) }
+    return { user, metadata, storedUsers, defaultUserId: getEffectiveDefaultUserId(config) }
 }
 
 function buildStatusText(data: StatusData): readonly string[] {

--- a/src/commands/auth/store-wrap.ts
+++ b/src/commands/auth/store-wrap.ts
@@ -39,7 +39,7 @@ export function withUserRefAware(store: TodoistTokenStore): TodoistTokenStore {
         clear: async (ref?: string) => {
             const targetRef = ref ?? getRequestedUserRef()
             if (targetRef !== undefined) await requireExists(targetRef)
-            await store.clear(targetRef)
+            return store.clear(targetRef)
         },
     })
 }

--- a/src/commands/config/config.test.ts
+++ b/src/commands/config/config.test.ts
@@ -266,6 +266,33 @@ describe('config view', () => {
         expect(output).toContain('read-only (data:read)')
     })
 
+    it('marks a lone account as default in pretty mode with no pinned defaultUser', async () => {
+        // Effective-default rule: a single stored account is implicitly the
+        // default, matching `accounts list` / `auth status` even with no pin.
+        presentConfig({
+            config_version: 2,
+            users: [{ id: '111', email: 'first@example.com', auth_mode: 'read-write' }],
+        })
+        mockListStoredUsers.mockResolvedValue([
+            { id: '111', email: 'first@example.com', auth_mode: 'read-write' },
+        ])
+        mockProbeApiToken.mockResolvedValue({
+            token: 'tdo_first_token_xxxx1111',
+            metadata: {
+                authMode: 'read-write',
+                source: 'secure-store',
+                userId: '111',
+                email: 'first@example.com',
+            },
+        })
+        const consoleSpy = mockConsoleLog()
+
+        await createProgram().parseAsync(['node', 'td', 'config', 'view'])
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+
+        expect(output).toContain('(default)')
+    })
+
     it('flags ambiguous resolution when multiple users with no default', async () => {
         presentConfig({
             config_version: 2,

--- a/src/commands/config/view.ts
+++ b/src/commands/config/view.ts
@@ -76,7 +76,7 @@ function renderTokenLine(token: TokenStatus, showToken: boolean): string {
             return chalk.dim(`unknown — ${token.reason}`)
         case 'ambiguous':
             return chalk.dim(
-                'multiple stored accounts; pass --user <id|email> or set a default with `td user use`',
+                'multiple stored accounts; pass --user <id|email> or set a default with `td accounts use`',
             )
         case 'missing':
             return formatValue(undefined)

--- a/src/commands/config/view.ts
+++ b/src/commands/config/view.ts
@@ -9,7 +9,7 @@ import {
     TOKEN_ENV_VAR,
 } from '../../lib/auth.js'
 import { type Config, getConfigPath, readConfigStrict } from '../../lib/config.js'
-import { getDefaultUserId, NoUserSelectedError } from '../../lib/users.js'
+import { getEffectiveDefaultUserId, NoUserSelectedError } from '../../lib/users.js'
 
 const SECURE_STORE_DESCRIPTION = 'system credential manager'
 
@@ -213,7 +213,7 @@ export async function viewConfig(options: ViewConfigOptions): Promise<void> {
 
     const token = await probeTokenPresence()
     const users = await listStoredUsers()
-    const defaultUserId = getDefaultUserId(config)
+    const defaultUserId = getEffectiveDefaultUserId(config)
 
     if (read.state === 'missing' && token.state === 'missing' && users.length === 0) {
         console.log(

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -175,7 +175,7 @@ async function checkAuthentication(offline: boolean): Promise<DoctorCheck> {
                 name: 'auth',
                 status: 'warn',
                 message:
-                    'Multiple stored Todoist accounts but no default. Set one with `td user use <id|email>` or pass --user.',
+                    'Multiple stored Todoist accounts but no default. Set one with `td accounts use <id|email>` or pass --user.',
             }
         }
 

--- a/src/commands/user/aliases.ts
+++ b/src/commands/user/aliases.ts
@@ -1,0 +1,10 @@
+/**
+ * Back-compat aliases for the `accounts` command group (renamed from `user`).
+ *
+ * Shared between the real Commander command (`commands/user/index.ts`, via
+ * `.aliases()`) and the lazy-loader/​completion dispatcher (`src/index.ts`),
+ * which resolve different paths and would otherwise drift if the list were
+ * duplicated. Kept in this dependency-free module so `src/index.ts` can import
+ * it without eagerly pulling in the command implementation.
+ */
+export const ACCOUNT_COMMAND_ALIASES = ['user', 'users']

--- a/src/commands/user/current.ts
+++ b/src/commands/user/current.ts
@@ -1,50 +1,75 @@
+import { formatJson, formatNdjson } from '@doist/cli-core'
+import { attachAccountCurrentCommand } from '@doist/cli-core/auth'
 import chalk from 'chalk'
-import { readConfig, resolveActiveUser } from '../../lib/auth.js'
-import { getEffectiveDefaultUserId } from '../../lib/users.js'
+import type { Command } from 'commander'
+import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
+import { resolveActiveUser } from '../../lib/auth.js'
 
-export interface CurrentUserOptions {
-    json?: boolean
-}
-
-export async function currentUserCommand(options: CurrentUserOptions): Promise<void> {
-    const resolved = await resolveActiveUser()
-    const config = await readConfig()
-    const defaultId = getEffectiveDefaultUserId(config)
-    const isDefault = resolved.id === defaultId
-
-    if (options.json) {
-        console.log(
-            JSON.stringify(
-                {
+/**
+ * Attach `td accounts current` via cli-core's `attachAccountCurrentCommand`.
+ *
+ * A signed-in stored account resolves through `store.activeAccount()` and is
+ * rendered by `renderText` / `renderJson`. The env-token and legacy
+ * single-user sources live outside the store (so `activeAccount()` returns
+ * `null` for them — env via the adapter's short-circuit, legacy because it has
+ * no record), and are rendered in `onNotAuthenticated` via the read-side
+ * resolver. The stored-case `--json` `source` is reported as `secure-store`;
+ * the env/legacy sources are surfaced accurately by the fallback branch.
+ */
+export function attachTodoistUserCurrentCommand(
+    parent: Command,
+    store: TodoistTokenStore,
+): Command {
+    return attachAccountCurrentCommand<TodoistAccount>(parent, {
+        store,
+        description: 'Show the active account (resolved from --user, default, or single login)',
+        renderText: ({ account, isDefault }) => {
+            const marker = isDefault ? chalk.green(' (default)') : ''
+            return `${account.email} ${chalk.dim(`(id:${account.id})`)}${marker}`
+        },
+        renderJson: ({ account, isDefault }) => ({
+            id: account.id,
+            email: account.email,
+            source: 'secure-store',
+            isDefault,
+            authMode: account.auth_mode,
+            authScope: account.auth_scope,
+            authFlags: account.auth_flags,
+        }),
+        onNotAuthenticated: async ({ view }) => {
+            // Nothing resolved in the store, so the active credential is
+            // out-of-store (TODOIST_API_TOKEN or legacy single-user creds) — or
+            // there's nothing at all, in which case `resolveActiveUser` throws
+            // `NoTokenError`, matching the previous behaviour.
+            const resolved = await resolveActiveUser()
+            if (view.json || view.ndjson) {
+                const payload = {
                     id: resolved.id === 'env' || resolved.id === 'legacy' ? null : resolved.id,
                     email: resolved.email || null,
                     source: resolved.source,
-                    isDefault,
+                    isDefault: false,
                     authMode: resolved.authMode,
                     authScope: resolved.authScope,
                     authFlags: resolved.authFlags,
-                },
-                null,
-                2,
-            ),
-        )
-        return
-    }
-
-    if (resolved.source === 'env') {
-        console.log(chalk.dim('Using TODOIST_API_TOKEN environment variable (no stored user).'))
-        return
-    }
-
-    if (resolved.id === 'legacy') {
-        console.log(
-            chalk.dim(
-                'Using legacy single-user credentials. Run `td auth login` to migrate to a stored account.',
-            ),
-        )
-        return
-    }
-
-    const marker = isDefault ? chalk.green(' (default)') : ''
-    console.log(`${resolved.email} ${chalk.dim(`(id:${resolved.id})`)}${marker}`)
+                }
+                console.log(view.json ? formatJson(payload) : formatNdjson([payload]))
+                return
+            }
+            if (resolved.source === 'env') {
+                console.log(
+                    chalk.dim('Using TODOIST_API_TOKEN environment variable (no stored user).'),
+                )
+                return
+            }
+            if (resolved.id === 'legacy') {
+                console.log(
+                    chalk.dim(
+                        'Using legacy single-user credentials. Run `td auth login` to migrate to a stored account.',
+                    ),
+                )
+                return
+            }
+            console.log(`${resolved.email} ${chalk.dim(`(id:${resolved.id})`)}`)
+        },
+    })
 }

--- a/src/commands/user/current.ts
+++ b/src/commands/user/current.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk'
 import type { Command } from 'commander'
 import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
 import { resolveActiveUser } from '../../lib/auth.js'
+import { projectAccount } from './project-account.js'
 
 /**
  * Attach `td accounts current` via cli-core's `attachAccountCurrentCommand`.
@@ -28,13 +29,8 @@ export function attachTodoistUserCurrentCommand(
             return `${account.email} ${chalk.dim(`(id:${account.id})`)}${marker}`
         },
         renderJson: ({ account, isDefault }) => ({
-            id: account.id,
-            email: account.email,
+            ...projectAccount(account, isDefault),
             source: 'secure-store',
-            isDefault,
-            authMode: account.auth_mode,
-            authScope: account.auth_scope,
-            authFlags: account.auth_flags,
         }),
         onNotAuthenticated: async ({ view }) => {
             // Nothing resolved in the store, so the active credential is

--- a/src/commands/user/current.ts
+++ b/src/commands/user/current.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import { readConfig, resolveActiveUser } from '../../lib/auth.js'
-import { getDefaultUserId } from '../../lib/users.js'
+import { getEffectiveDefaultUserId } from '../../lib/users.js'
 
 export interface CurrentUserOptions {
     json?: boolean
@@ -9,7 +9,7 @@ export interface CurrentUserOptions {
 export async function currentUserCommand(options: CurrentUserOptions): Promise<void> {
     const resolved = await resolveActiveUser()
     const config = await readConfig()
-    const defaultId = getDefaultUserId(config)
+    const defaultId = getEffectiveDefaultUserId(config)
     const isDefault = resolved.id === defaultId
 
     if (options.json) {

--- a/src/commands/user/current.ts
+++ b/src/commands/user/current.ts
@@ -14,8 +14,9 @@ import { projectAccount } from './project-account.js'
  * single-user sources live outside the store (so `activeAccount()` returns
  * `null` for them — env via the adapter's short-circuit, legacy because it has
  * no record), and are rendered in `onNotAuthenticated` via the read-side
- * resolver. The stored-case `--json` `source` is reported as `secure-store`;
- * the env/legacy sources are surfaced accurately by the fallback branch.
+ * resolver. The stored-case `--json` `source` is read off the account (the
+ * adapter's `activeAccount` annotates `secure-store` vs `config-file`); the
+ * env/legacy sources come from the fallback branch.
  */
 export function attachTodoistUserCurrentCommand(
     parent: Command,
@@ -30,7 +31,7 @@ export function attachTodoistUserCurrentCommand(
         },
         renderJson: ({ account, isDefault }) => ({
             ...projectAccount(account, isDefault),
-            source: 'secure-store',
+            source: (account.source as string | undefined) ?? 'secure-store',
         }),
         onNotAuthenticated: async ({ view }) => {
             // Nothing resolved in the store, so the active credential is

--- a/src/commands/user/index.ts
+++ b/src/commands/user/index.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander'
 import { createTodoistTokenStore } from '../../lib/auth-store.js'
+import { ACCOUNT_COMMAND_ALIASES } from './aliases.js'
 import { currentUserCommand } from './current.js'
 import { attachTodoistUserListCommand } from './list.js'
 import { removeUserCommand } from './remove.js'
@@ -10,7 +11,7 @@ export function registerUserCommand(program: Command): void {
     // existing scripts (and the docs that long said `td user …`) keep working.
     const account = program
         .command('accounts')
-        .aliases(['user', 'users'])
+        .aliases(ACCOUNT_COMMAND_ALIASES)
         .description('Manage stored Todoist accounts (multi-user)')
 
     // `list` and `use`/`default` delegate to cli-core's generic account

--- a/src/commands/user/index.ts
+++ b/src/commands/user/index.ts
@@ -1,9 +1,9 @@
 import { Command } from 'commander'
 import { createTodoistTokenStore } from '../../lib/auth-store.js'
 import { ACCOUNT_COMMAND_ALIASES } from './aliases.js'
-import { currentUserCommand } from './current.js'
+import { attachTodoistUserCurrentCommand } from './current.js'
 import { attachTodoistUserListCommand } from './list.js'
-import { removeUserCommand } from './remove.js'
+import { attachTodoistUserRemoveCommand } from './remove.js'
 import { attachTodoistUserUseCommand } from './use.js'
 
 export function registerUserCommand(program: Command): void {
@@ -14,23 +14,13 @@ export function registerUserCommand(program: Command): void {
         .aliases(ACCOUNT_COMMAND_ALIASES)
         .description('Manage stored Todoist accounts (multi-user)')
 
-    // `list` and `use`/`default` delegate to cli-core's generic account
-    // attachers (consuming `store.list()` / `store.setDefault()`); `current`
-    // and `remove` stay hand-rolled — cli-core ships no attacher for them.
+    // All four subcommands delegate to cli-core's generic account attachers
+    // (list/use/current/remove), consuming the `TokenStore` contract directly.
     const store = createTodoistTokenStore()
     attachTodoistUserListCommand(account, store)
     attachTodoistUserUseCommand(account, store)
-
-    account
-        .command('current')
-        .description('Show the active account (resolved from --user, default, or single login)')
-        .option('--json', 'Output as JSON')
-        .action(currentUserCommand)
-
-    account
-        .command('remove <ref>')
-        .description('Remove a stored account (deletes its token and config entry)')
-        .action((ref: string) => removeUserCommand(ref))
+    attachTodoistUserCurrentCommand(account, store)
+    attachTodoistUserRemoveCommand(account, store)
 
     account.addHelpText(
         'after',

--- a/src/commands/user/index.ts
+++ b/src/commands/user/index.ts
@@ -1,45 +1,45 @@
 import { Command } from 'commander'
+import { createTodoistTokenStore } from '../../lib/auth-store.js'
 import { currentUserCommand } from './current.js'
-import { listUsersCommand } from './list.js'
+import { attachTodoistUserListCommand } from './list.js'
 import { removeUserCommand } from './remove.js'
-import { useUserCommand } from './use.js'
+import { attachTodoistUserUseCommand } from './use.js'
 
 export function registerUserCommand(program: Command): void {
-    const user = program.command('user').description('Manage stored Todoist accounts (multi-user)')
+    // Renamed from `user` to `accounts`; `user`/`users` stay as aliases so
+    // existing scripts (and the docs that long said `td user …`) keep working.
+    const account = program
+        .command('accounts')
+        .aliases(['user', 'users'])
+        .description('Manage stored Todoist accounts (multi-user)')
 
-    user.command('list')
-        .description('List all stored Todoist accounts')
-        .option('--json', 'Output as JSON')
-        .option('--ndjson', 'Output as newline-delimited JSON')
-        .action(listUsersCommand)
+    // `list` and `use`/`default` delegate to cli-core's generic account
+    // attachers (consuming `store.list()` / `store.setDefault()`); `current`
+    // and `remove` stay hand-rolled — cli-core ships no attacher for them.
+    const store = createTodoistTokenStore()
+    attachTodoistUserListCommand(account, store)
+    attachTodoistUserUseCommand(account, store)
 
-    user.command('use <ref>')
-        .description('Set the default account used when --user is not provided')
-        .action((ref: string) => useUserCommand(ref))
-
-    // `default` is an explicit alias for `use` — same behavior, different verb.
-    user.command('default <ref>')
-        .description('Alias of `td user use <ref>`')
-        .action((ref: string) => useUserCommand(ref))
-
-    user.command('current')
+    account
+        .command('current')
         .description('Show the active account (resolved from --user, default, or single login)')
         .option('--json', 'Output as JSON')
         .action(currentUserCommand)
 
-    user.command('remove <ref>')
+    account
+        .command('remove <ref>')
         .description('Remove a stored account (deletes its token and config entry)')
         .action((ref: string) => removeUserCommand(ref))
 
-    user.addHelpText(
+    account.addHelpText(
         'after',
         `
 Examples:
-  $ td auth login                 # add an account (sets it as default if first)
-  $ td user list                  # see all stored accounts
-  $ td user use scott@doist.com   # set default
-  $ td user current               # show the active account
+  $ td auth login                     # add an account (sets it as default if first)
+  $ td accounts list                  # see all stored accounts
+  $ td accounts use scott@doist.com   # set default
+  $ td accounts current               # show the active account
   $ td --user other@example.com task list   # one-off override
-  $ td user remove old@example.com`,
+  $ td accounts remove old@example.com`,
     )
 }

--- a/src/commands/user/list.ts
+++ b/src/commands/user/list.ts
@@ -1,53 +1,56 @@
-import { formatJson, formatNdjson, printEmpty } from '@doist/cli-core'
+import { attachAccountListCommand } from '@doist/cli-core/auth'
 import chalk from 'chalk'
-import { listStoredUsers, readConfig, type StoredUser } from '../../lib/auth.js'
+import type { Command } from 'commander'
+import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
 import { isAccessible } from '../../lib/global-args.js'
-import { getDefaultUserId } from '../../lib/users.js'
 
-export interface ListUsersOptions {
-    json?: boolean
-    ndjson?: boolean
-}
-
-function projectUser(u: StoredUser, defaultId: string | undefined) {
+/**
+ * Per-account `--json` / `--ndjson` shape. Flattens the stored
+ * `TodoistAccount` into the camelCase fields the CLI has always surfaced,
+ * dropping the internal `label` duplicate and snake_case config keys. The
+ * `{ accounts, default }` envelope around these entries is owned by cli-core's
+ * `attachAccountListCommand`.
+ */
+function projectAccount(account: TodoistAccount, isDefault: boolean) {
     return {
-        id: u.id,
-        email: u.email,
-        isDefault: u.id === defaultId,
-        authMode: u.auth_mode,
-        authScope: u.auth_scope,
-        authFlags: u.auth_flags,
-        storage: u.api_token ? 'config-file' : 'secure-store',
+        id: account.id,
+        email: account.email,
+        isDefault,
+        authMode: account.auth_mode,
+        authScope: account.auth_scope,
+        authFlags: account.auth_flags,
     }
 }
 
-export async function listUsersCommand(options: ListUsersOptions): Promise<void> {
-    const users = await listStoredUsers()
-    const config = await readConfig()
-    const defaultId = getDefaultUserId(config)
-
-    if (users.length === 0) {
-        printEmpty({
-            options,
-            message: chalk.dim('No stored Todoist accounts. Run `td auth login` to add one.'),
-        })
-        return
-    }
-
-    if (options.json) {
-        console.log(formatJson(users.map((u) => projectUser(u, defaultId))))
-        return
-    }
-
-    if (options.ndjson) {
-        console.log(formatNdjson(users.map((u) => projectUser(u, defaultId))))
-        return
-    }
-
-    const accessible = isAccessible()
-    for (const u of users) {
-        const isDefault = u.id === defaultId
-        const marker = isDefault ? (accessible ? ' [default]' : chalk.green(' (default)')) : ''
-        console.log(`${u.email} ${chalk.dim(`(id:${u.id})`)}${marker}`)
-    }
+/**
+ * Attach `td accounts list` via cli-core's generic `attachAccountListCommand`,
+ * which reads `store.list()` and owns the `{ accounts, default }` machine
+ * envelope. The Todoist overrides keep human output identical to the
+ * hand-rolled version (`<email> (id:<id>)` + a default marker that respects
+ * `--accessible`) and flatten each machine entry via `projectAccount`.
+ *
+ * `isDefault` now reflects the store's *effective* default (a lone account
+ * counts as default even with no pinned `defaultUser`), matching what
+ * `active()` would resolve.
+ */
+export function attachTodoistUserListCommand(parent: Command, store: TodoistTokenStore): Command {
+    return attachAccountListCommand<TodoistAccount>(parent, {
+        store,
+        description: 'List all stored Todoist accounts',
+        renderText: ({ accounts }) => {
+            if (accounts.length === 0) {
+                return chalk.dim('No stored Todoist accounts. Run `td auth login` to add one.')
+            }
+            const accessible = isAccessible()
+            return accounts.map(({ account, isDefault }) => {
+                const marker = isDefault
+                    ? accessible
+                        ? ' [default]'
+                        : chalk.green(' (default)')
+                    : ''
+                return `${account.email} ${chalk.dim(`(id:${account.id})`)}${marker}`
+            })
+        },
+        renderJson: ({ account, isDefault }) => projectAccount(account, isDefault),
+    })
 }

--- a/src/commands/user/list.ts
+++ b/src/commands/user/list.ts
@@ -3,24 +3,7 @@ import chalk from 'chalk'
 import type { Command } from 'commander'
 import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
 import { isAccessible } from '../../lib/global-args.js'
-
-/**
- * Per-account `--json` / `--ndjson` shape. Flattens the stored
- * `TodoistAccount` into the camelCase fields the CLI has always surfaced,
- * dropping the internal `label` duplicate and snake_case config keys. The
- * `{ accounts, default }` envelope around these entries is owned by cli-core's
- * `attachAccountListCommand`.
- */
-function projectAccount(account: TodoistAccount, isDefault: boolean) {
-    return {
-        id: account.id,
-        email: account.email,
-        isDefault,
-        authMode: account.auth_mode,
-        authScope: account.auth_scope,
-        authFlags: account.auth_flags,
-    }
-}
+import { projectAccount } from './project-account.js'
 
 /**
  * Attach `td accounts list` via cli-core's generic `attachAccountListCommand`,

--- a/src/commands/user/project-account.ts
+++ b/src/commands/user/project-account.ts
@@ -1,0 +1,19 @@
+import type { TodoistAccount } from '../../lib/auth-store.js'
+
+/**
+ * Shared `TodoistAccount` → CLI JSON projection used by `accounts list` and
+ * `accounts current` so their per-account machine payloads can't drift. The
+ * stored config keys (`auth_mode`, …) are flattened to the camelCase field
+ * names the CLI has always surfaced; `label` (a duplicate of `email`) is
+ * dropped. `accounts current` extends the result with a `source` field.
+ */
+export function projectAccount(account: TodoistAccount, isDefault: boolean) {
+    return {
+        id: account.id,
+        email: account.email,
+        isDefault,
+        authMode: account.auth_mode,
+        authScope: account.auth_scope,
+        authFlags: account.auth_flags,
+    }
+}

--- a/src/commands/user/remove.ts
+++ b/src/commands/user/remove.ts
@@ -1,42 +1,37 @@
+import { attachAccountRemoveCommand } from '@doist/cli-core/auth'
 import chalk from 'chalk'
-import { createTodoistTokenStore } from '../../lib/auth-store.js'
-import { readConfig } from '../../lib/auth.js'
-import { CliError } from '../../lib/errors.js'
-import { isQuiet } from '../../lib/global-args.js'
-import { getDefaultUserId, requireUserByRef } from '../../lib/users.js'
+import type { Command } from 'commander'
+import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
 
-export async function removeUserCommand(ref: string | undefined): Promise<void> {
-    if (!ref) {
-        throw new CliError(
-            'MISSING_REF',
-            'Please provide a user id or email: `td accounts remove <id|email>`',
-        )
-    }
-
-    // Resolve the ref against the on-disk config first so we can report
-    // "Removed <email>" + the "cleared default" hint with the user's actual
-    // email — the store's clear path is keyed by id, not email, and would
-    // silently no-op on miss (printing the wrong reassurance).
-    const config = await readConfig()
-    const { user } = requireUserByRef(config, ref)
-    const wasDefault = getDefaultUserId(config) === user.id
-
-    const store = createTodoistTokenStore()
-    await store.clear(user.id)
-
-    if (!isQuiet()) {
-        console.log(chalk.green('✓'), `Removed ${user.email}`)
-        if (wasDefault) {
-            console.log(
-                chalk.dim(
-                    'Cleared default account. Set a new one with `td accounts use <id|email>`.',
-                ),
-            )
-        }
-    }
-
-    const result = store.getLastClearResult()
-    if (result?.warning) {
-        console.error(chalk.yellow('Warning:'), result.warning)
-    }
+/**
+ * Attach `td accounts remove <ref>` via cli-core's `attachAccountRemoveCommand`.
+ *
+ * `store.clear(ref)` resolves the ref and deletes by the canonical `account.id`
+ * in one token-free step (so a record whose secret is unreadable stays
+ * removable), returning the removed account plus whether it was the default — a
+ * miss surfaces as `ACCOUNT_NOT_FOUND`. The Todoist hook surfaces the
+ * keyring-fallback warning that the `TokenStore.clear` contract can't carry.
+ */
+export function attachTodoistUserRemoveCommand(parent: Command, store: TodoistTokenStore): Command {
+    return attachAccountRemoveCommand<TodoistAccount>(parent, {
+        store,
+        description: 'Remove a stored account (deletes its token and config entry)',
+        renderText: ({ account, wasDefault }) => {
+            const lines = [`${chalk.green('✓')} Removed ${account.email ?? account.id}`]
+            if (wasDefault) {
+                lines.push(
+                    chalk.dim(
+                        'Cleared default account. Set a new one with `td accounts use <id|email>`.',
+                    ),
+                )
+            }
+            return lines
+        },
+        onRemoved: () => {
+            const result = store.getLastClearResult()
+            if (result?.warning) {
+                console.error(chalk.yellow('Warning:'), result.warning)
+            }
+        },
+    })
 }

--- a/src/commands/user/remove.ts
+++ b/src/commands/user/remove.ts
@@ -9,7 +9,7 @@ export async function removeUserCommand(ref: string | undefined): Promise<void> 
     if (!ref) {
         throw new CliError(
             'MISSING_REF',
-            'Please provide a user id or email: `td user remove <id|email>`',
+            'Please provide a user id or email: `td accounts remove <id|email>`',
         )
     }
 
@@ -28,7 +28,9 @@ export async function removeUserCommand(ref: string | undefined): Promise<void> 
         console.log(chalk.green('✓'), `Removed ${user.email}`)
         if (wasDefault) {
             console.log(
-                chalk.dim('Cleared default account. Set a new one with `td user use <id|email>`.'),
+                chalk.dim(
+                    'Cleared default account. Set a new one with `td accounts use <id|email>`.',
+                ),
             )
         }
     }

--- a/src/commands/user/use.ts
+++ b/src/commands/user/use.ts
@@ -1,22 +1,17 @@
-import chalk from 'chalk'
-import { createTodoistTokenStore } from '../../lib/auth-store.js'
-import { CliError } from '../../lib/errors.js'
-import { isQuiet } from '../../lib/global-args.js'
+import { attachAccountUseCommand } from '@doist/cli-core/auth'
+import type { Command } from 'commander'
+import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
 
-export async function useUserCommand(ref: string | undefined): Promise<void> {
-    if (!ref) {
-        throw new CliError(
-            'MISSING_REF',
-            'Please provide a user id or email: `td user use <id|email>`',
-        )
-    }
-
-    // `store.setDefault(ref)` throws `CliError('ACCOUNT_NOT_FOUND', …)` on miss,
-    // which the top-level error handler renders as the standard "not found"
-    // message — no pre-check needed.
-    await createTodoistTokenStore().setDefault(ref)
-
-    if (!isQuiet()) {
-        console.log(chalk.green('✓'), `Default account set to ${ref}`)
-    }
+/**
+ * Attach `td accounts use <ref>` (alias `td accounts default <ref>`) via cli-core's
+ * generic `attachAccountUseCommand`, which calls `store.setDefault(ref)` and
+ * owns the success line / `--json` (`{ ok, default }`) / silent-`--ndjson`
+ * output. `setDefault`'s `CliError('ACCOUNT_NOT_FOUND', …)` on a ref miss
+ * propagates to the top-level handler unchanged.
+ */
+export function attachTodoistUserUseCommand(parent: Command, store: TodoistTokenStore): Command {
+    return attachAccountUseCommand<TodoistAccount>(parent, {
+        store,
+        description: 'Set the default account used when --user is not provided',
+    }).alias('default')
 }

--- a/src/commands/user/user.test.ts
+++ b/src/commands/user/user.test.ts
@@ -116,11 +116,20 @@ describe('user command', () => {
 
             await createProgram().parseAsync(['node', 'td', 'accounts', 'list', '--ndjson'])
 
-            expect(consoleSpy).toHaveBeenCalledTimes(2)
-            const first = JSON.parse(consoleSpy.mock.calls[0][0] as string)
-            const second = JSON.parse(consoleSpy.mock.calls[1][0] as string)
-            expect(first).toMatchObject({ id: '1', email: 'a@b.c', isDefault: false })
-            expect(second).toMatchObject({ id: '2', email: 'd@e.f', isDefault: true })
+            const lines = (consoleSpy.mock.calls.flat().join('\n') as string)
+                .split('\n')
+                .filter((line) => line.length > 0)
+            expect(lines).toHaveLength(2)
+            expect(JSON.parse(lines[0]!)).toMatchObject({
+                id: '1',
+                email: 'a@b.c',
+                isDefault: false,
+            })
+            expect(JSON.parse(lines[1]!)).toMatchObject({
+                id: '2',
+                email: 'd@e.f',
+                isDefault: true,
+            })
         })
 
         it('outputs a {accounts, default} envelope when --json given', async () => {
@@ -165,7 +174,7 @@ describe('user command', () => {
         })
 
         it('rejects an unknown ref', async () => {
-            // `td user use` routes directly through `store.setDefault(ref)`
+            // `td accounts use` routes directly through `store.setDefault(ref)`
             // now; cli-core's `KeyringTokenStore` throws
             // `CliError('ACCOUNT_NOT_FOUND', …)` on miss — the test stub
             // mirrors that contract so the command propagates correctly.
@@ -189,6 +198,31 @@ describe('user command', () => {
 
             expect(setDefaultMock).toHaveBeenCalledWith('111')
         })
+
+        it('emits {ok, default} for --json, resolving the canonical default id', async () => {
+            // After setDefault the attacher re-reads list() to surface the
+            // account's canonical id as `default`.
+            listMock.mockResolvedValue([
+                { account: { id: '111', email: 'a@b.c' }, isDefault: true },
+            ])
+
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'use', 'a@b.c', '--json'])
+
+            expect(setDefaultMock).toHaveBeenCalledWith('a@b.c')
+            const payload = JSON.parse(consoleSpy.mock.calls[0][0] as string)
+            expect(payload).toEqual({ ok: true, default: '111' })
+        })
+
+        it('is silent for --ndjson (success-action convention)', async () => {
+            listMock.mockResolvedValue([
+                { account: { id: '111', email: 'a@b.c' }, isDefault: true },
+            ])
+
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'use', '111', '--ndjson'])
+
+            expect(setDefaultMock).toHaveBeenCalledWith('111')
+            expect(consoleSpy).not.toHaveBeenCalled()
+        })
     })
 
     describe('current', () => {
@@ -211,6 +245,26 @@ describe('user command', () => {
             const out = consoleSpy.mock.calls.flat().join('\n')
             expect(out).toContain('a@b.c')
             expect(out).toContain('default')
+        })
+
+        it('marks a lone account as default even with no pinned defaultUser', async () => {
+            // Effective-default rule: a single stored account is implicitly the
+            // default, matching `accounts list`'s store-derived marker.
+            mockResolveActiveUser.mockResolvedValue({
+                id: '111',
+                email: 'a@b.c',
+                token: 't',
+                authMode: 'read-write',
+                source: 'secure-store',
+            })
+            mockReadConfig.mockResolvedValue({
+                config_version: 2,
+                users: [{ id: '111', email: 'a@b.c' }],
+            })
+
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'current'])
+
+            expect(consoleSpy.mock.calls.flat().join('\n')).toContain('default')
         })
 
         it('says env when running on TODOIST_API_TOKEN', async () => {

--- a/src/commands/user/user.test.ts
+++ b/src/commands/user/user.test.ts
@@ -294,6 +294,27 @@ describe('user command', () => {
 
             expect(consoleSpy.mock.calls.flat().join('\n')).toContain('legacy')
         })
+
+        it('emits one ndjson line for the env fallback', async () => {
+            // The onNotAuthenticated branch formats NDJSON itself for
+            // out-of-store sources.
+            mockResolveActiveUser.mockResolvedValue({
+                id: 'env',
+                email: '',
+                token: 'envtoken',
+                authMode: 'unknown',
+                source: 'env',
+            })
+
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'current', '--ndjson'])
+
+            expect(consoleSpy).toHaveBeenCalledTimes(1)
+            expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toMatchObject({
+                id: null,
+                source: 'env',
+                isDefault: false,
+            })
+        })
     })
 
     describe('remove', () => {
@@ -341,6 +362,38 @@ describe('user command', () => {
             await createProgram().parseAsync(['node', 'td', 'accounts', 'remove', '111'])
 
             expect(errorSpy.mock.calls.flat().join('\n')).toContain('Keyring unavailable')
+        })
+
+        it('emits { ok, removed } for --json', async () => {
+            clearMock.mockResolvedValue({
+                account: { id: '111', email: 'a@b.c' },
+                wasDefault: false,
+            })
+
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'remove', '111', '--json'])
+
+            expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toEqual({
+                ok: true,
+                removed: '111',
+            })
+        })
+
+        it('is silent on stdout for --ndjson', async () => {
+            clearMock.mockResolvedValue({
+                account: { id: '111', email: 'a@b.c' },
+                wasDefault: false,
+            })
+
+            await createProgram().parseAsync([
+                'node',
+                'td',
+                'accounts',
+                'remove',
+                '111',
+                '--ndjson',
+            ])
+
+            expect(consoleSpy).not.toHaveBeenCalled()
         })
     })
 })

--- a/src/commands/user/user.test.ts
+++ b/src/commands/user/user.test.ts
@@ -12,6 +12,7 @@ vi.mock('../../lib/auth.js', async (importOriginal) => {
 const setDefaultMock = vi.fn()
 const listMock = vi.fn()
 const clearMock = vi.fn()
+const activeAccountMock = vi.fn()
 const lastClearMock = vi.fn<() => unknown>()
 vi.mock('../../lib/auth-store.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../../lib/auth-store.js')>()
@@ -19,6 +20,7 @@ vi.mock('../../lib/auth-store.js', async (importOriginal) => {
         ...actual,
         createTodoistTokenStore: () => ({
             active: vi.fn(),
+            activeAccount: activeAccountMock,
             list: listMock,
             set: vi.fn(),
             setDefault: setDefaultMock,
@@ -226,18 +228,17 @@ describe('user command', () => {
     })
 
     describe('current', () => {
-        it('prints the active user', async () => {
-            mockResolveActiveUser.mockResolvedValue({
-                id: '111',
-                email: 'a@b.c',
-                token: 't',
-                authMode: 'read-write',
-                source: 'secure-store',
-            })
-            mockReadConfig.mockResolvedValue({
-                config_version: 2,
-                user: { defaultUser: '111' },
-                users: [{ id: '111', email: 'a@b.c' }],
+        beforeEach(() => {
+            // Default: store resolves nothing, so tests opt into a stored
+            // account explicitly and the env/legacy cases fall through to the
+            // `onNotAuthenticated` resolver.
+            activeAccountMock.mockReset().mockResolvedValue(null)
+        })
+
+        it('prints the active stored account with its default marker', async () => {
+            activeAccountMock.mockResolvedValue({
+                account: { id: '111', email: 'a@b.c', auth_mode: 'read-write' },
+                isDefault: true,
             })
 
             await createProgram().parseAsync(['node', 'td', 'accounts', 'current'])
@@ -247,49 +248,26 @@ describe('user command', () => {
             expect(out).toContain('default')
         })
 
-        it('marks a lone account as default even with no pinned defaultUser', async () => {
-            // Effective-default rule: a single stored account is implicitly the
-            // default, matching `accounts list`'s store-derived marker.
-            mockResolveActiveUser.mockResolvedValue({
+        it('emits the stored account shape for --json', async () => {
+            activeAccountMock.mockResolvedValue({
+                account: { id: '111', email: 'a@b.c', auth_mode: 'read-write' },
+                isDefault: true,
+            })
+
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'current', '--json'])
+
+            expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toMatchObject({
                 id: '111',
                 email: 'a@b.c',
-                token: 't',
-                authMode: 'read-write',
                 source: 'secure-store',
-            })
-            mockReadConfig.mockResolvedValue({
-                config_version: 2,
-                users: [{ id: '111', email: 'a@b.c' }],
-            })
-
-            await createProgram().parseAsync(['node', 'td', 'accounts', 'current'])
-
-            expect(consoleSpy.mock.calls.flat().join('\n')).toContain('default')
-        })
-
-        it('ignores an orphaned defaultUser pointer and falls through to the sole account', async () => {
-            // `defaultUser` points at a removed account; the effective rule
-            // must drop the stale pin and treat the lone remaining account as
-            // default, matching `resolveActiveUser`'s fall-through.
-            mockResolveActiveUser.mockResolvedValue({
-                id: '111',
-                email: 'a@b.c',
-                token: 't',
+                isDefault: true,
                 authMode: 'read-write',
-                source: 'secure-store',
             })
-            mockReadConfig.mockResolvedValue({
-                config_version: 2,
-                user: { defaultUser: '999' },
-                users: [{ id: '111', email: 'a@b.c' }],
-            })
-
-            await createProgram().parseAsync(['node', 'td', 'accounts', 'current'])
-
-            expect(consoleSpy.mock.calls.flat().join('\n')).toContain('default')
         })
 
         it('says env when running on TODOIST_API_TOKEN', async () => {
+            // env short-circuits `activeAccount` (-> null), so `current` falls
+            // through to the resolver, which reports the env source.
             mockResolveActiveUser.mockResolvedValue({
                 id: 'env',
                 email: '',
@@ -300,40 +278,69 @@ describe('user command', () => {
 
             await createProgram().parseAsync(['node', 'td', 'accounts', 'current'])
 
-            const out = consoleSpy.mock.calls.flat().join('\n')
-            expect(out).toContain('TODOIST_API_TOKEN')
+            expect(consoleSpy.mock.calls.flat().join('\n')).toContain('TODOIST_API_TOKEN')
+        })
+
+        it('reports legacy single-user credentials', async () => {
+            mockResolveActiveUser.mockResolvedValue({
+                id: 'legacy',
+                email: 'old@e.f',
+                token: 'legacytoken',
+                authMode: 'unknown',
+                source: 'config-file',
+            })
+
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'current'])
+
+            expect(consoleSpy.mock.calls.flat().join('\n')).toContain('legacy')
         })
     })
 
     describe('remove', () => {
         beforeEach(() => {
-            clearMock.mockReset().mockResolvedValue(undefined)
+            clearMock.mockReset()
             lastClearMock.mockReset().mockReturnValue({ storage: 'secure-store' })
         })
 
-        it('removes the user by id and clears default', async () => {
-            mockReadConfig.mockResolvedValue({
-                config_version: 2,
-                user: { defaultUser: '111' },
-                users: [{ id: '111', email: 'a@b.c' }],
+        it('removes the resolved account and notes the cleared default', async () => {
+            // The store resolves the ref, clears by canonical id, and reports
+            // whether it was the default.
+            clearMock.mockResolvedValue({
+                account: { id: '111', email: 'a@b.c' },
+                wasDefault: true,
             })
 
-            await createProgram().parseAsync(['node', 'td', 'accounts', 'remove', '111'])
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'remove', 'a@b.c'])
 
-            expect(clearMock).toHaveBeenCalledWith('111')
-            expect(consoleSpy.mock.calls.flat().join('\n')).toContain('Cleared default')
+            expect(clearMock).toHaveBeenCalledWith('a@b.c')
+            const out = consoleSpy.mock.calls.flat().join('\n')
+            expect(out).toContain('Removed a@b.c')
+            expect(out).toContain('Cleared default')
         })
 
         it('rejects an unknown ref', async () => {
-            mockReadConfig.mockResolvedValue({
-                config_version: 2,
-                users: [{ id: '111', email: 'a@b.c' }],
-            })
+            // A `null` return from `clear()` means the ref matched nothing.
+            clearMock.mockResolvedValue(null)
 
             await expect(
                 createProgram().parseAsync(['node', 'td', 'accounts', 'remove', 'nope']),
-            ).rejects.toHaveProperty('code', 'USER_NOT_FOUND')
-            expect(clearMock).not.toHaveBeenCalled()
+            ).rejects.toHaveProperty('code', 'ACCOUNT_NOT_FOUND')
+        })
+
+        it('surfaces a keyring-fallback warning to stderr', async () => {
+            clearMock.mockResolvedValue({
+                account: { id: '111', email: 'a@b.c' },
+                wasDefault: false,
+            })
+            lastClearMock.mockReturnValue({
+                storage: 'config-file',
+                warning: 'Keyring unavailable; removed plaintext token instead.',
+            })
+            const errorSpy = mockConsoleError()
+
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'remove', '111'])
+
+            expect(errorSpy.mock.calls.flat().join('\n')).toContain('Keyring unavailable')
         })
     })
 })

--- a/src/commands/user/user.test.ts
+++ b/src/commands/user/user.test.ts
@@ -108,7 +108,7 @@ describe('user command', () => {
             expect(lines).toContain('default')
         })
 
-        it('streams one JSON value per console.log for --ndjson with stored accounts', async () => {
+        it('streams one JSON value per line for --ndjson with stored accounts', async () => {
             listMock.mockResolvedValue([
                 { account: { id: '1', email: 'a@b.c', auth_mode: 'read-write' }, isDefault: false },
                 { account: { id: '2', email: 'd@e.f', auth_mode: 'read-only' }, isDefault: true },
@@ -237,7 +237,7 @@ describe('user command', () => {
             mockReadConfig.mockResolvedValue({
                 config_version: 2,
                 user: { defaultUser: '111' },
-                users: [],
+                users: [{ id: '111', email: 'a@b.c' }],
             })
 
             await createProgram().parseAsync(['node', 'td', 'accounts', 'current'])
@@ -259,6 +259,28 @@ describe('user command', () => {
             })
             mockReadConfig.mockResolvedValue({
                 config_version: 2,
+                users: [{ id: '111', email: 'a@b.c' }],
+            })
+
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'current'])
+
+            expect(consoleSpy.mock.calls.flat().join('\n')).toContain('default')
+        })
+
+        it('ignores an orphaned defaultUser pointer and falls through to the sole account', async () => {
+            // `defaultUser` points at a removed account; the effective rule
+            // must drop the stale pin and treat the lone remaining account as
+            // default, matching `resolveActiveUser`'s fall-through.
+            mockResolveActiveUser.mockResolvedValue({
+                id: '111',
+                email: 'a@b.c',
+                token: 't',
+                authMode: 'read-write',
+                source: 'secure-store',
+            })
+            mockReadConfig.mockResolvedValue({
+                config_version: 2,
+                user: { defaultUser: '999' },
                 users: [{ id: '111', email: 'a@b.c' }],
             })
 

--- a/src/commands/user/user.test.ts
+++ b/src/commands/user/user.test.ts
@@ -1,17 +1,16 @@
-import { describeEmptyMachineOutput } from '@doist/cli-core/testing'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/auth.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../../lib/auth.js')>()
     return {
         ...actual,
-        listStoredUsers: vi.fn(),
         readConfig: vi.fn(),
         resolveActiveUser: vi.fn(),
     }
 })
 
 const setDefaultMock = vi.fn()
+const listMock = vi.fn()
 const clearMock = vi.fn()
 const lastClearMock = vi.fn<() => unknown>()
 vi.mock('../../lib/auth-store.js', async (importOriginal) => {
@@ -20,7 +19,7 @@ vi.mock('../../lib/auth-store.js', async (importOriginal) => {
         ...actual,
         createTodoistTokenStore: () => ({
             active: vi.fn(),
-            list: vi.fn().mockResolvedValue([]),
+            list: listMock,
             set: vi.fn(),
             setDefault: setDefaultMock,
             clear: clearMock,
@@ -32,12 +31,11 @@ vi.mock('../../lib/auth-store.js', async (importOriginal) => {
 
 vi.mock('chalk')
 
-import { listStoredUsers, readConfig, resolveActiveUser } from '../../lib/auth.js'
+import { readConfig, resolveActiveUser } from '../../lib/auth.js'
 import { mockConsoleError, mockConsoleLog } from '../../test-support/console-spy.js'
 import { createTestProgram } from '../../test-support/program.js'
 import { registerUserCommand } from './index.js'
 
-const mockListStoredUsers = vi.mocked(listStoredUsers)
 const mockReadConfig = vi.mocked(readConfig)
 const mockResolveActiveUser = vi.mocked(resolveActiveUser)
 
@@ -56,28 +54,53 @@ describe('user command', () => {
     })
 
     describe('list', () => {
-        describeEmptyMachineOutput('empty machine output contract', {
-            setup: () => {
-                mockListStoredUsers.mockResolvedValue([])
+        beforeEach(() => {
+            listMock.mockReset().mockResolvedValue([])
+        })
+
+        it.each([['user'], ['users']])(
+            'is reachable via the back-compat `%s` alias',
+            async (alias) => {
+                listMock.mockResolvedValue([
+                    { account: { id: '1', email: 'a@b.c' }, isDefault: true },
+                ])
+
+                await createProgram().parseAsync(['node', 'td', alias, 'list'])
+
+                expect(consoleSpy.mock.calls.flat().join('\n')).toContain('a@b.c')
             },
-            run: async (extraArgs) => {
-                await createProgram().parseAsync(['node', 'td', 'user', 'list', ...extraArgs])
-            },
-            humanMessage: /No stored Todoist accounts/,
+        )
+
+        describe('empty machine output', () => {
+            it('emits an empty {accounts, default} envelope for --json', async () => {
+                await createProgram().parseAsync(['node', 'td', 'accounts', 'list', '--json'])
+
+                const payload = JSON.parse(consoleSpy.mock.calls[0][0] as string)
+                expect(payload).toEqual({ accounts: [], default: null })
+            })
+
+            it('emits nothing for --ndjson', async () => {
+                await createProgram().parseAsync(['node', 'td', 'accounts', 'list', '--ndjson'])
+
+                expect(consoleSpy).not.toHaveBeenCalled()
+            })
+
+            it('prints the empty-state message in human mode', async () => {
+                await createProgram().parseAsync(['node', 'td', 'accounts', 'list'])
+
+                expect(consoleSpy.mock.calls.flat().join('\n')).toMatch(
+                    /No stored Todoist accounts/,
+                )
+            })
         })
 
         it('marks the default user', async () => {
-            mockListStoredUsers.mockResolvedValue([
-                { id: '1', email: 'a@b.c' },
-                { id: '2', email: 'd@e.f' },
+            listMock.mockResolvedValue([
+                { account: { id: '1', email: 'a@b.c' }, isDefault: false },
+                { account: { id: '2', email: 'd@e.f' }, isDefault: true },
             ])
-            mockReadConfig.mockResolvedValue({
-                config_version: 2,
-                user: { defaultUser: '2' },
-                users: [],
-            })
 
-            await createProgram().parseAsync(['node', 'td', 'user', 'list'])
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'list'])
 
             const lines = consoleSpy.mock.calls.flat().join('\n')
             expect(lines).toContain('a@b.c')
@@ -85,59 +108,49 @@ describe('user command', () => {
             expect(lines).toContain('default')
         })
 
-        it('emits one JSON value per line for --ndjson with stored accounts', async () => {
-            mockListStoredUsers.mockResolvedValue([
-                { id: '1', email: 'a@b.c', auth_mode: 'read-write' },
-                { id: '2', email: 'd@e.f', auth_mode: 'read-only' },
+        it('streams one JSON value per console.log for --ndjson with stored accounts', async () => {
+            listMock.mockResolvedValue([
+                { account: { id: '1', email: 'a@b.c', auth_mode: 'read-write' }, isDefault: false },
+                { account: { id: '2', email: 'd@e.f', auth_mode: 'read-only' }, isDefault: true },
             ])
-            mockReadConfig.mockResolvedValue({
-                config_version: 2,
-                user: { defaultUser: '2' },
-                users: [],
-            })
 
-            await createProgram().parseAsync(['node', 'td', 'user', 'list', '--ndjson'])
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'list', '--ndjson'])
 
-            const output = consoleSpy.mock.calls[0][0] as string
-            const lines = output.split('\n')
-            expect(lines).toHaveLength(2)
-            const first = JSON.parse(lines[0])
-            const second = JSON.parse(lines[1])
+            expect(consoleSpy).toHaveBeenCalledTimes(2)
+            const first = JSON.parse(consoleSpy.mock.calls[0][0] as string)
+            const second = JSON.parse(consoleSpy.mock.calls[1][0] as string)
             expect(first).toMatchObject({ id: '1', email: 'a@b.c', isDefault: false })
             expect(second).toMatchObject({ id: '2', email: 'd@e.f', isDefault: true })
-            expect(output.endsWith('\n')).toBe(false) // no trailing newline within payload
         })
 
-        it('outputs JSON when --json given', async () => {
-            mockListStoredUsers.mockResolvedValue([
-                { id: '1', email: 'a@b.c', auth_mode: 'read-write' },
+        it('outputs a {accounts, default} envelope when --json given', async () => {
+            listMock.mockResolvedValue([
+                { account: { id: '1', email: 'a@b.c', auth_mode: 'read-write' }, isDefault: true },
             ])
-            mockReadConfig.mockResolvedValue({
-                config_version: 2,
-                user: { defaultUser: '1' },
-                users: [],
-            })
 
-            await createProgram().parseAsync(['node', 'td', 'user', 'list', '--json'])
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'list', '--json'])
 
             const payload = JSON.parse(consoleSpy.mock.calls[0][0] as string)
-            expect(payload).toEqual([
-                {
-                    id: '1',
-                    email: 'a@b.c',
-                    isDefault: true,
-                    authMode: 'read-write',
-                    authScope: undefined,
-                    authFlags: undefined,
-                    storage: 'secure-store',
-                },
-            ])
+            expect(payload).toEqual({
+                accounts: [
+                    {
+                        id: '1',
+                        email: 'a@b.c',
+                        isDefault: true,
+                        authMode: 'read-write',
+                    },
+                ],
+                default: '1',
+            })
         })
     })
 
     describe('use', () => {
         beforeEach(() => {
             setDefaultMock.mockReset().mockResolvedValue(undefined)
+            // The attacher re-reads `store.list()` after `setDefault` to
+            // resolve the canonical default id for `--json` output.
+            listMock.mockReset().mockResolvedValue([])
         })
 
         it('sets the default user by id', async () => {
@@ -146,7 +159,7 @@ describe('user command', () => {
                 users: [{ id: '111', email: 'a@b.c' }],
             })
 
-            await createProgram().parseAsync(['node', 'td', 'user', 'use', '111'])
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'use', '111'])
 
             expect(setDefaultMock).toHaveBeenCalledWith('111')
         })
@@ -162,7 +175,7 @@ describe('user command', () => {
             )
 
             await expect(
-                createProgram().parseAsync(['node', 'td', 'user', 'use', 'nope']),
+                createProgram().parseAsync(['node', 'td', 'accounts', 'use', 'nope']),
             ).rejects.toHaveProperty('code', 'ACCOUNT_NOT_FOUND')
         })
 
@@ -172,7 +185,7 @@ describe('user command', () => {
                 users: [{ id: '111', email: 'a@b.c' }],
             })
 
-            await createProgram().parseAsync(['node', 'td', 'user', 'default', '111'])
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'default', '111'])
 
             expect(setDefaultMock).toHaveBeenCalledWith('111')
         })
@@ -193,7 +206,7 @@ describe('user command', () => {
                 users: [],
             })
 
-            await createProgram().parseAsync(['node', 'td', 'user', 'current'])
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'current'])
 
             const out = consoleSpy.mock.calls.flat().join('\n')
             expect(out).toContain('a@b.c')
@@ -209,7 +222,7 @@ describe('user command', () => {
                 source: 'env',
             })
 
-            await createProgram().parseAsync(['node', 'td', 'user', 'current'])
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'current'])
 
             const out = consoleSpy.mock.calls.flat().join('\n')
             expect(out).toContain('TODOIST_API_TOKEN')
@@ -229,7 +242,7 @@ describe('user command', () => {
                 users: [{ id: '111', email: 'a@b.c' }],
             })
 
-            await createProgram().parseAsync(['node', 'td', 'user', 'remove', '111'])
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'remove', '111'])
 
             expect(clearMock).toHaveBeenCalledWith('111')
             expect(consoleSpy.mock.calls.flat().join('\n')).toContain('Cleared default')
@@ -242,7 +255,7 @@ describe('user command', () => {
             })
 
             await expect(
-                createProgram().parseAsync(['node', 'td', 'user', 'remove', 'nope']),
+                createProgram().parseAsync(['node', 'td', 'accounts', 'remove', 'nope']),
             ).rejects.toHaveProperty('code', 'USER_NOT_FOUND')
             expect(clearMock).not.toHaveBeenCalled()
         })

--- a/src/commands/user/user.test.ts
+++ b/src/commands/user/user.test.ts
@@ -265,6 +265,21 @@ describe('user command', () => {
             })
         })
 
+        it('reports the account source annotated by the store (config-file fallback)', async () => {
+            // The adapter's `activeAccount` annotates the resolved account with
+            // its real token source; `current --json` surfaces it verbatim.
+            activeAccountMock.mockResolvedValue({
+                account: { id: '111', email: 'a@b.c', source: 'config-file' },
+                isDefault: true,
+            })
+
+            await createProgram().parseAsync(['node', 'td', 'accounts', 'current', '--json'])
+
+            expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toMatchObject({
+                source: 'config-file',
+            })
+        })
+
         it('says env when running on TODOIST_API_TOKEN', async () => {
             // env short-circuits `activeAccount` (-> null), so `current` falls
             // through to the resolver, which reports the env source.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { stripUserFlag } from '@doist/cli-core'
 import { type Command, program } from 'commander'
 import packageJson from '../package.json' with { type: 'json' }
+import { ACCOUNT_COMMAND_ALIASES } from './commands/user/aliases.js'
 import { BaseCliError, CliError } from './lib/errors.js'
 import { getRequestedUserRef, isJsonMode, isNdjsonMode, isRawMode } from './lib/global-args.js'
 import { initializeLogger } from './lib/logger.js'
@@ -128,7 +129,7 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>, str
     accounts: [
         'Manage stored Todoist accounts (multi-user)',
         async () => (await import('./commands/user/index.js')).registerUserCommand,
-        ['user', 'users'],
+        ACCOUNT_COMMAND_ALIASES,
     ],
     apps: [
         'Manage your registered Todoist developer apps',

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ program
     .option('-q, --quiet', 'Suppress success messages (create commands still print the ID)')
     .option(
         '--user <ref>',
-        'Run as a specific stored Todoist account (id or email). See `td user list`.',
+        'Run as a specific stored Todoist account (id or email). See `td accounts list`.',
     )
     .addHelpText(
         'after',
@@ -47,8 +47,8 @@ Note for AI/LLM agents:
   Use --user <id|email> on any command to act as a specific stored account.`,
     )
 
-// Lazy command registry: [description, loader]
-const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = {
+// Lazy command registry: [description, loader, aliases?]
+const commands: Record<string, [string, () => Promise<(p: Command) => void>, string[]?]> = {
     add: [
         'Quick add task with natural language (e.g., "Buy milk tomorrow p1 #Shopping")',
         async () => (await import('./commands/add.js')).registerAddCommand,
@@ -125,9 +125,10 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
         'Manage authentication',
         async () => (await import('./commands/auth/index.js')).registerAuthCommand,
     ],
-    user: [
+    accounts: [
         'Manage stored Todoist accounts (multi-user)',
         async () => (await import('./commands/user/index.js')).registerUserCommand,
+        ['user', 'users'],
     ],
     apps: [
         'Manage your registered Todoist developer apps',
@@ -184,9 +185,18 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
     ],
 }
 
+// Map every command token (canonical name + aliases) to its canonical key, so
+// the lazy dispatcher and completion can resolve an alias back to its loader.
+const commandAliases: Record<string, string> = {}
+for (const [name, [, , aliases]] of Object.entries(commands)) {
+    commandAliases[name] = name
+    for (const alias of aliases ?? []) commandAliases[alias] = name
+}
+
 // Register placeholders so --help lists all commands
-for (const [name, [description]] of Object.entries(commands)) {
-    program.command(name).description(description)
+for (const [name, [description, , aliases]] of Object.entries(commands)) {
+    const placeholder = program.command(name).description(description)
+    if (aliases) placeholder.aliases(aliases)
 }
 
 program.hook('preAction', (_thisCommand, actionCommand) => {
@@ -215,7 +225,7 @@ program.hook('preAction', (_thisCommand, actionCommand) => {
             reportUserFlagError('--user requires a value: <id|email>.', [
                 'Example: td --user scott@doist.com task list',
             ])
-        } else if (Object.hasOwn(commands, ref)) {
+        } else if (Object.hasOwn(commandAliases, ref)) {
             reportUserFlagError(
                 `--user requires a value: <id|email>. Got "${ref}", which looks like a subcommand — did you forget the value?`,
                 [`Example: td --user scott@doist.com ${ref}`],
@@ -231,7 +241,8 @@ program.hook('preAction', (_thisCommand, actionCommand) => {
 if (process.argv[2] === 'completion-server') {
     const { parseCompLine } = await import('./lib/completion.js')
     const compWords = parseCompLine(process.env.COMP_LINE ?? '')
-    const compCmd = compWords.find((w) => !w.startsWith('-') && w in commands)
+    const compToken = compWords.find((w) => !w.startsWith('-') && w in commandAliases)
+    const compCmd = compToken ? commandAliases[compToken] : undefined
 
     const toLoad = ['completion', ...(compCmd && compCmd !== 'completion' ? [compCmd] : [])]
     for (const name of toLoad) {
@@ -247,7 +258,10 @@ if (process.argv[2] === 'completion-server') {
 } else {
     // Find which command (if any) is being invoked — match only known command names
     // to avoid treating option values (e.g. --progress-jsonl /tmp/out) as commands
-    const commandName = process.argv.slice(2).find((a) => !a.startsWith('-') && a in commands)
+    const commandToken = process.argv
+        .slice(2)
+        .find((a) => !a.startsWith('-') && a in commandAliases)
+    const commandName = commandToken ? commandAliases[commandToken] : undefined
 
     if (commandName && commands[commandName]) {
         // Remove placeholder, load real command module, register it

--- a/src/lib/auth-store.ts
+++ b/src/lib/auth-store.ts
@@ -95,5 +95,10 @@ export function createTodoistTokenStore(): TodoistTokenStore {
     return Object.assign(Object.create(inner) as TodoistTokenStore, {
         active: async (ref?: AccountRef) => (envTokenSet() ? null : inner.active(ref)),
         activeBundle: async (ref?: AccountRef) => (envTokenSet() ? null : inner.activeBundle(ref)),
+        // `accounts current` resolves through `activeAccount`; short-circuit it
+        // on the env token too so env wins over a stored default (it routes to
+        // the command's `onNotAuthenticated` env branch), matching `active`.
+        activeAccount: async (ref?: AccountRef) =>
+            envTokenSet() ? null : inner.activeAccount(ref),
     })
 }

--- a/src/lib/auth-store.ts
+++ b/src/lib/auth-store.ts
@@ -4,9 +4,9 @@ import {
     createKeyringTokenStore,
     type KeyringTokenStore,
 } from '@doist/cli-core/auth'
-import { type AuthFlag, type AuthMode, getConfigPath } from './config.js'
+import { type AuthFlag, type AuthMode, getConfigPath, readConfig } from './config.js'
 import { createTodoistUserRecordStore } from './user-records.js'
-import { matchUserRef } from './users.js'
+import { getStoredUsers, matchUserRef } from './users.js'
 
 /**
  * Persisted identifiers for the keyring/config ABI. Shared with the read-side
@@ -98,7 +98,19 @@ export function createTodoistTokenStore(): TodoistTokenStore {
         // `accounts current` resolves through `activeAccount`; short-circuit it
         // on the env token too so env wins over a stored default (it routes to
         // the command's `onNotAuthenticated` env branch), matching `active`.
-        activeAccount: async (ref?: AccountRef) =>
-            envTokenSet() ? null : inner.activeAccount(ref),
+        activeAccount: async (ref?: AccountRef) => {
+            if (envTokenSet()) return null
+            const resolved = await inner.activeAccount(ref)
+            if (!resolved) return null
+            // Annotate the token source so `accounts current --json` reports it
+            // accurately: a per-user `api_token` means the plaintext config-file
+            // fallback, otherwise the secure store. Only `current` consumes
+            // `activeAccount`, so this doesn't leak into `accounts list`.
+            const stored = getStoredUsers(await readConfig()).find(
+                (u) => u.id === resolved.account.id,
+            )
+            const source = stored?.api_token ? 'config-file' : 'secure-store'
+            return { ...resolved, account: { ...resolved.account, source } }
+        },
     })
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -17,7 +17,13 @@ import { accountForUser, SERVICE_NAME, TOKEN_ENV_VAR } from './auth-store.js'
 import { type AuthFlag, type AuthMode, readConfig, type StoredUser } from './config.js'
 import { CliError } from './errors.js'
 import { getRequestedUserRef } from './global-args.js'
-import { findUserByRef, getStoredUsers, NoUserSelectedError, UserNotFoundError } from './users.js'
+import {
+    findUserByRef,
+    getEffectiveDefaultUser,
+    getStoredUsers,
+    NoUserSelectedError,
+    UserNotFoundError,
+} from './users.js'
 
 export { TOKEN_ENV_VAR } from './auth-store.js'
 
@@ -76,7 +82,9 @@ export async function resolveActiveUser(opts: { ref?: string } = {}): Promise<Re
         throw ref ? new UserNotFoundError(ref) : new NoTokenError()
     }
 
-    const target = ref ? (findUserByRef(config, ref)?.user ?? null) : pickDefault(config, users)
+    const target = ref
+        ? (findUserByRef(config, ref)?.user ?? null)
+        : (getEffectiveDefaultUser(config) ?? null)
     if (!target) {
         // ref miss when records exist, or multi-user no-default.
         throw ref ? new UserNotFoundError(ref) : new NoUserSelectedError()
@@ -92,19 +100,6 @@ export async function resolveActiveUser(opts: { ref?: string } = {}): Promise<Re
         authFlags: target.auth_flags,
         source,
     }
-}
-
-function pickDefault(
-    config: { user?: { defaultUser?: string } },
-    users: StoredUser[],
-): StoredUser | null {
-    const defaultId = config.user?.defaultUser
-    if (defaultId) {
-        const found = users.find((u) => u.id === defaultId)
-        if (found) return found
-        // Default points at a missing user — fall through to single-user fallback.
-    }
-    return users.length === 1 ? users[0] : null
 }
 
 /** Bearer-only shortcut. Most call sites (SDK, uploads, stats) only need this. */

--- a/src/lib/completion.test.ts
+++ b/src/lib/completion.test.ts
@@ -191,6 +191,26 @@ describe('getCompletions', () => {
             const commandNames = names(result)
             expect(commandNames).toContain('update')
         })
+
+        it('suggests command aliases alongside the canonical name', () => {
+            const program = new Command()
+            program.name('td')
+            const accounts = program
+                .command('accounts')
+                .aliases(['user', 'users'])
+                .description('Manage stored accounts')
+            accounts.command('use <ref>').alias('default').description('Set the default account')
+
+            const top = names(getCompletions(program, [''], ''))
+            expect(top).toEqual(expect.arrayContaining(['accounts', 'user', 'users']))
+
+            const sub = names(getCompletions(program, ['accounts', ''], ''))
+            expect(sub).toEqual(expect.arrayContaining(['use', 'default']))
+
+            const byPrefix = names(getCompletions(program, ['accounts', 'def'], 'def'))
+            expect(byPrefix).toContain('default')
+            expect(byPrefix).not.toContain('use')
+        })
     })
 
     describe('options', () => {

--- a/src/lib/completion.ts
+++ b/src/lib/completion.ts
@@ -193,17 +193,22 @@ export function getCompletions(
 }
 
 function getSubcommandCompletions(cmd: Command, prefix: string): CompletionItem[] {
-    return cmd.commands
-        .filter(
-            (c: Command) =>
-                !(c as Command & { _hidden?: boolean })._hidden &&
-                !HIDDEN_COMMAND_NAMES.has(c.name()),
-        )
-        .filter((c: Command) => c.name().startsWith(prefix))
-        .map((c: Command) => ({
-            name: c.name(),
-            description: c.description(),
-        }))
+    return (
+        cmd.commands
+            .filter(
+                (c: Command) =>
+                    !(c as Command & { _hidden?: boolean })._hidden &&
+                    !HIDDEN_COMMAND_NAMES.has(c.name()),
+            )
+            // Emit the canonical name and every alias as separate candidates, so a
+            // renamed command's back-compat aliases (e.g. `accounts` → `user`) and
+            // subcommand aliases (e.g. `use` → `default`) still tab-complete.
+            .flatMap((c: Command) =>
+                [c.name(), ...c.aliases()]
+                    .filter((name) => name.startsWith(prefix))
+                    .map((name) => ({ name, description: c.description() })),
+            )
+    )
 }
 
 function getOptionCompletions(

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -68,17 +68,19 @@ Tokens are stored in the OS credential manager when available, with fallback to 
 The CLI can hold credentials for multiple Todoist accounts at once.
 
 \`\`\`bash
-td auth login                       # adds the account; first one becomes default
-td user list                        # all stored accounts (with default marker)
-td user list --json                 # array of accounts with auth metadata (--ndjson also supported)
-td user use <id|email>              # set the default account (alias: td user default)
-td user current                     # show the active account
-td user remove <id|email>           # delete an account (and its token)
-td --user <id|email> task list      # one-off override for any command
-td auth logout --user <id|email>    # log out a specific account
+td auth login                          # adds the account; first one becomes default
+td accounts list                       # all stored accounts (with default marker)
+td accounts list --json                # { accounts: [...], default } envelope; --ndjson streams one account per line
+td accounts use <id|email>             # set the default account (alias: td accounts default; --json/--ndjson supported)
+td accounts current                    # show the active account
+td accounts remove <id|email>          # delete an account (and its token)
+td --user <id|email> task list         # one-off override for any command
+td auth logout --user <id|email>       # log out a specific account
 \`\`\`
 
-Resolution order: \`--user <ref>\` > \`user.defaultUser\` from config > the only stored account. With multiple accounts and no default, commands error and ask for \`--user\` (or \`td user use\`). \`<ref>\` matches an exact id or email (case-insensitive on email). \`TODOIST_API_TOKEN\` still bypasses the resolver entirely.
+\`td accounts\` is also available as \`td user\` / \`td users\` (back-compat aliases).
+
+Resolution order: \`--user <ref>\` > \`user.defaultUser\` from config > the only stored account. With multiple accounts and no default, commands error and ask for \`--user\` (or \`td accounts use\`). \`<ref>\` matches an exact id or email (case-insensitive on email). \`TODOIST_API_TOKEN\` still bypasses the resolver entirely.
 
 ## Quick Reference
 
@@ -91,7 +93,7 @@ Resolution order: \`--user <ref>\` > \`user.defaultUser\` from config > the only
 - Collaboration: \`td comment ...\`, \`td notification ...\`, \`td reminder ...\`
 - Templates and files: \`td template ...\`, \`td attachment view <file-url>\`, \`td backup ...\`
 - Help Center: \`td hc locales/search/view\`
-- Account and tooling: \`td stats\`, \`td settings ...\`, \`td config view\`, \`td user ...\`, \`td completion ...\`, \`td view <todoist-url>\`, \`td doctor\`, \`td update\`, \`td changelog\`
+- Account and tooling: \`td stats\`, \`td settings ...\`, \`td config view\`, \`td accounts ...\`, \`td completion ...\`, \`td view <todoist-url>\`, \`td doctor\`, \`td update\`, \`td changelog\`
 - Developer apps: \`td apps list/view\` (requires \`td auth login --additional-scopes=app-management\`)
 - Backups: \`td backup list/download\` (requires \`td auth login --additional-scopes=backups\`)
 - Billing: \`td billing subscription/plan/prices/pricing\` (requires \`td auth login --additional-scopes=billing\`)

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -72,8 +72,8 @@ td auth login                          # adds the account; first one becomes def
 td accounts list                       # all stored accounts (with default marker)
 td accounts list --json                # { accounts: [...], default } envelope; --ndjson streams one account per line
 td accounts use <id|email>             # set the default account (alias: td accounts default; --json/--ndjson supported)
-td accounts current                    # show the active account
-td accounts remove <id|email>          # delete an account (and its token)
+td accounts current                    # show the active account (--json/--ndjson supported)
+td accounts remove <id|email>          # delete an account and its token (--json/--ndjson supported)
 td --user <id|email> task list         # one-off override for any command
 td auth logout --user <id|email>       # log out a specific account
 \`\`\`

--- a/src/lib/users.test.ts
+++ b/src/lib/users.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import type { Config } from './config.js'
+import { getEffectiveDefaultUser, getEffectiveDefaultUserId } from './users.js'
+
+describe('getEffectiveDefaultUser', () => {
+    it('returns the pinned default when it resolves to a stored account', () => {
+        const config: Config = {
+            users: [
+                { id: '1', email: 'a@b.c' },
+                { id: '2', email: 'd@e.f' },
+            ],
+            user: { defaultUser: '2' },
+        }
+        expect(getEffectiveDefaultUser(config)?.id).toBe('2')
+        expect(getEffectiveDefaultUserId(config)).toBe('2')
+    })
+
+    it('falls through an orphaned pin to the sole stored account', () => {
+        const config: Config = {
+            users: [{ id: '1', email: 'a@b.c' }],
+            user: { defaultUser: '999' },
+        }
+        expect(getEffectiveDefaultUserId(config)).toBe('1')
+    })
+
+    it('treats a lone account as default with no pin', () => {
+        expect(getEffectiveDefaultUserId({ users: [{ id: '1', email: 'a@b.c' }] })).toBe('1')
+    })
+
+    it('returns undefined for multiple accounts with no usable pin', () => {
+        const users = [
+            { id: '1', email: 'a@b.c' },
+            { id: '2', email: 'd@e.f' },
+        ]
+        expect(getEffectiveDefaultUser({ users })).toBeUndefined()
+        // Orphaned pin with multiple accounts → no implicit default either.
+        expect(getEffectiveDefaultUserId({ users, user: { defaultUser: '999' } })).toBeUndefined()
+    })
+
+    it('returns undefined when no accounts are stored', () => {
+        expect(getEffectiveDefaultUserId({})).toBeUndefined()
+    })
+})

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -5,8 +5,10 @@ export class UserNotFoundError extends CliError {
     constructor(ref: string) {
         super(
             'USER_NOT_FOUND',
-            `No stored user matches "${ref}". Use \`td user list\` to see authenticated accounts.`,
-            ['Run `td auth login` to add an account, or `td user list` to inspect existing ones'],
+            `No stored user matches "${ref}". Use \`td accounts list\` to see authenticated accounts.`,
+            [
+                'Run `td auth login` to add an account, or `td accounts list` to inspect existing ones',
+            ],
             'info',
         )
         this.name = 'UserNotFoundError'
@@ -20,7 +22,7 @@ export class NoUserSelectedError extends CliError {
             'Multiple Todoist accounts are stored. Specify which one to use.',
             [
                 'Pass `--user <id|email>` on the command, or',
-                'Set a default with `td user use <id|email>`',
+                'Set a default with `td accounts use <id|email>`',
             ],
             'info',
         )

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -4,8 +4,8 @@ import { CliError } from './errors.js'
 export class UserNotFoundError extends CliError {
     constructor(ref: string) {
         super(
-            'USER_NOT_FOUND',
-            `No stored user matches "${ref}". Use \`td accounts list\` to see authenticated accounts.`,
+            'ACCOUNT_NOT_FOUND',
+            `No stored account matches "${ref}". Use \`td accounts list\` to see authenticated accounts.`,
             [
                 'Run `td auth login` to add an account, or `td accounts list` to inspect existing ones',
             ],
@@ -40,24 +40,15 @@ export function getDefaultUserId(config: Config): string | undefined {
 
 /**
  * The account that resolves as default when no `--user` is given: the pinned
- * `defaultUser`, or — when nothing is pinned — the sole stored account (a lone
- * account is implicitly default). Mirrors cli-core's `TokenStore.list()`
- * effective-default rule so the `(default)` marker is identical across
- * `accounts list`, `accounts current`, `auth status`, and `config view`.
- *
- * `getDefaultUserId` (the raw pinned pointer) is still the right call where the
- * pin itself matters — e.g. `accounts remove` deciding whether it cleared a
- * pin, or `doctor` diagnosing whether the pin resolves.
- */
-/**
- * The account that resolves as default when no `--user` is given: the pinned
  * `defaultUser` when it points at a stored account, otherwise — falling through
  * an orphaned pin — the sole stored account (a lone account is implicitly
  * default), or `undefined` when neither applies.
  *
  * Single source of truth for the default-selection rule: `resolveActiveUser`
  * (`auth.ts`) and `getEffectiveDefaultUserId` both call this so the active-user
- * resolver and the `(default)` marker can't drift.
+ * resolver and the `(default)` marker can't drift. `getDefaultUserId` (the raw
+ * pinned pointer) is still the right call where the pin itself matters — e.g.
+ * `doctor` diagnosing whether the pin resolves.
  */
 export function getEffectiveDefaultUser(config: Config): StoredUser | undefined {
     const users = getStoredUsers(config)

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -49,16 +49,29 @@ export function getDefaultUserId(config: Config): string | undefined {
  * pin itself matters — e.g. `accounts remove` deciding whether it cleared a
  * pin, or `doctor` diagnosing whether the pin resolves.
  */
-export function getEffectiveDefaultUserId(config: Config): string | undefined {
+/**
+ * The account that resolves as default when no `--user` is given: the pinned
+ * `defaultUser` when it points at a stored account, otherwise — falling through
+ * an orphaned pin — the sole stored account (a lone account is implicitly
+ * default), or `undefined` when neither applies.
+ *
+ * Single source of truth for the default-selection rule: `resolveActiveUser`
+ * (`auth.ts`) and `getEffectiveDefaultUserId` both call this so the active-user
+ * resolver and the `(default)` marker can't drift.
+ */
+export function getEffectiveDefaultUser(config: Config): StoredUser | undefined {
     const users = getStoredUsers(config)
     const pinned = getDefaultUserId(config)
-    // A pinned pointer only counts when it resolves to a stored account —
-    // mirrors `resolveActiveUser`, which ignores an orphaned `defaultUser` and
-    // falls through to the sole stored account. Returning a stale id here would
-    // put `accounts current` / `auth status` back out of sync on a config whose
-    // `defaultUser` points at a removed account.
-    if (pinned && users.some((u) => u.id === pinned)) return pinned
-    return users.length === 1 ? users[0]!.id : undefined
+    if (pinned) {
+        const found = users.find((u) => u.id === pinned)
+        if (found) return found
+        // Pinned pointer is orphaned — fall through to the sole-account rule.
+    }
+    return users.length === 1 ? users[0] : undefined
+}
+
+export function getEffectiveDefaultUserId(config: Config): string | undefined {
+    return getEffectiveDefaultUser(config)?.id
 }
 
 /**

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -39,6 +39,24 @@ export function getDefaultUserId(config: Config): string | undefined {
 }
 
 /**
+ * The account that resolves as default when no `--user` is given: the pinned
+ * `defaultUser`, or — when nothing is pinned — the sole stored account (a lone
+ * account is implicitly default). Mirrors cli-core's `TokenStore.list()`
+ * effective-default rule so the `(default)` marker is identical across
+ * `accounts list`, `accounts current`, `auth status`, and `config view`.
+ *
+ * `getDefaultUserId` (the raw pinned pointer) is still the right call where the
+ * pin itself matters — e.g. `accounts remove` deciding whether it cleared a
+ * pin, or `doctor` diagnosing whether the pin resolves.
+ */
+export function getEffectiveDefaultUserId(config: Config): string | undefined {
+    const pinned = getDefaultUserId(config)
+    if (pinned) return pinned
+    const users = getStoredUsers(config)
+    return users.length === 1 ? users[0]!.id : undefined
+}
+
+/**
  * Single source of truth for `--user <ref>` matching: exact id, or
  * case-insensitive email. Both `findUserByRef` (config-driven path) and
  * `auth-store.ts`'s cli-core `matchAccount` (keyring-store path) delegate

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -50,9 +50,14 @@ export function getDefaultUserId(config: Config): string | undefined {
  * pin, or `doctor` diagnosing whether the pin resolves.
  */
 export function getEffectiveDefaultUserId(config: Config): string | undefined {
-    const pinned = getDefaultUserId(config)
-    if (pinned) return pinned
     const users = getStoredUsers(config)
+    const pinned = getDefaultUserId(config)
+    // A pinned pointer only counts when it resolves to a stored account —
+    // mirrors `resolveActiveUser`, which ignores an orphaned `defaultUser` and
+    // falls through to the sole stored account. Returning a stale id here would
+    // put `accounts current` / `auth status` back out of sync on a config whose
+    // `defaultUser` points at a removed account.
+    if (pinned && users.some((u) => u.id === pinned)) return pinned
     return users.length === 1 ? users[0]!.id : undefined
 }
 


### PR DESCRIPTION
## Summary
- Rename the top-level `td user` command group to `td accounts`, keeping `user` and `users` as non-breaking aliases (wired through the lazy command dispatcher; tab-completion suggests all three).
- Move **all four** account subcommands onto cli-core's generic attachers, so they run on the `TokenStore` contract instead of hand-rolled logic:
  - `accounts list` → `attachAccountListCommand`
  - `accounts use` / `default` → `attachAccountUseCommand`
  - `accounts current` → `attachAccountCurrentCommand`
  - `accounts remove` → `attachAccountRemoveCommand`
- Unify the "default account" rule (`getEffectiveDefaultUserId`) across `auth status` and `config view` (the `list`/`current` markers come from the store directly).
- Update user-facing hints across the CLI to point at `td accounts …`.

## cli-core dependency
Requires **@doist/cli-core 0.23.0** (now pinned) — the release containing all four account attachers plus the `TokenStore` contract changes (`clear()` returns `ClearedAccount`, new optional `activeAccount()`).

## Behavior changes
- **`accounts list --json`/`--ndjson`**: cli-core's `{ accounts, default }` envelope (per-account entries keep the existing camelCase fields). The `storage` field is dropped (`store.list()` has no token-source info); empty `--json` is `{"accounts":[],"default":null}`.
- **`accounts current`**: output preserved (stored account renders with accurate `source`; env/legacy via `onNotAuthenticated`). Gains `--ndjson`. An `activeAccount` env-override is added to the store adapter so `TODOIST_API_TOKEN` still wins over a stored default.
- **`accounts remove`**: `store.clear(ref)` resolves + deletes by canonical id and reports `wasDefault` (token-free, so a broken keyring entry stays removable). Gains `--json` (`{ ok, removed }`) / silent `--ndjson`; human output and the keyring-fallback warning preserved.
- **`accounts use` / `remove`**: don't honor `--quiet` and use Commander's required-arg error for a missing `<ref>` — both are cli-core-wide attacher behaviors (also true of `auth login`/`logout`/`status`); proper fixes belong in cli-core's `emitView`.
- **Aliases**: `td user …` and `td users …` continue to work unchanged.

## Versioning
The `accounts list --json` reshape is an intentional, low-impact change to a niche list-users machine surface; shipping as a minor `feat` (not `BREAKING CHANGE`).

## Test plan
- [x] `npm run type-check`
- [x] `npm test` (1654 pass)
- [x] `npm run check` (oxlint + oxfmt)
- [x] `check:skill-sync`
- [x] Smoke-tested `accounts list/current/remove` (+ `--json`/`--ndjson`, env-token path) and the `user`/`users` aliases against the linked cli-core build