### PR TITLE
Bump GitHub Action pins to node24-compatible majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,13 +52,13 @@ jobs:
                   GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   token: ${{ steps.generate_token.outputs.token }}
                   fetch-depth: 0
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: '22'
                   cache: npm

--- a/.github/workflows/update-todoist-sdk.yml
+++ b/.github/workflows/update-todoist-sdk.yml
@@ -12,7 +12,7 @@ jobs:
             latest-version: ${{ steps.check-updates.outputs.latest-version }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node
               uses: actions/setup-node@v6
@@ -48,7 +48,7 @@ jobs:
 
             - name: Upload updated package files
               if: steps.check-updates.outputs.updates-available == 'true'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: updated-packages
                   path: |
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Download updated package files
               uses: actions/download-artifact@v4
@@ -94,7 +94,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Download updated package files
               uses: actions/download-artifact@v4

--- a/.github/workflows/update-todoist-sdk.yml
+++ b/.github/workflows/update-todoist-sdk.yml
@@ -64,7 +64,7 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Download updated package files
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: updated-packages
 
@@ -97,7 +97,7 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Download updated package files
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: updated-packages
 


### PR DESCRIPTION
Bumps GitHub Action pins to majors that ship with the node24 runtime, ahead of GitHub's node20 deprecation.

- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `actions/upload-artifact` v4 → v7

Tracking: https://github.com/Doist/platform-backlog/issues/1385
