### PR TITLE
fix: bump Todoist SDK to 10.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@doist/cli-core": "0.24.0",
-        "@doist/todoist-sdk": "10.3.0",
+        "@doist/todoist-sdk": "10.3.1",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
@@ -181,16 +181,16 @@
       }
     },
     "node_modules/@doist/todoist-sdk": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.3.0.tgz",
-      "integrity": "sha512-Nxovh0n7TYmfBbZiJLjaWfZGJrcG09tSO3MKmG8RgQGHMHBhkM0r1yCXpQWzXbuRQ8ZLD/0akg+4w0FosrFfOg==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.3.1.tgz",
+      "integrity": "sha512-4lXI6ixn8U0O980Ri/Yx+oOr8jsJp3V8AJnI1Tve0f8BTXuHJ1sYN3N1pkqZ9iYaLIQe31pP5GIIkQkk+MH17w==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "6.3.0",
         "emoji-regex": "10.6.0",
         "form-data": "4.0.5",
         "ts-custom-error": "^3.2.0",
-        "undici": "^7.16.0",
+        "undici": "7.24.8",
         "uuid": "11.1.1",
         "zod": "4.3.6"
       },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "@doist/cli-core": "0.24.0",
-    "@doist/todoist-sdk": "10.3.0",
+    "@doist/todoist-sdk": "10.3.1",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",


### PR DESCRIPTION
## Summary
- bump @doist/todoist-sdk to 10.3.1
- pick up the SDK-side undici pin to 7.24.8
- fixes fresh installs on Node 26 resolving to the broken undici 7.27.1 path

## Validation
- npm run build
- npm test
- Docker Linux Node 26.3.0 validation: SDK 10.3.1 / undici 7.24.8, auth status and today query succeeded

Fixes #384.