### PR TITLE
chore(docs): Removes note about `todoist-cli-go`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 
 A command-line interface for Todoist.
 
-> [!NOTE]
-> If you have come here after upgrading your `todoist-cli` package in Homebrew and it is not what you were expecting, you may have been using what is now [`todoist-cli-go`](https://formulae.brew.sh/formula/todoist-cli-go).
-
 ## Installation
 
 > ```bash


### PR DESCRIPTION
We promised to keep this note for a month on our readme, that month expired on the 22nd, so removing it now. 