### PR TITLE
feat(project): add `project share` to invite a collaborator

### DIFF
--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -90,7 +90,7 @@ Resolution order: `--user <ref>` > `user.defaultUser` from config > the only sto
 
 - Daily views: `td today`, `td inbox`, `td upcoming`, `td completed`, `td activity`
 - Task lifecycle: `td task list/view/add/quickadd/update/reschedule/move/complete/uncomplete/delete/browse` (alias: `td task qa` for `quickadd`)
-- Projects: `td project list/view/create/update/archive/unarchive/archived/delete/move/reorder/join/browse/collaborators/permissions`
+- Projects: `td project list/view/create/update/archive/unarchive/archived/delete/move/reorder/join/share/browse/collaborators/permissions`
 - Project analytics: `td project progress/health/health-context/activity-stats/analyze-health`
 - Goals: `td goal list/view/create/update/delete/complete/uncomplete/link/unlink`
 - Organization: `td label ...`, `td filter ...`, `td section ...`, `td folder ...`, `td workspace ...`
@@ -178,6 +178,8 @@ td project archive "Roadmap"
 td project unarchive "Roadmap"
 td project move "Roadmap" --to-workspace "Acme" --folder "Engineering" --visibility team --yes
 td project join id:abc123
+td project share "Roadmap" alice@example.com
+td project share "Team Plan" bob@example.com --role guest --auto-invite
 td project delete "Roadmap" --yes
 td project progress "Roadmap"
 td project health "Roadmap"

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -179,6 +179,10 @@ td project unarchive "Roadmap"
 td project move "Roadmap" --to-workspace "Acme" --folder "Engineering" --visibility team --yes
 td project join id:abc123
 td project share "Roadmap" alice@example.com
+td project share --project "Roadmap" alice@example.com
+td project share "Roadmap" alice@example.com --message "Join the planning"
+td project share "Roadmap" alice@example.com --json
+td project share "Roadmap" alice@example.com --dry-run
 td project share "Team Plan" bob@example.com --role guest --auto-invite
 td project delete "Roadmap" --yes
 td project progress "Roadmap"

--- a/src/commands/project/index.ts
+++ b/src/commands/project/index.ts
@@ -20,6 +20,7 @@ import { moveProject } from './move.js'
 import { showPermissions } from './permissions.js'
 import { showProjectProgress } from './progress.js'
 import { reorderProject } from './reorder.js'
+import { shareProject } from './share.js'
 import { unarchiveProject } from './unarchive.js'
 import { updateProject } from './update.js'
 import { viewProject } from './view.js'
@@ -255,6 +256,31 @@ Examples:
         .option('--dry-run', 'Preview what would happen without executing')
         .action((id, options) => {
             return joinProjectCmd(id, options)
+        })
+
+    project
+        .command('share <ref> <email>')
+        .description('Invite a collaborator to a project')
+        .option(
+            '--role <role>',
+            'Workspace role: guest, member, or admin (workspace projects only; default: member)',
+        )
+        .option('--message <msg>', 'Optional invitation message')
+        .option(
+            '--auto-invite',
+            'If the email is not yet a workspace member, invite them to the workspace first (workspace projects only)',
+        )
+        .option('--json', 'Output the result as JSON')
+        .option('--dry-run', 'Preview what would happen without executing')
+        .addHelpText(
+            'after',
+            `
+Examples:
+  td project share "Roadmap" alice@example.com
+  td project share "Team Plan" bob@example.com --role guest --auto-invite`,
+        )
+        .action((ref, email, options) => {
+            return shareProject(ref, email, options)
         })
 
     const progressCmd = project

--- a/src/commands/project/index.ts
+++ b/src/commands/project/index.ts
@@ -260,12 +260,17 @@ Examples:
         })
 
     const shareCmd = project
-        .command('share [ref] [email]')
+        .command('share [project] [email]')
         .description('Invite a collaborator to a project')
-        .option('--project <ref>', 'Project name or id:xxx (alias for the positional ref)')
-        .option(
-            '--role <role>',
-            'Workspace role: guest, member, or admin (workspace projects only; default: member)',
+        .option('--project <ref>', 'Project name or id:xxx (alias for the positional project)')
+        .addOption(
+            withCaseInsensitiveChoices(
+                new Option(
+                    '--role <role>',
+                    'Workspace role (workspace projects only; default: member)',
+                ),
+                ['guest', 'member', 'admin'],
+            ),
         )
         .option('--message <msg>', 'Optional invitation message')
         .option(
@@ -282,29 +287,37 @@ Examples:
   td project share --project "Roadmap" alice@example.com
   td project share "Team Plan" bob@example.com --role guest --auto-invite`,
         )
-        .action((ref, email, options) => {
-            // Project can come from the positional ref or --project, but not both.
+        .action((projectArg, emailArg, options) => {
+            // The project is provided either positionally or via --project, never both.
+            // In --project mode the sole positional is the collaborator email.
             let projectRef: string | undefined
-            let collaboratorEmail: string | undefined
-            if (options.project) {
-                if (ref && email) {
+            let email: string | undefined
+            if (options.project !== undefined) {
+                if (emailArg !== undefined) {
                     throw new CliError(
                         'CONFLICTING_OPTIONS',
-                        'Cannot specify project both as argument and --project flag',
+                        'Cannot specify the project both positionally and via --project.',
                     )
                 }
                 projectRef = options.project
-                collaboratorEmail = ref
+                email = projectArg
             } else {
-                projectRef = ref
-                collaboratorEmail = email
+                projectRef = projectArg
+                email = emailArg
             }
 
-            if (!projectRef || !collaboratorEmail) {
+            if (projectRef === undefined) {
                 shareCmd.help()
                 return
             }
-            return shareProject(projectRef, collaboratorEmail, options)
+            if (email === undefined) {
+                throw new CliError(
+                    'MISSING_EMAIL',
+                    'Specify the email of the collaborator to invite.',
+                    ['Usage: td project share <project> <email>'],
+                )
+            }
+            return shareProject(projectRef, email, options)
         })
 
     const progressCmd = project

--- a/src/commands/project/index.ts
+++ b/src/commands/project/index.ts
@@ -1,6 +1,7 @@
 import { Command, Option } from 'commander'
 import { withCaseInsensitiveChoices } from '../../lib/completion.js'
 import { CURSOR_DESCRIPTION } from '../../lib/constants.js'
+import { CliError } from '../../lib/errors.js'
 import { parseOrderArg } from '../../lib/order.js'
 import { showProjectActivityStats } from './activity-stats.js'
 import { analyzeHealth } from './analyze-health.js'
@@ -258,9 +259,10 @@ Examples:
             return joinProjectCmd(id, options)
         })
 
-    project
-        .command('share <ref> <email>')
+    const shareCmd = project
+        .command('share [ref] [email]')
         .description('Invite a collaborator to a project')
+        .option('--project <ref>', 'Project name or id:xxx (alias for the positional ref)')
         .option(
             '--role <role>',
             'Workspace role: guest, member, or admin (workspace projects only; default: member)',
@@ -277,10 +279,32 @@ Examples:
             `
 Examples:
   td project share "Roadmap" alice@example.com
+  td project share --project "Roadmap" alice@example.com
   td project share "Team Plan" bob@example.com --role guest --auto-invite`,
         )
         .action((ref, email, options) => {
-            return shareProject(ref, email, options)
+            // Project can come from the positional ref or --project, but not both.
+            let projectRef: string | undefined
+            let collaboratorEmail: string | undefined
+            if (options.project) {
+                if (ref && email) {
+                    throw new CliError(
+                        'CONFLICTING_OPTIONS',
+                        'Cannot specify project both as argument and --project flag',
+                    )
+                }
+                projectRef = options.project
+                collaboratorEmail = ref
+            } else {
+                projectRef = ref
+                collaboratorEmail = email
+            }
+
+            if (!projectRef || !collaboratorEmail) {
+                shareCmd.help()
+                return
+            }
+            return shareProject(projectRef, collaboratorEmail, options)
         })
 
     const progressCmd = project

--- a/src/commands/project/project.share.test.ts
+++ b/src/commands/project/project.share.test.ts
@@ -287,4 +287,102 @@ describe('project share', () => {
             autoInvited: false,
         })
     })
+
+    it('finds a member across paginated workspace-user pages', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({
+            id: 'proj-1',
+            name: 'Park Ops',
+            workspaceId: 'ws-1',
+        })
+        mockApi.getWorkspaceUsers
+            .mockResolvedValueOnce({
+                workspaceUsers: [
+                    {
+                        userId: 'user-1',
+                        fullName: 'John Hammond',
+                        userEmail: 'john@ingen.com',
+                        role: 'ADMIN',
+                    },
+                ],
+                hasMore: true,
+                nextCursor: 'page-2',
+            })
+            .mockResolvedValueOnce({
+                workspaceUsers: [
+                    {
+                        userId: 'user-2',
+                        fullName: 'Alan Grant',
+                        userEmail: 'alan@ingen.com',
+                        role: 'MEMBER',
+                    },
+                ],
+                hasMore: false,
+            })
+
+        await program.parseAsync(['node', 'td', 'project', 'share', 'id:proj-1', 'alan@ingen.com'])
+
+        expect(mockApi.getWorkspaceUsers).toHaveBeenCalledTimes(2)
+        expect(mockApi.getWorkspaceUsers).toHaveBeenNthCalledWith(2, {
+            workspaceId: 'ws-1',
+            cursor: 'page-2',
+            limit: 200,
+        })
+        expect(mockApi.inviteWorkspaceUsers).not.toHaveBeenCalled()
+        expect(mockApi.sync).toHaveBeenCalledWith(
+            shareCommand({
+                type: 'share_project',
+                args: {
+                    projectId: 'proj-1',
+                    email: 'alan@ingen.com',
+                    message: undefined,
+                    workspaceRole: 'MEMBER',
+                },
+            }),
+        )
+    })
+
+    it('accepts the project via the --project flag', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Field Notes', isShared: true })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'project',
+            'share',
+            '--project',
+            'id:proj-1',
+            'alan@ingen.com',
+        ])
+
+        expect(mockApi.sync).toHaveBeenCalledWith(
+            shareCommand({
+                type: 'share_project',
+                args: { projectId: 'proj-1', email: 'alan@ingen.com', message: undefined },
+            }),
+        )
+        expect(consoleSpy).toHaveBeenCalledWith('Shared: Field Notes with alan@ingen.com')
+    })
+
+    it('errors when the project is given both positionally and via --project', async () => {
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'project',
+                'share',
+                'id:proj-1',
+                'alan@ingen.com',
+                '--project',
+                'id:proj-2',
+            ]),
+        ).rejects.toMatchObject({ code: 'CONFLICTING_OPTIONS' })
+
+        expect(mockApi.sync).not.toHaveBeenCalled()
+    })
 })

--- a/src/commands/project/project.share.test.ts
+++ b/src/commands/project/project.share.test.ts
@@ -5,6 +5,7 @@ vi.mock('../../lib/api/core.js', () => ({
     getApi: vi.fn(),
 }))
 
+import { CliError } from '../../lib/errors.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { createProjectProgram as createProgram } from '../../test-support/project-program.js'
@@ -437,5 +438,58 @@ describe('project share', () => {
         ).rejects.toMatchObject({ code: 'CONFLICTING_OPTIONS' })
 
         expect(mockApi.sync).not.toHaveBeenCalled()
+    })
+
+    it('maps a personal collaborator-limit rejection to a helpful error', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Field Notes', isShared: true })
+        // Backend rejects via sync_status; the SDK surfaces the human message.
+        mockApi.sync.mockRejectedValue(new Error('Too many invitations'))
+
+        await expect(
+            program.parseAsync(['node', 'td', 'project', 'share', 'id:proj-1', 'alan@ingen.com']),
+        ).rejects.toMatchObject({ code: 'COLLABORATOR_LIMIT_REACHED' })
+    })
+
+    it('maps a workspace guest-limit rejection during auto-invite to a helpful error', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({
+            id: 'proj-1',
+            name: 'Park Ops',
+            workspaceId: 'ws-1',
+        })
+        mockApi.getWorkspaceUsers.mockResolvedValue({ workspaceUsers: [], hasMore: false })
+        mockApi.inviteWorkspaceUsers.mockRejectedValue(
+            new Error('Workspace already has the maximum number of guests allowed'),
+        )
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'project',
+                'share',
+                'id:proj-1',
+                'ellie@ingen.com',
+                '--role',
+                'guest',
+                '--auto-invite',
+            ]),
+        ).rejects.toMatchObject({ code: 'WORKSPACE_GUEST_LIMIT_REACHED' })
+
+        expect(mockApi.sync).not.toHaveBeenCalled()
+    })
+
+    it('passes through an unrecognized backend error unchanged', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Field Notes', isShared: true })
+        mockApi.sync.mockRejectedValue(new CliError('API_ERROR', 'Some other failure'))
+
+        await expect(
+            program.parseAsync(['node', 'td', 'project', 'share', 'id:proj-1', 'alan@ingen.com']),
+        ).rejects.toMatchObject({ code: 'API_ERROR' })
     })
 })

--- a/src/commands/project/project.share.test.ts
+++ b/src/commands/project/project.share.test.ts
@@ -7,7 +7,7 @@ vi.mock('../../lib/api/core.js', () => ({
 
 import { setupApiMock } from '../../test-support/api-mock.js'
 import { type MockApi } from '../../test-support/mock-api.js'
-import { createProjectProgram as createProgram } from './test-helpers.js'
+import { createProjectProgram as createProgram } from '../../test-support/project-program.js'
 
 describe('project share', () => {
     let mockApi: MockApi
@@ -195,7 +195,7 @@ describe('project share', () => {
         expect(consoleSpy).toHaveBeenCalledWith('Invited ellie@ingen.com to workspace')
     })
 
-    it('rejects an invalid --role before calling the API', async () => {
+    it('rejects an invalid --role (Commander choices)', async () => {
         const program = createProgram()
 
         mockApi.getProject.mockResolvedValue({
@@ -215,10 +215,37 @@ describe('project share', () => {
                 '--role',
                 'editor',
             ]),
-        ).rejects.toMatchObject({ code: 'INVALID_ROLE' })
+        ).rejects.toThrow('Allowed choices are')
 
         expect(mockApi.sync).not.toHaveBeenCalled()
         expect(mockApi.inviteWorkspaceUsers).not.toHaveBeenCalled()
+    })
+
+    it('--role is case-insensitive', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({
+            id: 'proj-1',
+            name: 'Park Ops',
+            workspaceId: 'ws-1',
+        })
+        mockApi.getWorkspaceUsers.mockResolvedValue({ workspaceUsers: [], hasMore: false })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'project',
+            'share',
+            'id:proj-1',
+            'ellie@ingen.com',
+            '--role',
+            'Guest',
+            '--auto-invite',
+        ])
+
+        expect(mockApi.inviteWorkspaceUsers).toHaveBeenCalledWith(
+            expect.objectContaining({ role: 'GUEST' }),
+        )
     })
 
     it('--dry-run previews without mutating', async () => {
@@ -245,6 +272,32 @@ describe('project share', () => {
         expect(mockApi.sync).not.toHaveBeenCalled()
         expect(mockApi.inviteWorkspaceUsers).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would share project'))
+    })
+
+    it('--dry-run on a workspace project errors when the email is not a member and --auto-invite is omitted', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({
+            id: 'proj-1',
+            name: 'Park Ops',
+            workspaceId: 'ws-1',
+        })
+        mockApi.getWorkspaceUsers.mockResolvedValue({ workspaceUsers: [], hasMore: false })
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'project',
+                'share',
+                'id:proj-1',
+                'ellie@ingen.com',
+                '--dry-run',
+            ]),
+        ).rejects.toMatchObject({ code: 'NOT_WORKSPACE_MEMBER' })
+
+        expect(mockApi.sync).not.toHaveBeenCalled()
+        expect(mockApi.inviteWorkspaceUsers).not.toHaveBeenCalled()
     })
 
     it('outputs JSON with --json', async () => {

--- a/src/commands/project/project.share.test.ts
+++ b/src/commands/project/project.share.test.ts
@@ -1,0 +1,290 @@
+import { captureConsole } from '@doist/cli-core/testing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../lib/api/core.js', () => ({
+    getApi: vi.fn(),
+}))
+
+import { setupApiMock } from '../../test-support/api-mock.js'
+import { type MockApi } from '../../test-support/mock-api.js'
+import { createProjectProgram as createProgram } from './test-helpers.js'
+
+describe('project share', () => {
+    let mockApi: MockApi
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = setupApiMock()
+        consoleSpy = captureConsole()
+    })
+
+    function shareCommand(args: { type: string; args: Record<string, unknown> }) {
+        return expect.objectContaining({
+            commands: [expect.objectContaining(args)],
+        })
+    }
+
+    it('shares a personal project without a workspace role', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({
+            id: 'proj-1',
+            name: 'Field Notes',
+            isShared: true,
+        })
+
+        await program.parseAsync(['node', 'td', 'project', 'share', 'id:proj-1', 'alan@ingen.com'])
+
+        expect(mockApi.inviteWorkspaceUsers).not.toHaveBeenCalled()
+        expect(mockApi.sync).toHaveBeenCalledWith(
+            shareCommand({
+                type: 'share_project',
+                args: { projectId: 'proj-1', email: 'alan@ingen.com', message: undefined },
+            }),
+        )
+        expect(consoleSpy).toHaveBeenCalledWith('Shared: Field Notes with alan@ingen.com')
+    })
+
+    it('passes an optional message when sharing a personal project', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Field Notes', isShared: true })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'project',
+            'share',
+            'id:proj-1',
+            'ellie@ingen.com',
+            '--message',
+            'Welcome aboard',
+        ])
+
+        expect(mockApi.sync).toHaveBeenCalledWith(
+            shareCommand({
+                type: 'share_project',
+                args: { projectId: 'proj-1', email: 'ellie@ingen.com', message: 'Welcome aboard' },
+            }),
+        )
+    })
+
+    it('warns and ignores --role / --auto-invite on a personal project', async () => {
+        const program = createProgram()
+        const errorSpy = captureConsole('error')
+
+        mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Field Notes', isShared: true })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'project',
+            'share',
+            'id:proj-1',
+            'alan@ingen.com',
+            '--role',
+            'admin',
+            '--auto-invite',
+        ])
+
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('ignored for personal'))
+        expect(mockApi.inviteWorkspaceUsers).not.toHaveBeenCalled()
+        expect(mockApi.sync).toHaveBeenCalledWith(
+            shareCommand({
+                type: 'share_project',
+                args: { projectId: 'proj-1', email: 'alan@ingen.com', message: undefined },
+            }),
+        )
+    })
+
+    it('shares a workspace project with an existing member using the default MEMBER role', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({
+            id: 'proj-1',
+            name: 'Park Ops',
+            workspaceId: 'ws-1',
+        })
+        mockApi.getWorkspaceUsers.mockResolvedValue({
+            workspaceUsers: [
+                {
+                    userId: 'user-1',
+                    fullName: 'Alan Grant',
+                    userEmail: 'alan@ingen.com',
+                    role: 'MEMBER',
+                },
+            ],
+            hasMore: false,
+        })
+
+        await program.parseAsync(['node', 'td', 'project', 'share', 'id:proj-1', 'alan@ingen.com'])
+
+        expect(mockApi.inviteWorkspaceUsers).not.toHaveBeenCalled()
+        expect(mockApi.sync).toHaveBeenCalledWith(
+            shareCommand({
+                type: 'share_project',
+                args: {
+                    projectId: 'proj-1',
+                    email: 'alan@ingen.com',
+                    message: undefined,
+                    workspaceRole: 'MEMBER',
+                },
+            }),
+        )
+        expect(consoleSpy).toHaveBeenCalledWith('Shared: Park Ops with alan@ingen.com')
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Role: MEMBER'))
+    })
+
+    it('errors when a workspace email is not a member and --auto-invite is absent', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({
+            id: 'proj-1',
+            name: 'Park Ops',
+            workspaceId: 'ws-1',
+        })
+        mockApi.getWorkspaceUsers.mockResolvedValue({ workspaceUsers: [], hasMore: false })
+
+        await expect(
+            program.parseAsync(['node', 'td', 'project', 'share', 'id:proj-1', 'ellie@ingen.com']),
+        ).rejects.toMatchObject({ code: 'NOT_WORKSPACE_MEMBER' })
+
+        expect(mockApi.inviteWorkspaceUsers).not.toHaveBeenCalled()
+        expect(mockApi.sync).not.toHaveBeenCalled()
+    })
+
+    it('invites a non-member to the workspace first when --auto-invite is set', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({
+            id: 'proj-1',
+            name: 'Park Ops',
+            workspaceId: 'ws-1',
+        })
+        mockApi.getWorkspaceUsers.mockResolvedValue({ workspaceUsers: [], hasMore: false })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'project',
+            'share',
+            'id:proj-1',
+            'ellie@ingen.com',
+            '--role',
+            'guest',
+            '--auto-invite',
+        ])
+
+        expect(mockApi.inviteWorkspaceUsers).toHaveBeenCalledWith({
+            workspaceId: 'ws-1',
+            emailList: ['ellie@ingen.com'],
+            role: 'GUEST',
+        })
+        expect(mockApi.sync).toHaveBeenCalledWith(
+            shareCommand({
+                type: 'share_project',
+                args: {
+                    projectId: 'proj-1',
+                    email: 'ellie@ingen.com',
+                    message: undefined,
+                    workspaceRole: 'GUEST',
+                },
+            }),
+        )
+        expect(consoleSpy).toHaveBeenCalledWith('Invited ellie@ingen.com to workspace')
+    })
+
+    it('rejects an invalid --role before calling the API', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({
+            id: 'proj-1',
+            name: 'Park Ops',
+            workspaceId: 'ws-1',
+        })
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'project',
+                'share',
+                'id:proj-1',
+                'alan@ingen.com',
+                '--role',
+                'editor',
+            ]),
+        ).rejects.toMatchObject({ code: 'INVALID_ROLE' })
+
+        expect(mockApi.sync).not.toHaveBeenCalled()
+        expect(mockApi.inviteWorkspaceUsers).not.toHaveBeenCalled()
+    })
+
+    it('--dry-run previews without mutating', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({
+            id: 'proj-1',
+            name: 'Park Ops',
+            workspaceId: 'ws-1',
+        })
+        mockApi.getWorkspaceUsers.mockResolvedValue({ workspaceUsers: [], hasMore: false })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'project',
+            'share',
+            'id:proj-1',
+            'ellie@ingen.com',
+            '--auto-invite',
+            '--dry-run',
+        ])
+
+        expect(mockApi.sync).not.toHaveBeenCalled()
+        expect(mockApi.inviteWorkspaceUsers).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would share project'))
+    })
+
+    it('outputs JSON with --json', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({
+            id: 'proj-1',
+            name: 'Park Ops',
+            workspaceId: 'ws-1',
+        })
+        mockApi.getWorkspaceUsers.mockResolvedValue({
+            workspaceUsers: [
+                {
+                    userId: 'user-1',
+                    fullName: 'Alan Grant',
+                    userEmail: 'alan@ingen.com',
+                    role: 'MEMBER',
+                },
+            ],
+            hasMore: false,
+        })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'project',
+            'share',
+            'id:proj-1',
+            'alan@ingen.com',
+            '--json',
+        ])
+
+        const output = consoleSpy.mock.calls[0][0]
+        const parsed = JSON.parse(output)
+        expect(parsed).toEqual({
+            projectId: 'proj-1',
+            projectName: 'Park Ops',
+            email: 'alan@ingen.com',
+            role: 'MEMBER',
+            autoInvited: false,
+        })
+    })
+})

--- a/src/commands/project/project.test.ts
+++ b/src/commands/project/project.test.ts
@@ -1,4 +1,4 @@
-import { captureConsole, captureStream, createTestProgram } from '@doist/cli-core/testing'
+import { captureConsole, captureStream } from '@doist/cli-core/testing'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../lib/api/core.js', () => ({
@@ -19,16 +19,12 @@ import { fetchWorkspaceFolders, fetchWorkspaces, type Workspace } from '../../li
 import { openInBrowser } from '../../lib/browser.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
-import { registerProjectCommand } from './index.js'
+import { createProjectProgram as createProgram } from './test-helpers.js'
 
 const mockOpenInBrowser = vi.mocked(openInBrowser)
 
 const mockFetchWorkspaces = vi.mocked(fetchWorkspaces)
 const mockFetchWorkspaceFolders = vi.mocked(fetchWorkspaceFolders)
-
-function createProgram() {
-    return createTestProgram(registerProjectCommand)
-}
 
 describe('project list', () => {
     let mockApi: MockApi

--- a/src/commands/project/project.test.ts
+++ b/src/commands/project/project.test.ts
@@ -19,7 +19,7 @@ import { fetchWorkspaceFolders, fetchWorkspaces, type Workspace } from '../../li
 import { openInBrowser } from '../../lib/browser.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
 import { createMockApi, type MockApi } from '../../test-support/mock-api.js'
-import { createProjectProgram as createProgram } from './test-helpers.js'
+import { createProjectProgram as createProgram } from '../../test-support/project-program.js'
 
 const mockOpenInBrowser = vi.mocked(openInBrowser)
 

--- a/src/commands/project/share.ts
+++ b/src/commands/project/share.ts
@@ -1,4 +1,4 @@
-import { isWorkspaceProject, WORKSPACE_ROLES, type WorkspaceRole } from '@doist/todoist-sdk'
+import { isWorkspaceProject, type WorkspaceRole } from '@doist/todoist-sdk'
 import chalk from 'chalk'
 import { getApi } from '../../lib/api/core.js'
 import { shareProject as shareProjectSync } from '../../lib/api/projects-sync.js'
@@ -16,17 +16,9 @@ export type ProjectShareOptions = {
     dryRun?: boolean
 }
 
+// Role values are validated by Commander's `--role` choices; default to MEMBER.
 function parseRole(role: string | undefined): WorkspaceRole {
-    if (role === undefined) {
-        return 'MEMBER'
-    }
-    const upper = role.toUpperCase()
-    if (!(WORKSPACE_ROLES as readonly string[]).includes(upper)) {
-        throw new CliError('INVALID_ROLE', `Invalid role "${role}".`, [
-            `Valid roles: ${WORKSPACE_ROLES.map((r) => r.toLowerCase()).join(', ')}`,
-        ])
-    }
-    return upper as WorkspaceRole
+    return (role?.toUpperCase() ?? 'MEMBER') as WorkspaceRole
 }
 
 export async function shareProject(

--- a/src/commands/project/share.ts
+++ b/src/commands/project/share.ts
@@ -2,7 +2,7 @@ import { isWorkspaceProject, type WorkspaceRole } from '@doist/todoist-sdk'
 import chalk from 'chalk'
 import { getApi } from '../../lib/api/core.js'
 import { shareProject as shareProjectSync } from '../../lib/api/projects-sync.js'
-import { CliError } from '../../lib/errors.js'
+import { CliError, type ErrorCode } from '../../lib/errors.js'
 import { isQuiet } from '../../lib/global-args.js'
 import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveProjectRef } from '../../lib/refs.js'
@@ -19,6 +19,80 @@ export type ProjectShareOptions = {
 // Role values are validated by Commander's `--role` choices; default to MEMBER.
 function parseRole(role: string | undefined): WorkspaceRole {
     return (role?.toUpperCase() ?? 'MEMBER') as WorkspaceRole
+}
+
+// The backend rejects shares/invites that exceed plan limits or permissions
+// via the Sync API's per-command status. The SDK surfaces these as errors but
+// drops the machine `error_tag`, leaving only the HTTP status and the human
+// message — so we match those stable messages to attach actionable hints.
+const SHARE_ERROR_RULES: Array<{ match: RegExp; code: ErrorCode; hints: string[] }> = [
+    {
+        match: /too many invitations/i,
+        code: 'COLLABORATOR_LIMIT_REACHED',
+        hints: [
+            'The project is at its collaborator limit (active members plus pending invitations).',
+            'Remove a collaborator first, or move the project into a workspace.',
+        ],
+    },
+    {
+        match: /already a collaborator/i,
+        code: 'ALREADY_COLLABORATOR',
+        hints: ['That person already has access to this project.'],
+    },
+    {
+        match: /maximum number of guests/i,
+        code: 'WORKSPACE_GUEST_LIMIT_REACHED',
+        hints: [
+            'The workspace has reached its guest limit.',
+            'Invite them as a member (--role member), remove an existing guest, or upgrade the workspace plan.',
+        ],
+    },
+    {
+        match: /maximum number of members/i,
+        code: 'WORKSPACE_MEMBER_LIMIT_REACHED',
+        hints: ['The workspace is at its member limit. Upgrade the plan or remove a member.'],
+    },
+    {
+        match: /already a member of your workspace/i,
+        code: 'ALREADY_WORKSPACE_MEMBER',
+        hints: ['They are already a workspace member — share without --auto-invite.'],
+    },
+    {
+        match: /reached the limit on the number of workspaces/i,
+        code: 'WORKSPACE_JOIN_LIMIT_REACHED',
+        hints: ['The invitee has joined the maximum number of workspaces and cannot join another.'],
+    },
+    {
+        match: /not verified/i,
+        code: 'ACCOUNT_NOT_VERIFIED',
+        hints: ['Verify your Todoist account email before sharing projects.'],
+    },
+    {
+        match: /project is frozen/i,
+        code: 'PROJECT_FROZEN',
+        hints: ['This project is frozen and cannot accept new collaborators right now.'],
+    },
+    {
+        match: /disabled by the admins/i,
+        code: 'SHARE_FORBIDDEN',
+        hints: [
+            'Inviting people from outside the workspace is disabled.',
+            'Ask a workspace admin, or add them to the workspace first.',
+        ],
+    },
+]
+
+// Re-throw a known share/invite limit or permission failure as a CliError with
+// a clearer code and hints, preserving the backend message. Unknown errors pass
+// through unchanged.
+function rethrowShareError(error: unknown): never {
+    if (error instanceof Error) {
+        const rule = SHARE_ERROR_RULES.find((r) => r.match.test(error.message))
+        if (rule) {
+            throw new CliError(rule.code, error.message, rule.hints)
+        }
+    }
+    throw error
 }
 
 export async function shareProject(
@@ -47,7 +121,11 @@ export async function shareProject(
             return
         }
 
-        await shareProjectSync({ projectId: project.id, email, message: options.message })
+        try {
+            await shareProjectSync({ projectId: project.id, email, message: options.message })
+        } catch (error) {
+            rethrowShareError(error)
+        }
 
         if (options.json) {
             console.log(
@@ -93,20 +171,24 @@ export async function shareProject(
         return
     }
 
-    if (autoInvited) {
-        await api.inviteWorkspaceUsers({
-            workspaceId: project.workspaceId,
-            emailList: [email],
-            role,
-        })
-    }
+    try {
+        if (autoInvited) {
+            await api.inviteWorkspaceUsers({
+                workspaceId: project.workspaceId,
+                emailList: [email],
+                role,
+            })
+        }
 
-    await shareProjectSync({
-        projectId: project.id,
-        email,
-        message: options.message,
-        workspaceRole: role,
-    })
+        await shareProjectSync({
+            projectId: project.id,
+            email,
+            message: options.message,
+            workspaceRole: role,
+        })
+    } catch (error) {
+        rethrowShareError(error)
+    }
 
     if (options.json) {
         console.log(

--- a/src/commands/project/share.ts
+++ b/src/commands/project/share.ts
@@ -4,8 +4,9 @@ import { getApi } from '../../lib/api/core.js'
 import { shareProject as shareProjectSync } from '../../lib/api/projects-sync.js'
 import { CliError } from '../../lib/errors.js'
 import { isQuiet } from '../../lib/global-args.js'
-import { printDryRun } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveProjectRef } from '../../lib/refs.js'
+import { findUser } from '../workspace/helpers.js'
 
 export type ProjectShareOptions = {
     role?: string
@@ -26,25 +27,6 @@ function parseRole(role: string | undefined): WorkspaceRole {
         ])
     }
     return upper as WorkspaceRole
-}
-
-async function isWorkspaceMember(
-    api: Awaited<ReturnType<typeof getApi>>,
-    workspaceId: string,
-    email: string,
-): Promise<boolean> {
-    const target = email.toLowerCase()
-    let cursor: string | undefined
-
-    while (true) {
-        const response = await api.getWorkspaceUsers({ workspaceId, cursor, limit: 200 })
-        if (response.workspaceUsers.some((u) => u.userEmail.toLowerCase() === target)) {
-            return true
-        }
-        if (!response.hasMore || !response.nextCursor) break
-        cursor = response.nextCursor
-    }
-    return false
 }
 
 export async function shareProject(
@@ -77,11 +59,12 @@ export async function shareProject(
 
         if (options.json) {
             console.log(
-                JSON.stringify(
-                    { projectId: project.id, projectName: project.name, email, autoInvited: false },
-                    null,
-                    2,
-                ),
+                formatJson({
+                    projectId: project.id,
+                    projectName: project.name,
+                    email,
+                    autoInvited: false,
+                }),
             )
             return
         }
@@ -94,29 +77,30 @@ export async function shareProject(
 
     // Workspace project: role applies, optional auto-invite to the workspace.
     const role = parseRole(options.role)
-    const isMember = await isWorkspaceMember(api, project.workspaceId, email)
+    const lowerEmail = email.toLowerCase()
+    const isMember =
+        (await findUser(project.workspaceId, (u) => u.userEmail.toLowerCase() === lowerEmail)) !==
+        null
 
-    if (options.dryRun) {
-        printDryRun('share project', {
-            Project: project.name,
-            Email: email,
-            Role: role,
-            'Auto-invite': !isMember
-                ? options.autoInvite
-                    ? 'yes'
-                    : 'required (not a member)'
-                : undefined,
-        })
-        return
-    }
-
+    // Validate before the dry-run early return so a dry run reflects the real outcome.
     if (!isMember && !options.autoInvite) {
         throw new CliError('NOT_WORKSPACE_MEMBER', `${email} is not a member of this workspace.`, [
             'Pass --auto-invite to invite them to the workspace first',
         ])
     }
 
-    const autoInvited = !isMember && Boolean(options.autoInvite)
+    const autoInvited = !isMember
+
+    if (options.dryRun) {
+        printDryRun('share project', {
+            Project: project.name,
+            Email: email,
+            Role: role,
+            'Auto-invite': autoInvited ? 'yes' : undefined,
+        })
+        return
+    }
+
     if (autoInvited) {
         await api.inviteWorkspaceUsers({
             workspaceId: project.workspaceId,
@@ -134,11 +118,13 @@ export async function shareProject(
 
     if (options.json) {
         console.log(
-            JSON.stringify(
-                { projectId: project.id, projectName: project.name, email, role, autoInvited },
-                null,
-                2,
-            ),
+            formatJson({
+                projectId: project.id,
+                projectName: project.name,
+                email,
+                role,
+                autoInvited,
+            }),
         )
         return
     }

--- a/src/commands/project/share.ts
+++ b/src/commands/project/share.ts
@@ -1,0 +1,152 @@
+import { isWorkspaceProject, WORKSPACE_ROLES, type WorkspaceRole } from '@doist/todoist-sdk'
+import chalk from 'chalk'
+import { getApi } from '../../lib/api/core.js'
+import { shareProject as shareProjectSync } from '../../lib/api/projects-sync.js'
+import { CliError } from '../../lib/errors.js'
+import { isQuiet } from '../../lib/global-args.js'
+import { printDryRun } from '../../lib/output.js'
+import { resolveProjectRef } from '../../lib/refs.js'
+
+export type ProjectShareOptions = {
+    role?: string
+    message?: string
+    autoInvite?: boolean
+    json?: boolean
+    dryRun?: boolean
+}
+
+function parseRole(role: string | undefined): WorkspaceRole {
+    if (role === undefined) {
+        return 'MEMBER'
+    }
+    const upper = role.toUpperCase()
+    if (!(WORKSPACE_ROLES as readonly string[]).includes(upper)) {
+        throw new CliError('INVALID_ROLE', `Invalid role "${role}".`, [
+            `Valid roles: ${WORKSPACE_ROLES.map((r) => r.toLowerCase()).join(', ')}`,
+        ])
+    }
+    return upper as WorkspaceRole
+}
+
+async function isWorkspaceMember(
+    api: Awaited<ReturnType<typeof getApi>>,
+    workspaceId: string,
+    email: string,
+): Promise<boolean> {
+    const target = email.toLowerCase()
+    let cursor: string | undefined
+
+    while (true) {
+        const response = await api.getWorkspaceUsers({ workspaceId, cursor, limit: 200 })
+        if (response.workspaceUsers.some((u) => u.userEmail.toLowerCase() === target)) {
+            return true
+        }
+        if (!response.hasMore || !response.nextCursor) break
+        cursor = response.nextCursor
+    }
+    return false
+}
+
+export async function shareProject(
+    ref: string,
+    email: string,
+    options: ProjectShareOptions = {},
+): Promise<void> {
+    const api = await getApi()
+    const project = await resolveProjectRef(api, ref)
+
+    // Personal/shared project: no roles, no workspace invite.
+    if (!isWorkspaceProject(project)) {
+        if (options.role !== undefined || options.autoInvite) {
+            console.error(
+                chalk.dim(
+                    '--role and --auto-invite are ignored for personal (non-workspace) projects.',
+                ),
+            )
+        }
+
+        if (options.dryRun) {
+            printDryRun('share project', {
+                Project: project.name,
+                Email: email,
+            })
+            return
+        }
+
+        await shareProjectSync({ projectId: project.id, email, message: options.message })
+
+        if (options.json) {
+            console.log(
+                JSON.stringify(
+                    { projectId: project.id, projectName: project.name, email, autoInvited: false },
+                    null,
+                    2,
+                ),
+            )
+            return
+        }
+        if (!isQuiet()) {
+            console.log(`Shared: ${project.name} with ${email}`)
+            console.log(chalk.dim(`ID: ${project.id}`))
+        }
+        return
+    }
+
+    // Workspace project: role applies, optional auto-invite to the workspace.
+    const role = parseRole(options.role)
+    const isMember = await isWorkspaceMember(api, project.workspaceId, email)
+
+    if (options.dryRun) {
+        printDryRun('share project', {
+            Project: project.name,
+            Email: email,
+            Role: role,
+            'Auto-invite': !isMember
+                ? options.autoInvite
+                    ? 'yes'
+                    : 'required (not a member)'
+                : undefined,
+        })
+        return
+    }
+
+    if (!isMember && !options.autoInvite) {
+        throw new CliError('NOT_WORKSPACE_MEMBER', `${email} is not a member of this workspace.`, [
+            'Pass --auto-invite to invite them to the workspace first',
+        ])
+    }
+
+    const autoInvited = !isMember && Boolean(options.autoInvite)
+    if (autoInvited) {
+        await api.inviteWorkspaceUsers({
+            workspaceId: project.workspaceId,
+            emailList: [email],
+            role,
+        })
+    }
+
+    await shareProjectSync({
+        projectId: project.id,
+        email,
+        message: options.message,
+        workspaceRole: role,
+    })
+
+    if (options.json) {
+        console.log(
+            JSON.stringify(
+                { projectId: project.id, projectName: project.name, email, role, autoInvited },
+                null,
+                2,
+            ),
+        )
+        return
+    }
+    if (!isQuiet()) {
+        if (autoInvited) {
+            console.log(`Invited ${email} to workspace`)
+        }
+        console.log(`Shared: ${project.name} with ${email}`)
+        console.log(chalk.dim(`Role: ${role}`))
+    }
+}

--- a/src/commands/project/test-helpers.ts
+++ b/src/commands/project/test-helpers.ts
@@ -1,0 +1,7 @@
+import { createTestProgram } from '@doist/cli-core/testing'
+import { registerProjectCommand } from './index.js'
+
+/** Builds a test program with the `project` command tree registered. */
+export function createProjectProgram() {
+    return createTestProgram(registerProjectCommand)
+}

--- a/src/commands/workspace/helpers.ts
+++ b/src/commands/workspace/helpers.ts
@@ -109,7 +109,11 @@ export async function resolveWorkspaceUserRef(
     ])
 }
 
-async function findUser(
+/**
+ * Paginates `getWorkspaceUsers` and returns the first user matching
+ * `predicate`, or `null` if none match. Stops as soon as a match is found.
+ */
+export async function findUser(
     workspaceId: string,
     predicate: (user: WorkspaceUser) => boolean,
 ): Promise<WorkspaceUser | null> {

--- a/src/lib/api/projects-sync.ts
+++ b/src/lib/api/projects-sync.ts
@@ -1,4 +1,4 @@
-import { createCommand } from '@doist/todoist-sdk'
+import { createCommand, type ShareProjectArgs } from '@doist/todoist-sdk'
 import { getApi } from './core.js'
 
 export async function moveProjectParent(id: string, parentId: string | null): Promise<void> {
@@ -14,5 +14,12 @@ export async function reorderProjects(
     const api = await getApi()
     await api.sync({
         commands: [createCommand('project_reorder', { projects: items })],
+    })
+}
+
+export async function shareProject(args: ShareProjectArgs): Promise<void> {
+    const api = await getApi()
+    await api.sync({
+        commands: [createCommand('share_project', args)],
     })
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -91,6 +91,16 @@ export type ErrorCode =
     | 'NOT_SHARED'
     | 'PROJECT_ARCHIVED'
     | 'UNKNOWN_AGENT'
+    // Sharing limits & permissions
+    | 'COLLABORATOR_LIMIT_REACHED'
+    | 'ALREADY_COLLABORATOR'
+    | 'WORKSPACE_GUEST_LIMIT_REACHED'
+    | 'WORKSPACE_MEMBER_LIMIT_REACHED'
+    | 'ALREADY_WORKSPACE_MEMBER'
+    | 'WORKSPACE_JOIN_LIMIT_REACHED'
+    | 'ACCOUNT_NOT_VERIFIED'
+    | 'PROJECT_FROZEN'
+    | 'SHARE_FORBIDDEN'
     // Escape hatch for dynamic codes
     | (string & {})
 

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -86,7 +86,7 @@ Resolution order: \`--user <ref>\` > \`user.defaultUser\` from config > the only
 
 - Daily views: \`td today\`, \`td inbox\`, \`td upcoming\`, \`td completed\`, \`td activity\`
 - Task lifecycle: \`td task list/view/add/quickadd/update/reschedule/move/complete/uncomplete/delete/browse\` (alias: \`td task qa\` for \`quickadd\`)
-- Projects: \`td project list/view/create/update/archive/unarchive/archived/delete/move/reorder/join/browse/collaborators/permissions\`
+- Projects: \`td project list/view/create/update/archive/unarchive/archived/delete/move/reorder/join/share/browse/collaborators/permissions\`
 - Project analytics: \`td project progress/health/health-context/activity-stats/analyze-health\`
 - Goals: \`td goal list/view/create/update/delete/complete/uncomplete/link/unlink\`
 - Organization: \`td label ...\`, \`td filter ...\`, \`td section ...\`, \`td folder ...\`, \`td workspace ...\`
@@ -174,6 +174,8 @@ td project archive "Roadmap"
 td project unarchive "Roadmap"
 td project move "Roadmap" --to-workspace "Acme" --folder "Engineering" --visibility team --yes
 td project join id:abc123
+td project share "Roadmap" alice@example.com
+td project share "Team Plan" bob@example.com --role guest --auto-invite
 td project delete "Roadmap" --yes
 td project progress "Roadmap"
 td project health "Roadmap"

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -175,6 +175,10 @@ td project unarchive "Roadmap"
 td project move "Roadmap" --to-workspace "Acme" --folder "Engineering" --visibility team --yes
 td project join id:abc123
 td project share "Roadmap" alice@example.com
+td project share --project "Roadmap" alice@example.com
+td project share "Roadmap" alice@example.com --message "Join the planning"
+td project share "Roadmap" alice@example.com --json
+td project share "Roadmap" alice@example.com --dry-run
 td project share "Team Plan" bob@example.com --role guest --auto-invite
 td project delete "Roadmap" --yes
 td project progress "Roadmap"

--- a/src/test-support/mock-api.ts
+++ b/src/test-support/mock-api.ts
@@ -99,6 +99,7 @@ export function createMockApi(overrides: Partial<TodoistApi> = {}): MockApi {
         // Workspace
         getWorkspace: vi.fn(),
         getWorkspaceUsers: vi.fn().mockResolvedValue({ workspaceUsers: [], hasMore: false }),
+        inviteWorkspaceUsers: vi.fn().mockResolvedValue({ invitedEmails: [] }),
         getWorkspaceActiveProjects: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
         getWorkspaceArchivedProjects: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
         addWorkspace: vi.fn(),

--- a/src/test-support/project-program.ts
+++ b/src/test-support/project-program.ts
@@ -1,5 +1,5 @@
 import { createTestProgram } from '@doist/cli-core/testing'
-import { registerProjectCommand } from './index.js'
+import { registerProjectCommand } from '../commands/project/index.js'
 
 /** Builds a test program with the `project` command tree registered. */
 export function createProjectProgram() {


### PR DESCRIPTION
## What

Adds `td project share <project-ref> <email>` to invite a collaborator to a project — closes the gap alongside the existing `project join` and `project collaborators` commands.

Closes #372.

```
td project share <project-ref> <email> [--role guest|member|admin] [--message <msg>] [--auto-invite] [--json] [--dry-run]
```

## Behaviour

- **Personal / shared projects** — shares via the `share_project` sync command. `--role` / `--auto-invite` don't apply and are ignored with a warning.
- **Workspace projects** — `--role guest|member|admin` (default `member`) maps to the workspace role. If the email isn't already a workspace member, the command errors with a hint, unless `--auto-invite` is passed — which invites them to the workspace first (via `inviteWorkspaceUsers`) and then shares.
- `--message` attaches an optional invitation message.
- `--dry-run` previews (including whether an auto-invite would fire) without mutating; `--json` outputs the result.

## Notes

- Inviting is only available through the Sync API `share_project` command (there's no REST endpoint), so this adds a `shareProject` sync wrapper in `lib/api/projects-sync.ts`.
- Role vocabulary is the real workspace roles (`guest`/`member`/`admin`), not the `viewer`/`editor` in the original issue text.
- Skill content + `SKILL.md` updated and in sync.
- Share tests live in a new `project.share.test.ts`, and the shared `createProjectProgram` test helper was extracted for reuse.

## Verification

- `npm run type-check` ✅
- `npm run check` (lint + format) ✅
- `npm run check:skill-sync` ✅
- `npm test` — full suite passes (1672)