### PR TITLE
fix(deps): Updates `@doist/todoist-sdk` to 10.3.2.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@doist/cli-core": "0.24.0",
-        "@doist/todoist-sdk": "10.3.1",
+        "@doist/todoist-sdk": "10.3.2",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@doist/todoist-sdk": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.3.1.tgz",
-      "integrity": "sha512-4lXI6ixn8U0O980Ri/Yx+oOr8jsJp3V8AJnI1Tve0f8BTXuHJ1sYN3N1pkqZ9iYaLIQe31pP5GIIkQkk+MH17w==",
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.3.2.tgz",
+      "integrity": "sha512-m2hbG/Ta6wTeDzyp51PtPuR0l9096Z2JNtagou8dMuLFKx8kRJ3Y7mitqaip4wlfpmAn0f6y2vBdjLIkJ56gug==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "@doist/cli-core": "0.24.0",
-    "@doist/todoist-sdk": "10.3.1",
+    "@doist/todoist-sdk": "10.3.2",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",


### PR DESCRIPTION
Includes the fix for those running the CLI through Bun, instead of NPM.