### PR TITLE
test(auth): adopt cli-core buildTokenStore in auth tests

### DIFF
--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -1,27 +1,30 @@
-import { captureConsole, captureStream, createTestProgram } from '@doist/cli-core/testing'
+import {
+    type StoreEntry,
+    alanGrant,
+    buildTokenStore,
+    captureConsole,
+    captureStream,
+    createTestProgram,
+} from '@doist/cli-core/testing'
 import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Mock the auth-store factory so token / logout commands can drive a stub.
-const setMock = vi.fn()
-const clearMock = vi.fn()
-const activeMock = vi.fn<(ref?: string) => Promise<unknown>>()
-const listMock = vi.fn<() => Promise<unknown[]>>().mockResolvedValue([])
-const lastStorageMock = vi.fn<() => unknown>()
-const lastClearMock = vi.fn<() => unknown>()
+// Each test drives cli-core's stateful `buildTokenStore` fake. The mock factory
+// returns whatever store the current test installed via `useStore()` (see the
+// `makeTodoistStore` helper below), so the store's entries/spies are per-test.
+const holder = vi.hoisted(() => ({
+    store: undefined as import('../../lib/auth-store.js').TodoistTokenStore | undefined,
+}))
 vi.mock('../../lib/auth-store.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../../lib/auth-store.js')>()
     return {
         ...actual,
-        createTodoistTokenStore: () => ({
-            active: activeMock,
-            list: listMock,
-            setDefault: vi.fn(),
-            set: setMock,
-            clear: clearMock,
-            getLastStorageResult: lastStorageMock,
-            getLastClearResult: lastClearMock,
-        }),
+        createTodoistTokenStore: () => {
+            if (!holder.store) {
+                throw new Error('test store not set; call useStore() before createProgram()')
+            }
+            return holder.store
+        },
     }
 })
 
@@ -71,6 +74,7 @@ vi.mock('node:readline', () => ({
 }))
 
 import { createInterface, type Interface } from 'node:readline'
+import type { TokenStorageResult } from '@doist/cli-core/auth'
 import { createApiForToken, getApi } from '../../lib/api/core.js'
 import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
 import { NoTokenError, getAuthMetadata, listStoredUsers, readConfig } from '../../lib/auth.js'
@@ -103,6 +107,55 @@ function createProgram() {
     return createTestProgram(registerAuthCommand)
 }
 
+type MakeStoreOpts = {
+    // Default [] — an EMPTY store. A seeded `active()` snapshot would flip
+    // `status` onto the fetchLive path, so empty is the right default.
+    entries?: StoreEntry<TodoistAccount>[]
+    lastStorage?: TokenStorageResult
+    lastClear?: TokenStorageResult
+}
+
+/**
+ * Wrap cli-core's stateful `buildTokenStore` fake, bolting on the keyring-only
+ * methods (`getLastStorageResult` / `getLastClearResult` / `activeAccount`) that
+ * live on `KeyringTokenStore` but not `TokenStore`, so the result satisfies
+ * `TodoistTokenStore`. Returns the harness too (`state.entries`, `*Spy`) for
+ * assertions, plus setters to mutate the storage-result shape mid-test.
+ */
+function makeTodoistStore(opts: MakeStoreOpts = {}) {
+    const harness = buildTokenStore<TodoistAccount>({ entries: opts.entries ?? [] })
+    let lastStorage = opts.lastStorage
+    let lastClear = opts.lastClear
+    const store = Object.assign(harness.store as unknown as TodoistTokenStore, {
+        getLastStorageResult: () => lastStorage,
+        getLastClearResult: () => lastClear,
+        activeAccount: async (ref?: string) => {
+            const records = await harness.store.list()
+            const target = ref
+                ? records.find((r) => r.account.id === ref || r.account.email === ref)
+                : records.find((r) => r.isDefault)
+            return target ? { account: target.account, isDefault: target.isDefault } : null
+        },
+    })
+    return {
+        store,
+        harness,
+        setLastStorage: (r?: TokenStorageResult) => {
+            lastStorage = r
+        },
+        setLastClear: (r?: TokenStorageResult) => {
+            lastClear = r
+        },
+    }
+}
+
+/** Build a store and install it for the eager `createTodoistTokenStore()` call. */
+function useStore(opts: MakeStoreOpts = {}) {
+    const made = makeTodoistStore(opts)
+    holder.store = made.store
+    return made
+}
+
 describe('auth command', () => {
     let consoleSpy: ReturnType<typeof vi.spyOn>
     let errorSpy: ReturnType<typeof vi.spyOn>
@@ -113,6 +166,9 @@ describe('auth command', () => {
         errorSpy = captureConsole('error')
         mockListStoredUsers.mockResolvedValue([])
         mockReadConfig.mockResolvedValue({})
+        // Safety net: any test that forgets `useStore()` gets an empty store
+        // rather than the factory's "not set" throw.
+        holder.store = makeTodoistStore().store
     })
 
     afterEach(() => {
@@ -120,12 +176,8 @@ describe('auth command', () => {
     })
 
     describe('token subcommand', () => {
-        beforeEach(() => {
-            setMock.mockReset().mockResolvedValue(undefined)
-            lastStorageMock.mockReset().mockReturnValue({ storage: 'secure-store' })
-        })
-
         it('successfully saves a token', async () => {
+            const { harness } = useStore({ lastStorage: { storage: 'secure-store' } })
             const program = createProgram()
             const token = 'some_token_123456789'
 
@@ -134,19 +186,22 @@ describe('auth command', () => {
             await program.parseAsync(['node', 'td', 'auth', 'token', token])
 
             expect(mockCreateApiForToken).toHaveBeenCalledWith(token)
-            expect(setMock).toHaveBeenCalledWith(
+            expect(harness.state.entries).toHaveLength(1)
+            const [entry] = harness.state.entries
+            expect(entry.account).toEqual(
                 expect.objectContaining({
                     id: TEST_USER.id,
                     email: TEST_USER.email,
                     label: TEST_USER.email,
                     auth_mode: 'unknown',
                 }),
-                token,
             )
+            expect(entry.token).toBe(token)
             expect(consoleSpy).toHaveBeenCalledWith('✓', `Saved token for ${TEST_USER.email}`)
         })
 
         it('trims whitespace from token', async () => {
+            const { harness } = useStore({ lastStorage: { storage: 'secure-store' } })
             const program = createProgram()
             const tokenWithWhitespace = '  some_token_123456789  '
             const expectedToken = 'some_token_123456789'
@@ -156,10 +211,11 @@ describe('auth command', () => {
             await program.parseAsync(['node', 'td', 'auth', 'token', tokenWithWhitespace])
 
             expect(mockCreateApiForToken).toHaveBeenCalledWith(expectedToken)
-            expect(setMock).toHaveBeenCalledWith(expect.anything(), expectedToken)
+            expect(harness.state.entries[0]?.token).toBe(expectedToken)
         })
 
         it('prompts interactively when no token argument given', async () => {
+            const { harness } = useStore({ lastStorage: { storage: 'secure-store' } })
             const program = createProgram()
             const mockRl = {
                 question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
@@ -175,10 +231,11 @@ describe('auth command', () => {
             await program.parseAsync(['node', 'td', 'auth', 'token'])
 
             expect(mockRl.question).toHaveBeenCalled()
-            expect(setMock).toHaveBeenCalledWith(expect.anything(), 'interactive_token_456')
+            expect(harness.state.entries[0]?.token).toBe('interactive_token_456')
         })
 
         it('shows error when interactive input is empty', async () => {
+            const { harness } = useStore({ lastStorage: { storage: 'secure-store' } })
             const program = createProgram()
             const mockRl = {
                 question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
@@ -192,18 +249,20 @@ describe('auth command', () => {
 
             await program.parseAsync(['node', 'td', 'auth', 'token'])
 
-            expect(setMock).not.toHaveBeenCalled()
+            expect(harness.state.entries).toHaveLength(0)
             expect(errorSpy).toHaveBeenCalledWith('Error:', 'No token provided')
         })
 
         it('surfaces config-file fallback warning', async () => {
+            useStore({
+                lastStorage: {
+                    storage: 'config-file',
+                    warning:
+                        'system credential manager unavailable; token saved as plaintext in /tmp/test-config.json',
+                },
+            })
             const program = createProgram()
             stubProbeApiForUser()
-            lastStorageMock.mockReturnValue({
-                storage: 'config-file',
-                warning:
-                    'system credential manager unavailable; token saved as plaintext in /tmp/test-config.json',
-            })
 
             await program.parseAsync(['node', 'td', 'auth', 'token', 'some_token_123456789'])
 
@@ -355,32 +414,20 @@ describe('auth command', () => {
                 const program = new Command()
                 program.exitOverride()
                 const auth = program.command('auth')
-                const snapshotStore: TodoistTokenStore = {
-                    async active() {
-                        return { token: 'snapshot_token', account: SNAPSHOT_ACCOUNT }
-                    },
-                    async set() {},
-                    async setBundle() {},
-                    async activeBundle() {
-                        return {
+                // Status with `fetchLive` reads `activeBundle()` first and, on a
+                // null bundle with no `--user`, treats the account as logged out.
+                // Seed a bundle so the snapshot path resolves (token comes from
+                // `bundle.accessToken`).
+                const { store } = makeTodoistStore({
+                    entries: [
+                        {
                             account: SNAPSHOT_ACCOUNT,
+                            isDefault: true,
                             bundle: { accessToken: 'snapshot_token' },
-                        }
-                    },
-                    async activeAccount() {
-                        return { account: SNAPSHOT_ACCOUNT, isDefault: true }
-                    },
-                    async clear() {
-                        return null
-                    },
-                    async list() {
-                        return [{ account: SNAPSHOT_ACCOUNT, isDefault: true }]
-                    },
-                    async setDefault() {},
-                    getLastStorageResult: () => undefined,
-                    getLastClearResult: () => undefined,
-                }
-                attachTodoistStatusCommand(auth, snapshotStore)
+                        },
+                    ],
+                })
+                attachTodoistStatusCommand(auth, store)
                 return program
             }
 
@@ -460,16 +507,9 @@ describe('auth command', () => {
                 'system credential manager unavailable; token cleared from plaintext config.json',
         }
 
-        beforeEach(() => {
-            clearMock.mockReset().mockResolvedValue(undefined)
-            lastClearMock.mockReset().mockReturnValue({ storage: 'secure-store' })
-            activeMock.mockReset()
-            listMock.mockReset().mockResolvedValue([])
-        })
-
         it('surfaces keyring-fallback warning to stderr', async () => {
+            useStore({ lastClear: WARNING_RESULT })
             const program = createProgram()
-            lastClearMock.mockReturnValue(WARNING_RESULT)
 
             await program.parseAsync(['node', 'td', 'auth', 'logout'])
 
@@ -483,20 +523,17 @@ describe('auth command', () => {
             // and substitutes it when commander calls `store.clear(undefined)`.
             // Existence is checked via `store.list()` (no token side effect),
             // not `store.active()`.
-            listMock.mockResolvedValue([
-                {
-                    account: { id: '111', email: 'a@example.com', label: 'a@example.com' },
-                    isDefault: true,
-                },
-            ])
+            const { harness } = useStore({
+                entries: [{ account: alanGrant as TodoistAccount, isDefault: true }],
+            })
 
             const program = createProgram()
             const originalArgv = process.argv
-            process.argv = ['node', 'td', '--user', 'a@example.com', 'auth', 'logout']
+            process.argv = ['node', 'td', '--user', alanGrant.email, 'auth', 'logout']
             resetGlobalArgs()
             try {
                 await program.parseAsync(['node', 'td', 'auth', 'logout'])
-                expect(clearMock).toHaveBeenCalledWith('a@example.com')
+                expect(harness.clearSpy).toHaveBeenCalledWith(alanGrant.email)
             } finally {
                 process.argv = originalArgv
                 resetGlobalArgs()
@@ -507,17 +544,17 @@ describe('auth command', () => {
             // cli-core's `clear(ref)` is contractually a no-op on miss; without
             // the wrap's pre-check, `logout --user mistake` would print
             // "✓ Logged out" and exit 0. The wrap surfaces the typed miss.
-            listMock.mockResolvedValue([])
+            const { harness } = useStore()
 
             const program = createProgram()
             const originalArgv = process.argv
-            process.argv = ['node', 'td', '--user', 'missing@example.com', 'auth', 'logout']
+            process.argv = ['node', 'td', '--user', 'missing@ingen.com', 'auth', 'logout']
             resetGlobalArgs()
             try {
                 await expect(
                     program.parseAsync(['node', 'td', 'auth', 'logout']),
                 ).rejects.toHaveProperty('code', 'ACCOUNT_NOT_FOUND')
-                expect(clearMock).not.toHaveBeenCalled()
+                expect(harness.clearSpy).not.toHaveBeenCalled()
             } finally {
                 process.argv = originalArgv
                 resetGlobalArgs()
@@ -530,8 +567,8 @@ describe('auth command', () => {
             // removed" confirmation; cli-core then prints `{ok: true}`. A
             // regression that leaked human prose into stdout — or dropped the
             // envelope — would corrupt machine-output consumers.
+            useStore({ lastClear: WARNING_RESULT })
             const program = createProgram()
-            lastClearMock.mockReturnValue(WARNING_RESULT)
 
             await program.parseAsync(['node', 'td', 'auth', 'logout', '--json'])
 
@@ -550,18 +587,24 @@ describe('auth command', () => {
         // don't cover (they only exercise `.clear`).
 
         it('routes --user from global args through the active() path', async () => {
-            const account = { id: '111', email: 'a@example.com', label: 'a@example.com' }
-            listMock.mockResolvedValue([{ account, isDefault: true }])
-            activeMock.mockResolvedValue({ token: 'stored-token-1234567', account })
+            const { harness } = useStore({
+                entries: [
+                    {
+                        account: alanGrant as TodoistAccount,
+                        isDefault: true,
+                        token: 'stored-token-1234567',
+                    },
+                ],
+            })
 
             const program = createProgram()
             const stdoutWrite = captureStream()
             const originalArgv = process.argv
-            process.argv = ['node', 'td', '--user', 'a@example.com', 'auth', 'token', 'view']
+            process.argv = ['node', 'td', '--user', alanGrant.email, 'auth', 'token', 'view']
             resetGlobalArgs()
             try {
                 await program.parseAsync(['node', 'td', 'auth', 'token', 'view'])
-                expect(activeMock).toHaveBeenCalledWith('a@example.com')
+                expect(harness.activeSpy).toHaveBeenCalledWith(alanGrant.email)
                 expect(stdoutWrite).toHaveBeenCalledWith('stored-token-1234567')
             } finally {
                 process.argv = originalArgv
@@ -570,17 +613,17 @@ describe('auth command', () => {
         })
 
         it('surfaces UserNotFoundError when --user does not match', async () => {
-            listMock.mockResolvedValue([])
+            const { harness } = useStore()
 
             const program = createProgram()
             const originalArgv = process.argv
-            process.argv = ['node', 'td', '--user', 'nobody@example.com', 'auth', 'token', 'view']
+            process.argv = ['node', 'td', '--user', 'nobody@ingen.com', 'auth', 'token', 'view']
             resetGlobalArgs()
             try {
                 await expect(
                     program.parseAsync(['node', 'td', 'auth', 'token', 'view']),
                 ).rejects.toHaveProperty('code', 'ACCOUNT_NOT_FOUND')
-                expect(activeMock).not.toHaveBeenCalled()
+                expect(harness.activeSpy).not.toHaveBeenCalled()
             } finally {
                 process.argv = originalArgv
                 resetGlobalArgs()

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -129,12 +129,16 @@ function makeTodoistStore(opts: MakeStoreOpts = {}) {
     const store = Object.assign(harness.store as unknown as TodoistTokenStore, {
         getLastStorageResult: () => lastStorage,
         getLastClearResult: () => lastClear,
+        // Resolve through the fake's own `active()` (which applies the store
+        // matcher) rather than re-deriving ref matching here, then read the
+        // default flag off `list()` for the resolved account.
         activeAccount: async (ref?: string) => {
+            const resolved = await harness.store.active(ref)
+            if (!resolved) return null
             const records = await harness.store.list()
-            const target = ref
-                ? records.find((r) => r.account.id === ref || r.account.email === ref)
-                : records.find((r) => r.isDefault)
-            return target ? { account: target.account, isDefault: target.isDefault } : null
+            const isDefault =
+                records.find((r) => r.account.id === resolved.account.id)?.isDefault ?? false
+            return { account: resolved.account, isDefault }
         },
     })
     return {
@@ -156,6 +160,11 @@ function useStore(opts: MakeStoreOpts = {}) {
     return made
 }
 
+/** Explicit empty-store install for the logged-out / `onNotAuthenticated` path. */
+function useEmptyStore() {
+    return useStore()
+}
+
 describe('auth command', () => {
     let consoleSpy: ReturnType<typeof vi.spyOn>
     let errorSpy: ReturnType<typeof vi.spyOn>
@@ -166,9 +175,10 @@ describe('auth command', () => {
         errorSpy = captureConsole('error')
         mockListStoredUsers.mockResolvedValue([])
         mockReadConfig.mockResolvedValue({})
-        // Safety net: any test that forgets `useStore()` gets an empty store
-        // rather than the factory's "not set" throw.
-        holder.store = makeTodoistStore().store
+        // No default store: a test that forgets `useStore()`/`useEmptyStore()`
+        // hits the factory's "not set" throw rather than silently falling back
+        // to the logged-out path and mis-covering a stored/snapshot branch.
+        holder.store = undefined
     })
 
     afterEach(() => {
@@ -279,6 +289,7 @@ describe('auth command', () => {
 
     describe('status subcommand', () => {
         it('shows authenticated status when logged in', async () => {
+            useEmptyStore()
             const program = createProgram()
             const mockApi = createMockApi({ getUser: vi.fn().mockResolvedValue(TEST_USER) })
             mockGetApi.mockResolvedValue(mockApi)
@@ -297,6 +308,7 @@ describe('auth command', () => {
         })
 
         it('marks the active user as default when matching', async () => {
+            useEmptyStore()
             const program = createProgram()
             const mockApi = createMockApi({ getUser: vi.fn().mockResolvedValue(TEST_USER) })
             mockGetApi.mockResolvedValue(mockApi)
@@ -317,6 +329,7 @@ describe('auth command', () => {
         it('marks a lone account as default with no pinned defaultUser', async () => {
             // Effective-default rule: a single stored account is implicitly the
             // default, so the marker matches `accounts list` even with no pin.
+            useEmptyStore()
             const program = createProgram()
             const mockApi = createMockApi({ getUser: vi.fn().mockResolvedValue(TEST_USER) })
             mockGetApi.mockResolvedValue(mockApi)
@@ -334,6 +347,7 @@ describe('auth command', () => {
         })
 
         it('lists other stored accounts', async () => {
+            useEmptyStore()
             const program = createProgram()
             const mockApi = createMockApi({ getUser: vi.fn().mockResolvedValue(TEST_USER) })
             mockGetApi.mockResolvedValue(mockApi)
@@ -354,6 +368,7 @@ describe('auth command', () => {
         })
 
         it('outputs JSON when --json flag is used', async () => {
+            useEmptyStore()
             const program = createProgram()
             const mockApi = createMockApi({ getUser: vi.fn().mockResolvedValue(TEST_USER) })
             mockGetApi.mockResolvedValue(mockApi)
@@ -381,6 +396,7 @@ describe('auth command', () => {
         })
 
         it('throws NoTokenError when not authenticated', async () => {
+            useEmptyStore()
             const program = createProgram()
             mockGetApi.mockRejectedValue(new NoTokenError())
             // status now first calls `store.active()` (via cli-core) and, if a


### PR DESCRIPTION
Closes #362.

## What

Replace the hand-rolled `vi.fn()` token-store interaction mocks in `src/commands/auth/auth.test.ts` with cli-core's stateful `buildTokenStore` fake from `@doist/cli-core/testing` — the part PR #361 deliberately scoped out.

## How

- Add a `makeTodoistStore` helper that wraps `buildTokenStore<TodoistAccount>` and bolts on the keyring-only methods (`getLastStorageResult` / `getLastClearResult` / `activeAccount`) that live on `KeyringTokenStore` but not `TokenStore`, so the result satisfies `TodoistTokenStore`.
- A `vi.hoisted` holder + `useStore()` installer feeds a per-test store into the `createTodoistTokenStore` mock (the factory is called eagerly at register time, so the store is installed before `createProgram()`).
- Assertions move from the bare mocks to the harness: `state.entries` / `clearSpy` / `activeSpy`.
- The persisted-account snapshot block converts to a `buildTokenStore`-backed store too, seeded with a **bundle** (status reads `activeBundle()` first and treats a null bundle as logged-out, so a plain token wouldn't resolve that path).
- logout / token-view ref-resolution tests use the shared ingen fixtures (`alanGrant`). No `matchAccount` override needed — todoist resolves by id/email/label, cli-core's default.

## Notes

- Test-only refactor; no product behaviour change.
- Net: deletes the six module-level `vi.fn()`s + stub factory, the bespoke snapshot-store literal, and three reset `beforeEach` blocks.

## Verification

- `npm run type-check` — clean
- `npm test` — 1688 passed
- `npm run check` — clean