### PR TITLE
fix: install Pi skills in agent directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ td skill install pi
 td skill install universal
 ```
 
-Skills are installed to `~/<agent-dir>/skills/todoist-cli/SKILL.md` (e.g. `~/.claude/` for claude-code, `~/.agents/` for universal, etc.). When updating the CLI, installed skills are updated automatically. The `universal` agent is compatible with Amp, OpenCode, and other agents that read from `~/.agents/`.
+Skills are installed to `~/<agent-dir>/skills/todoist-cli/SKILL.md` (e.g. `~/.claude/` for claude-code, `~/.agents/` for universal, etc.; Pi uses `~/.pi/agent/skills/todoist-cli/SKILL.md` for global installs). When updating the CLI, installed skills are updated automatically. The `universal` agent is compatible with Amp, OpenCode, and other agents that read from `~/.agents/`.
 
 ```bash
 td skill list

--- a/src/commands/skill/skill.test.ts
+++ b/src/commands/skill/skill.test.ts
@@ -221,6 +221,11 @@ describe('installer paths', () => {
         })
     }
 
+    it('installs Pi global skills under the Pi agent directory', () => {
+        const globalPath = skillInstallers.pi.getInstallPath(false)
+        expect(globalPath).toContain(join('.pi', 'agent', 'skills', 'todoist-cli', 'SKILL.md'))
+    })
+
     it('generates skill file with YAML frontmatter', () => {
         const content = skillInstallers['claude-code'].generateContent()
         expect(content).toContain('---')

--- a/src/lib/skills/create-installer.ts
+++ b/src/lib/skills/create-installer.ts
@@ -10,6 +10,7 @@ interface InstallerConfig {
     name: string
     description: string
     dirName: string
+    globalDirName?: string
 }
 
 export function generateSkillFile(): string {
@@ -30,7 +31,8 @@ metadata:
 export function createInstaller(config: InstallerConfig): SkillInstaller {
     function getInstallPath(local: boolean): string {
         const base = local ? process.cwd() : homedir()
-        return join(base, config.dirName, 'skills', SKILL_NAME, 'SKILL.md')
+        const dirName = local ? config.dirName : (config.globalDirName ?? config.dirName)
+        return join(base, dirName, 'skills', SKILL_NAME, 'SKILL.md')
     }
 
     return {

--- a/src/lib/skills/index.ts
+++ b/src/lib/skills/index.ts
@@ -31,6 +31,7 @@ export const skillInstallers: Record<string, SkillInstaller> = {
         name: 'pi',
         description: 'Pi skill for Todoist CLI',
         dirName: '.pi',
+        globalDirName: '.pi/agent',
     }),
     universal: createInstaller({
         name: 'universal',


### PR DESCRIPTION
## Summary
- Fix Pi global skill installs to write under `~/.pi/agent/skills`
- Keep local Pi installs under `.pi/skills`
- Document the Pi-specific global install path

## What was wrong
`td skill install pi` installed the skill at `~/.pi/skills/todoist-cli/SKILL.md`. Pi does not discover that path for global skills. According to the Pi skills documentation, global skills are loaded from `~/.pi/agent/skills/` and project-local skills from `.pi/skills/`: https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/skills.md#locations

This meant a successful global install did not make the Todoist skill available to Pi until the user manually moved or symlinked it.

## Tests
- `npm run check`
- `npm run type-check`
- `npm test`