### PR TITLE
feat(section): add description to create and update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@doist/cli-core": "0.25.1",
-        "@doist/todoist-sdk": "10.3.2",
+        "@doist/todoist-sdk": "10.4.0",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@doist/todoist-sdk": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.3.2.tgz",
-      "integrity": "sha512-m2hbG/Ta6wTeDzyp51PtPuR0l9096Z2JNtagou8dMuLFKx8kRJ3Y7mitqaip4wlfpmAn0f6y2vBdjLIkJ56gug==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.4.0.tgz",
+      "integrity": "sha512-65NlE2c91bBIwayXNz9B9HQTNx0d212nLpDDgzmYoZsIpNIJYN0HfJj4Xjt7nc5Sw7vfGEwhFJ1BPR3GLGV69A==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "6.3.0",
@@ -205,7 +205,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
       "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -217,7 +216,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -228,7 +226,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1039,7 +1036,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
       "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1934,7 +1930,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1951,7 +1946,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1968,7 +1962,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1985,7 +1978,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2002,7 +1994,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2019,7 +2010,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2036,7 +2026,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2053,7 +2042,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2070,7 +2058,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2087,7 +2074,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2104,7 +2090,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2121,7 +2106,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2138,7 +2122,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2157,7 +2140,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2174,7 +2156,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2994,7 +2975,6 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3036,7 +3016,7 @@
       "version": "25.9.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
       "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -4706,7 +4686,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5702,7 +5681,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5723,7 +5701,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5744,7 +5721,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5765,7 +5741,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5786,7 +5761,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5807,7 +5781,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5828,7 +5801,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5849,7 +5821,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5870,7 +5841,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5891,7 +5861,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5912,7 +5881,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10394,7 +10362,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -10473,7 +10440,7 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "@doist/cli-core": "0.25.1",
-    "@doist/todoist-sdk": "10.3.2",
+    "@doist/todoist-sdk": "10.4.0",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "5.6.2",

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -235,7 +235,10 @@ td section list "Roadmap"
 td section list --search "Planning"
 td section list --search "Planning" --project "Roadmap"
 td section create --project "Roadmap" --name "In Progress"
+td section create --project "Roadmap" --name "QA" --description "Bugs to verify"
+td section create --project "Roadmap" --name "Imported" --stdin   # read the description from stdin
 td section update id:123 --name "Done"
+td section update id:123 --description "Sprint backlog"            # description-only update
 td section reorder "Review" --project "Roadmap" --before "Done"
 td section reorder "Review" --project "Roadmap" --after "In Progress"
 td section reorder --section "Review" --project "Roadmap" --position 0 --dry-run

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -239,6 +239,7 @@ td section create --project "Roadmap" --name "QA" --description "Bugs to verify"
 td section create --project "Roadmap" --name "Imported" --stdin   # read the description from stdin
 td section update id:123 --name "Done"
 td section update id:123 --description "Sprint backlog"            # description-only update
+echo "" | td section update id:123 --stdin                        # empty stdin clears the description
 td section reorder "Review" --project "Roadmap" --before "Done"
 td section reorder "Review" --project "Roadmap" --after "In Progress"
 td section reorder --section "Review" --project "Roadmap" --position 0 --dry-run

--- a/src/commands/section/create.ts
+++ b/src/commands/section/create.ts
@@ -1,21 +1,36 @@
 import chalk from 'chalk'
 import { getApi } from '../../lib/api/core.js'
+import { CliError } from '../../lib/errors.js'
 import { isQuiet } from '../../lib/global-args.js'
 import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveProjectId } from '../../lib/refs.js'
+import { readStdin } from '../../lib/stdin.js'
 
 interface CreateOptions {
     name: string
     project: string
+    description?: string
+    stdin?: boolean
     json?: boolean
     dryRun?: boolean
 }
 
 export async function createSection(options: CreateOptions): Promise<void> {
+    if (options.stdin && options.description !== undefined) {
+        throw new CliError('CONFLICTING_OPTIONS', 'Cannot use both --description and --stdin')
+    }
+    let description: string | undefined
+    if (options.stdin) {
+        description = await readStdin()
+    } else if (options.description) {
+        description = options.description
+    }
+
     if (options.dryRun) {
         printDryRun('create section', {
             Name: options.name,
             Project: options.project,
+            Description: description,
         })
         return
     }
@@ -23,10 +38,15 @@ export async function createSection(options: CreateOptions): Promise<void> {
     const api = await getApi()
     const projectId = await resolveProjectId(api, options.project)
 
-    const section = await api.addSection({
+    // `description` is forwarded by the REST client but not yet in the SDK's
+    // AddSectionArgs type (and the SDK strips it from section reads). Tracked as
+    // an SDK dependency. Keep the SDK signature so only `description` escapes typing.
+    const args: Parameters<typeof api.addSection>[0] & { description?: string } = {
         name: options.name,
         projectId,
-    })
+        ...(description !== undefined ? { description } : {}),
+    }
+    const section = await api.addSection(args)
 
     if (options.json) {
         console.log(formatJson(section, 'section'))

--- a/src/commands/section/create.ts
+++ b/src/commands/section/create.ts
@@ -38,15 +38,11 @@ export async function createSection(options: CreateOptions): Promise<void> {
     const api = await getApi()
     const projectId = await resolveProjectId(api, options.project)
 
-    // `description` is forwarded by the REST client but not yet in the SDK's
-    // AddSectionArgs type (and the SDK strips it from section reads). Tracked as
-    // an SDK dependency. Keep the SDK signature so only `description` escapes typing.
-    const args: Parameters<typeof api.addSection>[0] & { description?: string } = {
+    const section = await api.addSection({
         name: options.name,
         projectId,
         ...(description !== undefined ? { description } : {}),
-    }
-    const section = await api.addSection(args)
+    })
 
     if (options.json) {
         console.log(formatJson(section, 'section'))

--- a/src/commands/section/index.ts
+++ b/src/commands/section/index.ts
@@ -50,6 +50,8 @@ export function registerSectionCommand(program: Command): void {
         .description('Create a section')
         .option('--name <name>', 'Section name (required)')
         .option('--project <name>', 'Project name or id:xxx (required)')
+        .option('--description <text>', 'Section description (markdown)')
+        .option('--stdin', 'Read section description from stdin')
         .option('--json', 'Output the created section as JSON')
         .option('--dry-run', 'Preview what would happen without executing')
         .action((options) => {
@@ -76,11 +78,16 @@ export function registerSectionCommand(program: Command): void {
     const updateCmd = section
         .command('update [id]')
         .description('Update a section')
-        .option('--name <name>', 'New section name (required)')
+        .option('--name <name>', 'New section name')
+        .option(
+            '--description <text>',
+            'New description (markdown); pipe empty input via --stdin to clear',
+        )
+        .option('--stdin', 'Read section description from stdin')
         .option('--json', 'Output the updated section as JSON')
         .option('--dry-run', 'Preview what would happen without executing')
         .action((id, options) => {
-            if (!id || !options.name) {
+            if (!id) {
                 updateCmd.help()
                 return
             }

--- a/src/commands/section/section.test.ts
+++ b/src/commands/section/section.test.ts
@@ -5,10 +5,17 @@ vi.mock('../../lib/api/core.js', () => ({
     getApi: vi.fn(),
 }))
 
+vi.mock('../../lib/stdin.js', () => ({
+    readStdin: vi.fn(),
+}))
+
+import { readStdin } from '../../lib/stdin.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
 import { fixtures } from '../../test-support/fixtures.js'
 import { type MockApi } from '../../test-support/mock-api.js'
 import { registerSectionCommand } from './index.js'
+
+const mockReadStdin = vi.mocked(readStdin)
 
 function createProgram() {
     return createTestProgram(registerSectionCommand)
@@ -200,6 +207,7 @@ describe('section create --json', () => {
         mockApi.addSection.mockResolvedValue({
             id: 'sec-new',
             name: 'New Section',
+            description: 'Section notes',
             projectId: 'proj-1',
             sectionOrder: 1,
         })
@@ -220,6 +228,8 @@ describe('section create --json', () => {
         const parsed = JSON.parse(output)
         expect(parsed.id).toBe('sec-new')
         expect(parsed.name).toBe('New Section')
+        // Regression guard: `description` must survive the curated JSON projection.
+        expect(parsed.description).toBe('Section notes')
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Created:'))
     })
 })
@@ -240,6 +250,7 @@ describe('section update --json', () => {
         mockApi.updateSection.mockResolvedValue({
             id: 'sec-1',
             name: 'New Name',
+            description: 'Updated notes',
             projectId: 'proj-1',
             sectionOrder: 1,
         })
@@ -259,6 +270,8 @@ describe('section update --json', () => {
         const parsed = JSON.parse(output)
         expect(parsed.id).toBe('sec-1')
         expect(parsed.name).toBe('New Name')
+        // Regression guard: `description` must survive the curated JSON projection.
+        expect(parsed.description).toBe('Updated notes')
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Updated:'))
     })
 })
@@ -646,6 +659,76 @@ describe('section create', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('sec-xyz'))
     })
+
+    it('creates section with --description', async () => {
+        const program = createProgram()
+
+        mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Work' })
+        mockApi.addSection.mockResolvedValue({ id: 'sec-new', name: 'Review' })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'section',
+            'create',
+            '--name',
+            'Review',
+            '--project',
+            'id:proj-1',
+            '--description',
+            'Pending review',
+        ])
+
+        expect(mockApi.addSection).toHaveBeenCalledWith({
+            name: 'Review',
+            projectId: 'proj-1',
+            description: 'Pending review',
+        })
+    })
+
+    it('reads description from stdin with --stdin', async () => {
+        const program = createProgram()
+
+        mockReadStdin.mockResolvedValue('Piped description')
+        mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Work' })
+        mockApi.addSection.mockResolvedValue({ id: 'sec-new', name: 'Review' })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'section',
+            'create',
+            '--name',
+            'Review',
+            '--project',
+            'id:proj-1',
+            '--stdin',
+        ])
+
+        expect(mockApi.addSection).toHaveBeenCalledWith(
+            expect.objectContaining({ description: 'Piped description' }),
+        )
+    })
+
+    it('rejects --description together with --stdin', async () => {
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'section',
+                'create',
+                '--name',
+                'Review',
+                '--project',
+                'id:proj-1',
+                '--description',
+                'x',
+                '--stdin',
+            ]),
+        ).rejects.toHaveProperty('code', 'CONFLICTING_OPTIONS')
+    })
 })
 
 describe('section delete', () => {
@@ -752,6 +835,66 @@ describe('section update', () => {
             name: 'New Name',
         })
         expect(consoleSpy).toHaveBeenCalledWith('Updated: Old Name → New Name (id:sec-1)')
+    })
+
+    it('updates description only, without a name change', async () => {
+        const program = createProgram()
+        const consoleSpy = captureConsole()
+
+        mockApi.getSection.mockResolvedValue({ id: 'sec-1', name: 'Planning' })
+        mockApi.updateSection.mockResolvedValue({ id: 'sec-1', name: 'Planning' })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'section',
+            'update',
+            'id:sec-1',
+            '--description',
+            'Sprint backlog',
+        ])
+
+        expect(mockApi.updateSection).toHaveBeenCalledWith('sec-1', {
+            description: 'Sprint backlog',
+        })
+        expect(consoleSpy).toHaveBeenCalledWith('Updated: Planning (id:sec-1)')
+    })
+
+    it('clears description with empty stdin', async () => {
+        const program = createProgram()
+
+        mockReadStdin.mockResolvedValue('')
+        mockApi.getSection.mockResolvedValue({ id: 'sec-1', name: 'Planning' })
+        mockApi.updateSection.mockResolvedValue({ id: 'sec-1', name: 'Planning' })
+
+        await program.parseAsync(['node', 'td', 'section', 'update', 'id:sec-1', '--stdin'])
+
+        expect(mockApi.updateSection).toHaveBeenCalledWith('sec-1', { description: '' })
+    })
+
+    it('throws when no changes specified', async () => {
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'td', 'section', 'update', 'id:sec-1']),
+        ).rejects.toHaveProperty('code', 'NO_CHANGES')
+    })
+
+    it('rejects --description together with --stdin', async () => {
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'section',
+                'update',
+                'id:sec-1',
+                '--description',
+                'x',
+                '--stdin',
+            ]),
+        ).rejects.toHaveProperty('code', 'CONFLICTING_OPTIONS')
     })
 })
 

--- a/src/commands/section/section.test.ts
+++ b/src/commands/section/section.test.ts
@@ -228,7 +228,9 @@ describe('section create --json', () => {
         const parsed = JSON.parse(output)
         expect(parsed.id).toBe('sec-new')
         expect(parsed.name).toBe('New Section')
-        // Regression guard: `description` must survive the curated JSON projection.
+        // Regression guard for the CLI's curated JSON projection: once the SDK
+        // exposes section `description` (it strips it today), it must not be
+        // dropped from the output. The mock simulates that post-SDK response.
         expect(parsed.description).toBe('Section notes')
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Created:'))
     })
@@ -270,7 +272,9 @@ describe('section update --json', () => {
         const parsed = JSON.parse(output)
         expect(parsed.id).toBe('sec-1')
         expect(parsed.name).toBe('New Name')
-        // Regression guard: `description` must survive the curated JSON projection.
+        // Regression guard for the CLI's curated JSON projection: once the SDK
+        // exposes section `description` (it strips it today), it must not be
+        // dropped from the output. The mock simulates that post-SDK response.
         expect(parsed.description).toBe('Updated notes')
         expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Updated:'))
     })
@@ -728,6 +732,30 @@ describe('section create', () => {
                 '--stdin',
             ]),
         ).rejects.toHaveProperty('code', 'CONFLICTING_OPTIONS')
+    })
+
+    it('reads stdin then previews under --stdin --dry-run without calling the API', async () => {
+        const program = createProgram()
+        const consoleSpy = captureConsole()
+
+        mockReadStdin.mockResolvedValue('Piped preview')
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'section',
+            'create',
+            '--name',
+            'Review',
+            '--project',
+            'id:proj-1',
+            '--stdin',
+            '--dry-run',
+        ])
+
+        expect(mockReadStdin).toHaveBeenCalled()
+        expect(mockApi.addSection).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Piped preview'))
     })
 })
 

--- a/src/commands/section/section.test.ts
+++ b/src/commands/section/section.test.ts
@@ -924,6 +924,28 @@ describe('section update', () => {
             ]),
         ).rejects.toHaveProperty('code', 'CONFLICTING_OPTIONS')
     })
+
+    it('reads stdin then previews under --stdin --dry-run without calling the API', async () => {
+        const program = createProgram()
+        const consoleSpy = captureConsole()
+
+        mockReadStdin.mockResolvedValue('Piped preview')
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'section',
+            'update',
+            'id:sec-1',
+            '--stdin',
+            '--dry-run',
+        ])
+
+        expect(mockReadStdin).toHaveBeenCalled()
+        expect(mockApi.updateSection).not.toHaveBeenCalled()
+        expect(mockApi.getSection).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Piped preview'))
+    })
 })
 
 describe('section --dry-run', () => {

--- a/src/commands/section/section.test.ts
+++ b/src/commands/section/section.test.ts
@@ -888,7 +888,7 @@ describe('section update', () => {
         expect(consoleSpy).toHaveBeenCalledWith('Updated: Planning (id:sec-1)')
     })
 
-    it('clears description with empty stdin', async () => {
+    it('clears description with empty stdin (sends null per backend NULL_CLEARS)', async () => {
         const program = createProgram()
 
         mockReadStdin.mockResolvedValue('')
@@ -897,7 +897,7 @@ describe('section update', () => {
 
         await program.parseAsync(['node', 'td', 'section', 'update', 'id:sec-1', '--stdin'])
 
-        expect(mockApi.updateSection).toHaveBeenCalledWith('sec-1', { description: '' })
+        expect(mockApi.updateSection).toHaveBeenCalledWith('sec-1', { description: null })
     })
 
     it('throws when no changes specified', async () => {

--- a/src/commands/section/update.ts
+++ b/src/commands/section/update.ts
@@ -54,9 +54,9 @@ export async function updateSection(sectionId: string, options: UpdateOptions): 
         return
     }
 
-    // Only fetch the existing section when renaming, to show "old → new".
-    // Description-only updates skip the extra blocking request.
-    const previousName = args.name ? (await api.getSection(id)).name : undefined
+    // Only fetch the existing section when renaming AND we'll print the result,
+    // to show "old → new". Description-only or quiet updates skip the roundtrip.
+    const previousName = args.name && !isQuiet() ? (await api.getSection(id)).name : undefined
     const updated = await api.updateSection(id, updateArgs)
     if (!isQuiet()) {
         const label = previousName ? `${previousName} → ${updated.name}` : updated.name

--- a/src/commands/section/update.ts
+++ b/src/commands/section/update.ts
@@ -19,11 +19,10 @@ export async function updateSection(sectionId: string, options: UpdateOptions): 
     }
     const id = lenientIdRef(sectionId, 'section')
 
-    // SDK dependency: UpdateSectionArgs currently requires `name` and omits
-    // `description`. We keep the SDK signature via Partial so only the two
-    // escape hatches (optional name, description) sit outside the SDK types.
-    type SectionUpdateArgs = Parameters<Awaited<ReturnType<typeof getApi>>['updateSection']>[1]
-    const args: Partial<SectionUpdateArgs> & { description?: string } = {}
+    // SDK dependency: UpdateSectionArgs requires `name` and omits `description`,
+    // so the args type lists exactly the two fields we send. The cast at the
+    // call site bridges to the SDK signature until it models both.
+    const args: { name?: string; description?: string } = {}
     if (options.name) args.name = options.name
     if (options.stdin) {
         args.description = await readStdin()
@@ -54,10 +53,12 @@ export async function updateSection(sectionId: string, options: UpdateOptions): 
         return
     }
 
-    const section = await api.getSection(id)
+    // Only fetch the existing section when renaming, to show "old → new".
+    // Description-only updates skip the extra blocking request.
+    const previousName = args.name ? (await api.getSection(id)).name : undefined
     const updated = await api.updateSection(id, updateArgs)
     if (!isQuiet()) {
-        const label = args.name ? `${section.name} → ${updated.name}` : updated.name
+        const label = previousName ? `${previousName} → ${updated.name}` : updated.name
         console.log(`Updated: ${label} (id:${id})`)
     }
 }

--- a/src/commands/section/update.ts
+++ b/src/commands/section/update.ts
@@ -19,13 +19,12 @@ export async function updateSection(sectionId: string, options: UpdateOptions): 
     }
     const id = lenientIdRef(sectionId, 'section')
 
-    // SDK dependency: UpdateSectionArgs requires `name` and omits `description`,
-    // so the args type lists exactly the two fields we send. The cast at the
-    // call site bridges to the SDK signature until it models both.
-    const args: { name?: string; description?: string } = {}
+    const args: { name?: string; description?: string | null } = {}
     if (options.name) args.name = options.name
     if (options.stdin) {
-        args.description = await readStdin()
+        // Empty stdin clears the description (backend NULL_CLEARS); non-empty sets it.
+        const piped = await readStdin()
+        args.description = piped === '' ? null : piped
     } else if (options.description) {
         args.description = options.description
     }
@@ -38,13 +37,15 @@ export async function updateSection(sectionId: string, options: UpdateOptions): 
         printDryRun('update section', {
             ID: id,
             Name: args.name,
-            Description: args.description,
+            Description: args.description === null ? '(cleared)' : args.description,
         })
         return
     }
 
     const api = await getApi()
-    // Cast covers the SDK gap above; the REST client forwards the extra fields.
+    // The SDK's UpdateSectionArgs is RequireAtLeastOne, which a dynamically-built
+    // partial can't satisfy statically; the NO_CHANGES guard above guarantees at
+    // least one field is set at runtime.
     const updateArgs = args as Parameters<typeof api.updateSection>[1]
 
     if (options.json) {

--- a/src/commands/section/update.ts
+++ b/src/commands/section/update.ts
@@ -1,28 +1,63 @@
 import { getApi } from '../../lib/api/core.js'
+import { CliError } from '../../lib/errors.js'
 import { isQuiet } from '../../lib/global-args.js'
 import { formatJson, printDryRun } from '../../lib/output.js'
 import { lenientIdRef } from '../../lib/refs.js'
+import { readStdin } from '../../lib/stdin.js'
 
-export async function updateSection(
-    sectionId: string,
-    options: { name: string; json?: boolean; dryRun?: boolean },
-): Promise<void> {
+interface UpdateOptions {
+    name?: string
+    description?: string
+    stdin?: boolean
+    json?: boolean
+    dryRun?: boolean
+}
+
+export async function updateSection(sectionId: string, options: UpdateOptions): Promise<void> {
+    if (options.stdin && options.description !== undefined) {
+        throw new CliError('CONFLICTING_OPTIONS', 'Cannot use both --description and --stdin')
+    }
     const id = lenientIdRef(sectionId, 'section')
 
+    // SDK dependency: UpdateSectionArgs currently requires `name` and omits
+    // `description`. We keep the SDK signature via Partial so only the two
+    // escape hatches (optional name, description) sit outside the SDK types.
+    type SectionUpdateArgs = Parameters<Awaited<ReturnType<typeof getApi>>['updateSection']>[1]
+    const args: Partial<SectionUpdateArgs> & { description?: string } = {}
+    if (options.name) args.name = options.name
+    if (options.stdin) {
+        args.description = await readStdin()
+    } else if (options.description) {
+        args.description = options.description
+    }
+
+    if (Object.keys(args).length === 0) {
+        throw new CliError('NO_CHANGES', 'No changes specified.')
+    }
+
     if (options.dryRun) {
-        printDryRun('update section', { ID: id, Name: options.name })
+        printDryRun('update section', {
+            ID: id,
+            Name: args.name,
+            Description: args.description,
+        })
         return
     }
 
     const api = await getApi()
+    // Cast covers the SDK gap above; the REST client forwards the extra fields.
+    const updateArgs = args as Parameters<typeof api.updateSection>[1]
 
     if (options.json) {
-        const updated = await api.updateSection(id, { name: options.name })
+        const updated = await api.updateSection(id, updateArgs)
         console.log(formatJson(updated, 'section'))
         return
     }
 
     const section = await api.getSection(id)
-    const updated = await api.updateSection(id, { name: options.name })
-    if (!isQuiet()) console.log(`Updated: ${section.name} → ${updated.name} (id:${id})`)
+    const updated = await api.updateSection(id, updateArgs)
+    if (!isQuiet()) {
+        const label = args.name ? `${section.name} → ${updated.name}` : updated.name
+        console.log(`Updated: ${label} (id:${id})`)
+    }
 }

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -197,7 +197,14 @@ const PROJECT_ESSENTIAL_FIELDS = [
     'workspaceId',
 ] as const
 const LABEL_ESSENTIAL_FIELDS = ['id', 'name', 'color', 'isFavorite'] as const
-const SECTION_ESSENTIAL_FIELDS = ['id', 'name', 'projectId', 'sectionOrder', 'url'] as const
+const SECTION_ESSENTIAL_FIELDS = [
+    'id',
+    'name',
+    'description',
+    'projectId',
+    'sectionOrder',
+    'url',
+] as const
 const COMMENT_ESSENTIAL_FIELDS = [
     'id',
     'content',

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -231,7 +231,10 @@ td section list "Roadmap"
 td section list --search "Planning"
 td section list --search "Planning" --project "Roadmap"
 td section create --project "Roadmap" --name "In Progress"
+td section create --project "Roadmap" --name "QA" --description "Bugs to verify"
+td section create --project "Roadmap" --name "Imported" --stdin   # read the description from stdin
 td section update id:123 --name "Done"
+td section update id:123 --description "Sprint backlog"            # description-only update
 td section reorder "Review" --project "Roadmap" --before "Done"
 td section reorder "Review" --project "Roadmap" --after "In Progress"
 td section reorder --section "Review" --project "Roadmap" --position 0 --dry-run

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -235,6 +235,7 @@ td section create --project "Roadmap" --name "QA" --description "Bugs to verify"
 td section create --project "Roadmap" --name "Imported" --stdin   # read the description from stdin
 td section update id:123 --name "Done"
 td section update id:123 --description "Sprint backlog"            # description-only update
+echo "" | td section update id:123 --stdin                        # empty stdin clears the description
 td section reorder "Review" --project "Roadmap" --before "Done"
 td section reorder "Review" --project "Roadmap" --after "In Progress"
 td section reorder --section "Review" --project "Roadmap" --position 0 --dry-run


### PR DESCRIPTION
## What

Surfaces section descriptions (26Q2 Project Essentials) in the CLI, mirroring the project/task description surface.

- `td section create` and `td section update` accept `--description <text>` and `--stdin`
- `td section update` no longer requires `--name` — description-only updates work, guarded by `NO_CHANGES`
- Curated `--json` output now includes `description`

## Same contract across descriptions

Identical to projects and tasks: the `--description` / `--stdin` flags, the `CONFLICTING_OPTIONS` guard, and the JSON essential field. Clearing follows the task pattern (pipe empty input via `--stdin`). The typed-args pattern matches the project PR — only the escape-hatch fields sit outside the SDK types (see below), keeping the rest of the payload compile-checked.

## ⚠️ SDK dependency (blocks full read-side behaviour)

`@doist/todoist-sdk` (pinned 10.3.2) does **not** yet model section descriptions, even though the backend shipped them on 2026-06-10:

- `SectionSchema` is a stripping `z.object` with no `description`, so the SDK drops it from section reads. **JSON output will not surface `description` until the SDK adds it.**
- `UpdateSectionArgs` requires `name` and omits `description`, so description-only updates and the `description` field need a localized escape hatch (documented inline).

The **write path works at runtime today** (the REST client forwards the field). The SDK gap is called out with comments in `create.ts` / `update.ts`. This PR needs an SDK release (add `description: z.string().nullable()` to `SectionSchema`; add `description` + optional `name` to `UpdateSectionArgs`) before the read side fully lands. Opening as a draft for that reason.

## Scope

- **In scope:** section descriptions in `create` / `update` / JSON.
- **Non-goals:** a `section view` text block (no such command exists; sections expose detail via `--json`), and the MCP (separate PR).

## Backend reference (asymmetry vs projects)

Section update clears with `null` (`NULL_CLEARS`), where project clears with `""` (`NULL_KEEPS_UNCHANGED`). The CLI sends what `--stdin` yields; the exact section clear wire value is a follow-up to confirm once the SDK exposes the field.

## Testing

- New unit tests: create (`--description`, `--stdin`, conflict), update (description-only, clear via empty `--stdin`, `NO_CHANGES`, conflict), and JSON regression guards asserting `description` survives the curated projection.
- Full suite green (1701 tests), type-check, lint/format, build all pass. Dry-run smoke-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
