### PR TITLE
fix(skill): install gemini skill to Antigravity path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ td skill install universal
 
 Skills are installed to `~/<agent-dir>/skills/todoist-cli/SKILL.md` (e.g. `~/.claude/` for claude-code, `~/.agents/` for universal, etc.). When updating the CLI, installed skills are updated automatically. The `universal` agent is compatible with Amp, OpenCode, and other agents that read from `~/.agents/`.
 
+The `gemini` agent installs to `~/.gemini/config/skills/todoist-cli/SKILL.md`, the global location read by Antigravity, Antigravity CLI and Antigravity IDE alike. For project-scoped Antigravity skills use `td skill install universal --local`, which writes to `.agents/skills/` — the workspace directory Antigravity reads.
+
 ```bash
 td skill list
 td skill uninstall <agent>

--- a/src/commands/skill/install.ts
+++ b/src/commands/skill/install.ts
@@ -19,9 +19,15 @@ export async function installSkill(agent: string, options: InstallOptions): Prom
     const local = options.local ?? false
     const force = options.force ?? false
 
+    const legacyPath = installer.getLegacyInstallPath(local)
+    const hadLegacy = await installer.hasLegacyInstall(local)
+
     await installer.install(local, force)
 
     const filepath = installer.getInstallPath(local)
     console.log(chalk.green('✓'), `Installed ${installer.name} skill`)
     console.log(chalk.dim(filepath))
+    if (hadLegacy && legacyPath) {
+        console.log(chalk.dim(`Removed skill from previous location ${legacyPath}`))
+    }
 }

--- a/src/commands/skill/skill.test.ts
+++ b/src/commands/skill/skill.test.ts
@@ -1,6 +1,6 @@
-import { access, mkdir, mkdtemp, readFile, rm, unlink, writeFile } from 'node:fs/promises'
+import { access, chmod, mkdir, mkdtemp, readFile, rm, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { captureConsole, createTestProgram } from '@doist/cli-core/testing'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -415,6 +415,22 @@ describe('legacy install migration', () => {
         expect(await exists(currentFile)).toBe(false)
         expect(await exists(legacyFile)).toBe(false)
     })
+
+    // Permissions do not apply to root, so the unlink would succeed there.
+    it.skipIf(process.getuid?.() === 0)(
+        'surfaces failures to remove the legacy skill',
+        async () => {
+            await writeLegacySkill()
+            const legacyDir = dirname(legacyFile)
+            await chmod(legacyDir, 0o555)
+
+            try {
+                await expect(installer.update(false)).rejects.toThrow()
+            } finally {
+                await chmod(legacyDir, 0o755)
+            }
+        },
+    )
 
     it('still throws when nothing is installed', async () => {
         await mkdir(join(fakeHome, '.gemini'), { recursive: true })

--- a/src/commands/skill/skill.test.ts
+++ b/src/commands/skill/skill.test.ts
@@ -188,7 +188,7 @@ describe('installer paths', () => {
         { agent: 'codex', dir: '.codex', desc: 'Codex skill for Todoist CLI' },
         { agent: 'copilot', dir: '.copilot', desc: 'GitHub Copilot skill for Todoist CLI' },
         { agent: 'cursor', dir: '.cursor', desc: 'Cursor skill for Todoist CLI' },
-        { agent: 'gemini', dir: '.gemini', desc: 'Gemini CLI skill for Todoist CLI' },
+        { agent: 'gemini', dir: '.gemini', desc: 'Antigravity (Gemini) skill for Todoist CLI' },
         { agent: 'pi', dir: '.pi', desc: 'Pi skill for Todoist CLI' },
         { agent: 'universal', dir: '.agents', desc: 'Universal agent skill for Todoist CLI' },
     ] as const
@@ -224,6 +224,11 @@ describe('installer paths', () => {
     it('installs Pi global skills under the Pi agent directory', () => {
         const globalPath = skillInstallers.pi.getInstallPath(false)
         expect(globalPath).toContain(join('.pi', 'agent', 'skills', 'todoist-cli', 'SKILL.md'))
+    })
+
+    it('installs Gemini global skills under the Antigravity config directory', () => {
+        const globalPath = skillInstallers.gemini.getInstallPath(false)
+        expect(globalPath).toContain(join('.gemini', 'config', 'skills', 'todoist-cli', 'SKILL.md'))
     })
 
     it('generates skill file with YAML frontmatter', () => {
@@ -318,6 +323,103 @@ describe('install detection', () => {
             process.chdir(originalCwd)
             await rm(testDir, { recursive: true, force: true })
         }
+    })
+})
+
+describe('legacy install migration', () => {
+    let fakeHome: string
+    let originalHome: string | undefined
+    let legacyFile: string
+    let currentFile: string
+
+    const installer = skillInstallers.gemini
+
+    beforeEach(async () => {
+        fakeHome = await mkdtemp(join(tmpdir(), 'skill-home-'))
+        originalHome = process.env.HOME
+        process.env.HOME = fakeHome
+        legacyFile = join(fakeHome, '.gemini', 'skills', 'todoist-cli', 'SKILL.md')
+        currentFile = join(fakeHome, '.gemini', 'config', 'skills', 'todoist-cli', 'SKILL.md')
+    })
+
+    afterEach(async () => {
+        if (originalHome === undefined) {
+            delete process.env.HOME
+        } else {
+            process.env.HOME = originalHome
+        }
+        await rm(fakeHome, { recursive: true, force: true })
+    })
+
+    async function writeLegacySkill() {
+        await mkdir(join(fakeHome, '.gemini', 'skills', 'todoist-cli'), { recursive: true })
+        await writeFile(legacyFile, 'old content', 'utf-8')
+    }
+
+    async function exists(filepath: string): Promise<boolean> {
+        try {
+            await access(filepath)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    it('reports the legacy path only for global scope', () => {
+        expect(installer.getLegacyInstallPath(false)).toBe(legacyFile)
+        expect(installer.getLegacyInstallPath(true)).toBeUndefined()
+    })
+
+    it('has no legacy path for agents that never moved', async () => {
+        const claudeCode = skillInstallers['claude-code']
+        expect(claudeCode.getLegacyInstallPath(false)).toBeUndefined()
+        expect(await claudeCode.hasLegacyInstall(false)).toBe(false)
+    })
+
+    it('installs to the new path and removes the legacy skill', async () => {
+        await writeLegacySkill()
+
+        await installer.install(false, false)
+
+        expect(await readFile(currentFile, 'utf-8')).toContain('name: todoist-cli')
+        expect(await exists(legacyFile)).toBe(false)
+        expect(await exists(join(fakeHome, '.gemini', 'skills'))).toBe(false)
+    })
+
+    it('migrates a legacy-only install on update', async () => {
+        await writeLegacySkill()
+
+        expect(await installer.isInstalled(false)).toBe(false)
+        expect(await installer.hasLegacyInstall(false)).toBe(true)
+
+        await installer.update(false)
+
+        expect(await readFile(currentFile, 'utf-8')).toContain('name: todoist-cli')
+        expect(await exists(legacyFile)).toBe(false)
+    })
+
+    it('uninstalls a legacy-only install', async () => {
+        await writeLegacySkill()
+
+        await expect(installer.uninstall(false)).resolves.not.toThrow()
+        expect(await exists(legacyFile)).toBe(false)
+    })
+
+    it('removes both locations on uninstall', async () => {
+        await writeLegacySkill()
+        await installer.install(false, true)
+        await writeLegacySkill()
+
+        await installer.uninstall(false)
+
+        expect(await exists(currentFile)).toBe(false)
+        expect(await exists(legacyFile)).toBe(false)
+    })
+
+    it('still throws when nothing is installed', async () => {
+        await mkdir(join(fakeHome, '.gemini'), { recursive: true })
+
+        await expect(installer.uninstall(false)).rejects.toThrow('Skill file not found')
     })
 })
 

--- a/src/commands/skill/update.ts
+++ b/src/commands/skill/update.ts
@@ -38,7 +38,9 @@ export async function updateSkill(agent: string, options: UpdateOptions): Promis
     }
 
     const local = options.local ?? false
-    const installed = await installer.isInstalled(local)
+    const legacyPath = installer.getLegacyInstallPath(local)
+    const hadLegacy = await installer.hasLegacyInstall(local)
+    const installed = (await installer.isInstalled(local)) || hadLegacy
 
     if (!installed) {
         throw new CliError(
@@ -52,4 +54,7 @@ export async function updateSkill(agent: string, options: UpdateOptions): Promis
     const filepath = installer.getInstallPath(local)
     console.log(chalk.green('✓'), `Updated ${installer.name} skill`)
     console.log(chalk.dim(filepath))
+    if (hadLegacy && legacyPath) {
+        console.log(chalk.dim(`Removed skill from previous location ${legacyPath}`))
+    }
 }

--- a/src/lib/skills/create-installer.ts
+++ b/src/lib/skills/create-installer.ts
@@ -6,11 +6,13 @@ import { CliError } from '../errors.js'
 import { SKILL_COMPATIBILITY, SKILL_CONTENT, SKILL_DESCRIPTION, SKILL_NAME } from './content.js'
 import type { SkillInstaller } from './types.js'
 
-interface InstallerConfig {
+type InstallerConfig = {
     name: string
     description: string
     dirName: string
     globalDirName?: string
+    /** Directory an earlier version of the CLI installed the global skill to, cleaned up on install and update. */
+    legacyGlobalDirName?: string
 }
 
 export function generateSkillFile(): string {
@@ -28,6 +30,22 @@ metadata:
     return frontmatter + SKILL_CONTENT
 }
 
+async function removeEmptyDirs(startDir: string, levels: number): Promise<void> {
+    let dir = startDir
+    for (let level = 0; level < levels; level++) {
+        try {
+            const files = await readdir(dir)
+            if (files.length > 0) {
+                return
+            }
+            await rmdir(dir)
+        } catch {
+            return
+        }
+        dir = dirname(dir)
+    }
+}
+
 export function createInstaller(config: InstallerConfig): SkillInstaller {
     function getInstallPath(local: boolean): string {
         const base = local ? process.cwd() : homedir()
@@ -35,11 +53,50 @@ export function createInstaller(config: InstallerConfig): SkillInstaller {
         return join(base, dirName, 'skills', SKILL_NAME, 'SKILL.md')
     }
 
+    function getLegacyInstallPath(local: boolean): string | undefined {
+        if (local || !config.legacyGlobalDirName) {
+            return undefined
+        }
+        return join(homedir(), config.legacyGlobalDirName, 'skills', SKILL_NAME, 'SKILL.md')
+    }
+
+    async function hasLegacyInstall(local: boolean): Promise<boolean> {
+        const filepath = getLegacyInstallPath(local)
+        if (!filepath) {
+            return false
+        }
+        try {
+            await access(filepath)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    async function removeLegacyInstall(local: boolean): Promise<void> {
+        const filepath = getLegacyInstallPath(local)
+        if (!filepath) {
+            return
+        }
+        try {
+            await unlink(filepath)
+        } catch {
+            return
+        }
+        // Prune the now-empty todoist-cli/ directory and, if nothing else lives
+        // there, the skills/ directory that contained it.
+        await removeEmptyDirs(dirname(filepath), 2)
+    }
+
     return {
         name: config.name,
         description: config.description,
 
         getInstallPath,
+
+        getLegacyInstallPath,
+
+        hasLegacyInstall,
 
         generateContent(): string {
             return generateSkillFile()
@@ -76,29 +133,28 @@ export function createInstaller(config: InstallerConfig): SkillInstaller {
             }
             await mkdir(dirname(filepath), { recursive: true })
             await writeFile(filepath, this.generateContent(), 'utf-8')
+            await removeLegacyInstall(local)
         },
 
         async update(local: boolean): Promise<void> {
             const filepath = getInstallPath(local)
+            await mkdir(dirname(filepath), { recursive: true })
             await writeFile(filepath, this.generateContent(), 'utf-8')
+            await removeLegacyInstall(local)
         },
 
         async uninstall(local: boolean): Promise<void> {
             const filepath = getInstallPath(local)
             const exists = await this.isInstalled(local)
-            if (!exists) {
+            const legacyExists = await hasLegacyInstall(local)
+            if (!exists && !legacyExists) {
                 throw new CliError('NOT_FOUND', `Skill file not found at ${filepath}`)
             }
-            await unlink(filepath)
-            const dir = dirname(filepath)
-            try {
-                const files = await readdir(dir)
-                if (files.length === 0) {
-                    await rmdir(dir)
-                }
-            } catch {
-                // Ignore errors when cleaning up empty directory
+            if (exists) {
+                await unlink(filepath)
+                await removeEmptyDirs(dirname(filepath), 1)
             }
+            await removeLegacyInstall(local)
         },
     }
 }

--- a/src/lib/skills/create-installer.ts
+++ b/src/lib/skills/create-installer.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, readdir, rmdir, unlink, writeFile } from 'node:fs/promises'
+import { access, mkdir, rmdir, unlink, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import packageJson from '../../../package.json' with { type: 'json' }
@@ -30,14 +30,15 @@ metadata:
     return frontmatter + SKILL_CONTENT
 }
 
+function isEnoent(error: unknown): boolean {
+    return error instanceof Error && 'code' in error && error.code === 'ENOENT'
+}
+
+/** Removes up to `levels` directories, walking upwards, stopping at the first one that is not empty. */
 async function removeEmptyDirs(startDir: string, levels: number): Promise<void> {
     let dir = startDir
     for (let level = 0; level < levels; level++) {
         try {
-            const files = await readdir(dir)
-            if (files.length > 0) {
-                return
-            }
             await rmdir(dir)
         } catch {
             return
@@ -80,8 +81,13 @@ export function createInstaller(config: InstallerConfig): SkillInstaller {
         }
         try {
             await unlink(filepath)
-        } catch {
-            return
+        } catch (error) {
+            // Anything other than the file already being gone leaves the old skill
+            // active for clients that still read it, so it must not pass silently.
+            if (isEnoent(error)) {
+                return
+            }
+            throw error
         }
         // Prune the now-empty todoist-cli/ directory and, if nothing else lives
         // there, the skills/ directory that contained it.

--- a/src/lib/skills/index.ts
+++ b/src/lib/skills/index.ts
@@ -24,8 +24,12 @@ export const skillInstallers: Record<string, SkillInstaller> = {
     }),
     gemini: createInstaller({
         name: 'gemini',
-        description: 'Gemini CLI skill for Todoist CLI',
+        // Antigravity reads global skills from ~/.gemini/config/skills — the only
+        // global location the Antigravity CLI, IDE and agent all pick up.
+        description: 'Antigravity (Gemini) skill for Todoist CLI',
         dirName: '.gemini',
+        globalDirName: '.gemini/config',
+        legacyGlobalDirName: '.gemini',
     }),
     pi: createInstaller({
         name: 'pi',

--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -1,7 +1,10 @@
-export interface SkillInstaller {
+export type SkillInstaller = {
     name: string
     description: string
     getInstallPath(local: boolean): string
+    /** Path a previous CLI version installed to, or undefined when the agent never had one. */
+    getLegacyInstallPath(local: boolean): string | undefined
+    hasLegacyInstall(local: boolean): Promise<boolean>
     generateContent(): string
     isInstalled(local: boolean): Promise<boolean>
     install(local: boolean, force: boolean): Promise<void>

--- a/src/lib/skills/update-installed.test.ts
+++ b/src/lib/skills/update-installed.test.ts
@@ -13,6 +13,8 @@ function mockInstaller(overrides: Partial<SkillInstaller> = {}): SkillInstaller 
         name: 'test',
         description: 'test',
         getInstallPath: vi.fn(() => '/test/path'),
+        getLegacyInstallPath: vi.fn(() => undefined),
+        hasLegacyInstall: vi.fn(async () => false),
         generateContent: vi.fn(() => 'content'),
         isInstalled: vi.fn(async () => false),
         install: vi.fn(async () => {}),
@@ -97,6 +99,25 @@ describe('updateAllInstalledSkills', () => {
 
         removeInstaller('agent-installed')
         removeInstaller('agent-missing')
+    })
+
+    it('updates agents that only have a skill at the legacy path', async () => {
+        setInstaller(
+            'agent-legacy',
+            mockInstaller({
+                name: 'agent-legacy',
+                isInstalled: vi.fn(async () => false),
+                hasLegacyInstall: vi.fn(async () => true),
+            }),
+        )
+
+        const result = await updateAllInstalledSkills(false)
+
+        expect(result.updated).toEqual(['agent-legacy'])
+        expect(result.skipped).toEqual([])
+        expect(getInstaller('agent-legacy').update).toHaveBeenCalledWith(false)
+
+        removeInstaller('agent-legacy')
     })
 
     it('continues updating remaining agents if one fails', async () => {

--- a/src/lib/skills/update-installed.ts
+++ b/src/lib/skills/update-installed.ts
@@ -13,7 +13,8 @@ export async function updateAllInstalledSkills(local: boolean): Promise<UpdateAl
 
     for (const [name, installer] of Object.entries(skillInstallers)) {
         try {
-            const isInstalled = await installer.isInstalled(local)
+            const isInstalled =
+                (await installer.isInstalled(local)) || (await installer.hasLegacyInstall(local))
             if (isInstalled) {
                 await installer.update(local)
                 updated.push(name)


### PR DESCRIPTION
Closes #423

## Problem

`td skill install gemini` wrote to `~/.gemini/skills/todoist-cli/SKILL.md`, the legacy Gemini CLI global skills directory. Gemini CLI has since been [transitioned to Antigravity CLI](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/) (it stopped serving Pro/Ultra/free users on 18 June 2026), and Antigravity resolves global skills from elsewhere — so the skill we installed was invisible to the agent.

Checked against the [Antigravity skills docs](https://antigravity.google/docs/skills) and [testing of every candidate path](https://atamel.dev/posts/2026/07-01_where_agy_agent_skills/):

| Global path | Antigravity | Antigravity CLI | Antigravity IDE |
| --- | --- | --- | --- |
| `~/.gemini/config/skills/` | ✅ | ✅ | ✅ |
| `~/.gemini/antigravity/skills/` | ✅ | ❌ | ✅ |
| `~/.gemini/antigravity-cli/skills/` | ❌ | ✅ | ✅ |
| `~/.gemini/skills/` (previous behaviour) | ❌ | ✅ | ✅ |

## Changes

- The `gemini` installer now targets `~/.gemini/config/skills/todoist-cli/SKILL.md`, the only global location all three Antigravity surfaces read. The agent key stays `gemini`, so `td skill install gemini` is unchanged.
- `createInstaller` gained an optional legacy global directory. Install and update write the new location and then delete the old file, pruning the emptied `todoist-cli/` and `skills/` directories.
- A skill that only exists at the legacy path counts as installed for update purposes, so existing installs migrate on their own — `postinstall` already runs `updateAllInstalledSkills`, so upgrading the CLI is enough. `install` and `update` print the removed legacy path.
- `uninstall` clears both locations and only errors when neither exists.
- `--local` is unchanged (`.gemini/skills/`) — it still serves enterprise Gemini Code Assist licences, which keep Gemini CLI support. Antigravity's workspace directory is `.agents/skills/`, already covered by `td skill install universal --local`; the README now says so.

## Testing

- New coverage in `skill.test.ts` for the Antigravity global path and the migration paths (install, update, uninstall from a legacy-only install, uninstall with neither present, and agents that have no legacy path), plus a legacy-only case in `update-installed.test.ts`.
- `npm test` (1736 passing), `npm run type-check`, `npm run check`, `npm run check:skill-sync` all pass.
- Manually verified against a sandboxed `$HOME` seeded with a legacy skill file: install writes `~/.gemini/config/skills/todoist-cli/SKILL.md`, removes `~/.gemini/skills/`, and uninstall cleans up afterwards.