### PR TITLE
feat(auth): add `--no-browser-open` to `auth login`

### DIFF
--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -42,6 +42,7 @@ td auth login --read-only --additional-scopes=backups
 td auth login --additional-scopes=billing
 td auth login --additional-scopes=app-management,backups
 td auth login --callback-port 9000           # override the OAuth callback port
+td auth login --no-browser-open              # print the authorize URL instead of opening a browser
 td auth login --json                         # emit the new account record as JSON
 td auth login --ndjson                       # one-line newline-delimited JSON
 td auth token
@@ -53,7 +54,7 @@ td auth logout
 td auth logout --json                        # emits `{"ok": true}` (--ndjson is silent)
 ```
 
-`td auth login`, `td auth status`, and `td auth logout` all accept the standard `--json` / `--ndjson` machine-output flags. For `login` and `status` the body carries the account record (id, email, auth metadata, plus `storedUsers` and `source` from status); `logout` emits a `{"ok": true}` envelope under `--json` and stays silent under `--ndjson`. Across all three, keyring-fallback warnings are written to stderr so stdout stays parseable. `td auth login` additionally accepts `--callback-port <n>` (default `8765`, with a small fallback range when the port is busy).
+`td auth login`, `td auth status`, and `td auth logout` all accept the standard `--json` / `--ndjson` machine-output flags. For `login` and `status` the body carries the account record (id, email, auth metadata, plus `storedUsers` and `source` from status); `logout` emits a `{"ok": true}` envelope under `--json` and stays silent under `--ndjson`. Across all three, keyring-fallback warnings are written to stderr so stdout stays parseable. `td auth login` additionally accepts `--callback-port <n>` (default `8765`, with a small fallback range when the port is busy) and `--no-browser-open`, which prints the authorization URL for manual copy-paste instead of opening a browser (useful on headless or remote hosts).
 
 Opt-in OAuth scopes are requested via `--additional-scopes=<list>` (comma-separated). Run `td auth login --help` for the full list. Currently supported:
 

--- a/src/commands/auth/login.test.ts
+++ b/src/commands/auth/login.test.ts
@@ -19,6 +19,9 @@ vi.mock('../../lib/api/core.js', () => ({
 
 vi.mock('chalk')
 
+const openMock = vi.fn()
+vi.mock('open', () => ({ default: (url: string) => openMock(url) }))
+
 // Capture (but don't execute) the options handed to cli-core's
 // `attachLoginCommand` so tests can invoke the Todoist-local callbacks
 // (`resolveScopes`, `onSuccess`) directly — cli-core's own tests don't cover
@@ -48,6 +51,7 @@ type AttachOptions = {
         view: { json: boolean; ndjson: boolean }
         flags: Record<string, unknown>
     }) => void | Promise<void>
+    openBrowser: (url: string) => Promise<void>
     store: { getLastStorageResult: () => unknown }
 }
 
@@ -55,6 +59,20 @@ function attachAndCapture(): AttachOptions {
     capturedAttachOptions.length = 0
     createTestProgram((program) => attachTodoistLoginCommand(program, createTodoistTokenStore()))
     return capturedAttachOptions[capturedAttachOptions.length - 1].options as AttachOptions
+}
+
+function attachAndCaptureLogin(): { options: AttachOptions; login: Command } {
+    capturedAttachOptions.length = 0
+    const captured: { login?: Command } = {}
+    createTestProgram((program) => {
+        captured.login = attachTodoistLoginCommand(program, createTodoistTokenStore())
+    })
+    const login = captured.login
+    if (!login) throw new Error('login command was not attached')
+    return {
+        options: capturedAttachOptions[capturedAttachOptions.length - 1].options as AttachOptions,
+        login,
+    }
 }
 
 const ACCOUNT = {
@@ -139,5 +157,32 @@ describe('attachTodoistLoginCommand: onSuccess output formatting', () => {
         expect(consoleSpy).toHaveBeenCalledTimes(1)
         expect(() => JSON.parse(consoleSpy.mock.calls[0][0] as string)).not.toThrow()
         expect(errorSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n')).toContain(warning)
+    })
+})
+
+describe('attachTodoistLoginCommand: --no-browser-open', () => {
+    beforeEach(() => {
+        openMock.mockClear()
+    })
+
+    afterEach(() => {
+        capturedAttachOptions.length = 0
+    })
+
+    it('opens the browser by default', async () => {
+        const { options } = attachAndCaptureLogin()
+        await options.openBrowser('https://todoist.com/oauth/authorize')
+        expect(openMock).toHaveBeenCalledWith('https://todoist.com/oauth/authorize')
+    })
+
+    it('skips opening the browser when --no-browser-open is set', async () => {
+        const { options, login } = attachAndCaptureLogin()
+        login.setOptionValue('browserOpen', false)
+
+        await options.openBrowser('https://todoist.com/oauth/authorize')
+
+        // cli-core still surfaces the URL itself; the local hook just declines
+        // to spawn a browser, leaving the printed URL for manual copy-paste.
+        expect(openMock).not.toHaveBeenCalled()
     })
 })

--- a/src/commands/auth/login.test.ts
+++ b/src/commands/auth/login.test.ts
@@ -61,17 +61,14 @@ function attachAndCapture(): AttachOptions {
     return capturedAttachOptions[capturedAttachOptions.length - 1].options as AttachOptions
 }
 
-function attachAndCaptureLogin(): { options: AttachOptions; login: Command } {
+function attachAndCaptureLogin(): { options: AttachOptions; program: Command } {
     capturedAttachOptions.length = 0
-    const captured: { login?: Command } = {}
-    createTestProgram((program) => {
-        captured.login = attachTodoistLoginCommand(program, createTodoistTokenStore())
-    })
-    const login = captured.login
-    if (!login) throw new Error('login command was not attached')
+    const program = createTestProgram((p) =>
+        attachTodoistLoginCommand(p, createTodoistTokenStore()),
+    )
     return {
         options: capturedAttachOptions[capturedAttachOptions.length - 1].options as AttachOptions,
-        login,
+        program,
     }
 }
 
@@ -170,14 +167,18 @@ describe('attachTodoistLoginCommand: --no-browser-open', () => {
     })
 
     it('opens the browser by default', async () => {
-        const { options } = attachAndCaptureLogin()
+        const { options, program } = attachAndCaptureLogin()
+        // Parse the real CLI surface so the test exercises flag wiring, not
+        // Commander's internal option store.
+        await program.parseAsync(['login'], { from: 'user' })
+
         await options.openBrowser('https://todoist.com/oauth/authorize')
         expect(openMock).toHaveBeenCalledWith('https://todoist.com/oauth/authorize')
     })
 
-    it('skips opening the browser when --no-browser-open is set', async () => {
-        const { options, login } = attachAndCaptureLogin()
-        login.setOptionValue('browserOpen', false)
+    it('skips opening the browser when --no-browser-open is passed', async () => {
+        const { options, program } = attachAndCaptureLogin()
+        await program.parseAsync(['login', '--no-browser-open'], { from: 'user' })
 
         await options.openBrowser('https://todoist.com/oauth/authorize')
 

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -28,6 +28,15 @@ const TODOIST_CALLBACK_PORT_FALLBACK = 5
  * to `resolveScopes`.
  */
 export function attachTodoistLoginCommand(auth: Command, store: TodoistTokenStore): Command {
+    // `--no-browser-open` lets the user finish the flow by copy-pasting the
+    // printed authorize URL (headless host, remote shell, or simply not wanting
+    // the browser hijacked). cli-core always surfaces the URL before the
+    // `openBrowser` hook fires, so skipping the spawn still leaves a usable
+    // login. The hook isn't handed the parsed flags, so we read the option off
+    // the command at call time via this forward reference (assigned below,
+    // before any login can run).
+    let loginCommand: Command | undefined
+
     const login = attachLoginCommand<TodoistAccount>(auth, {
         provider: createTodoistAuthProvider(),
         store,
@@ -43,6 +52,7 @@ export function attachTodoistLoginCommand(auth: Command, store: TodoistTokenStor
         renderSuccess: renderAuthSuccessPage,
         renderError: renderAuthErrorPage,
         openBrowser: async (url) => {
+            if (loginCommand?.opts().browserOpen === false) return
             await open(url)
         },
         onSuccess: ({ account, view }) => {
@@ -72,8 +82,14 @@ export function attachTodoistLoginCommand(auth: Command, store: TodoistTokenStor
         },
     })
 
+    loginCommand = login
+
     return login
         .description('Authenticate with Todoist via OAuth')
+        .option(
+            '--no-browser-open',
+            'Print the authorization URL instead of opening it in a browser automatically',
+        )
         .option(
             '--additional-scopes <list>',
             'Comma-separated opt-in OAuth scopes (see list below). The flag may be repeated; every occurrence is merged.',

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -2,10 +2,10 @@ import { formatJson, formatNdjson } from '@doist/cli-core'
 import { attachLoginCommand } from '@doist/cli-core/auth'
 import chalk from 'chalk'
 import type { Command } from 'commander'
-import open from 'open'
 import { renderAuthErrorPage, renderAuthSuccessPage } from '../../lib/auth-html.js'
 import { createTodoistAuthProvider } from '../../lib/auth-provider.js'
 import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
+import { openInBrowser } from '../../lib/browser.js'
 import {
     extractAdditionalScopes,
     formatScopesHelp,
@@ -53,7 +53,9 @@ export function attachTodoistLoginCommand(auth: Command, store: TodoistTokenStor
         renderError: renderAuthErrorPage,
         openBrowser: async (url) => {
             if (loginCommand?.opts().browserOpen === false) return
-            await open(url)
+            // cli-core already prints the authorize URL before this hook fires,
+            // so suppress the helper's own announcement to avoid a duplicate.
+            await openInBrowser(url, { announce: false })
         },
         onSuccess: ({ account, view }) => {
             const storage = store.getLastStorageResult()

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -1,6 +1,18 @@
 import open from 'open'
 
-export async function openInBrowser(url: string): Promise<void> {
-    console.log(`Opening ${url}`)
+type OpenInBrowserOptions = {
+    /**
+     * Print an `Opening <url>` line before launching. Default `true`. Callers
+     * that already surface the URL themselves (e.g. `auth login`, where
+     * cli-core prints the authorize URL) pass `false` to avoid a duplicate.
+     */
+    announce?: boolean
+}
+
+export async function openInBrowser(
+    url: string,
+    { announce = true }: OpenInBrowserOptions = {},
+): Promise<void> {
+    if (announce) console.log(`Opening ${url}`)
     await open(url)
 }

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -38,6 +38,7 @@ td auth login --read-only --additional-scopes=backups
 td auth login --additional-scopes=billing
 td auth login --additional-scopes=app-management,backups
 td auth login --callback-port 9000           # override the OAuth callback port
+td auth login --no-browser-open              # print the authorize URL instead of opening a browser
 td auth login --json                         # emit the new account record as JSON
 td auth login --ndjson                       # one-line newline-delimited JSON
 td auth token
@@ -49,7 +50,7 @@ td auth logout
 td auth logout --json                        # emits \`{"ok": true}\` (--ndjson is silent)
 \`\`\`
 
-\`td auth login\`, \`td auth status\`, and \`td auth logout\` all accept the standard \`--json\` / \`--ndjson\` machine-output flags. For \`login\` and \`status\` the body carries the account record (id, email, auth metadata, plus \`storedUsers\` and \`source\` from status); \`logout\` emits a \`{"ok": true}\` envelope under \`--json\` and stays silent under \`--ndjson\`. Across all three, keyring-fallback warnings are written to stderr so stdout stays parseable. \`td auth login\` additionally accepts \`--callback-port <n>\` (default \`8765\`, with a small fallback range when the port is busy).
+\`td auth login\`, \`td auth status\`, and \`td auth logout\` all accept the standard \`--json\` / \`--ndjson\` machine-output flags. For \`login\` and \`status\` the body carries the account record (id, email, auth metadata, plus \`storedUsers\` and \`source\` from status); \`logout\` emits a \`{"ok": true}\` envelope under \`--json\` and stays silent under \`--ndjson\`. Across all three, keyring-fallback warnings are written to stderr so stdout stays parseable. \`td auth login\` additionally accepts \`--callback-port <n>\` (default \`8765\`, with a small fallback range when the port is busy) and \`--no-browser-open\`, which prints the authorization URL for manual copy-paste instead of opening a browser (useful on headless or remote hosts).
 
 Opt-in OAuth scopes are requested via \`--additional-scopes=<list>\` (comma-separated). Run \`td auth login --help\` for the full list. Currently supported:
 


### PR DESCRIPTION
## What

Adds a `--no-browser-open` flag to `td auth login`. With it, the OAuth flow prints the authorization URL for manual copy-paste instead of automatically opening a browser.

```
td auth login --no-browser-open
```

## Why

Useful on headless or remote hosts, in SSH sessions, or any time you'd rather not have the desktop browser hijacked. cli-core already auto-skips the spawn on detected headless/WSL environments; this flag forces the skip everywhere.

## How

cli-core surfaces the authorize URL before its `openBrowser` hook fires, so skipping the spawn still leaves a usable login — the printed URL is the path through. cli-core's `openBrowser` hook isn't handed the parsed flags, so the option is read off the command at call time (commander negatable `--no-browser-open` → `browserOpen`, default `true`).

## Tests

- Added two tests: opens the browser by default, skips when the flag is set.
- SKILL content updated and regenerated via `sync:skill`.
- `type-check`, `check` (oxlint + oxfmt), and the auth login suite all pass.