### PR TITLE
ci: bump auto-request-reviews-action to v2

### DIFF
--- a/.github/workflows/request-reviews.yml
+++ b/.github/workflows/request-reviews.yml
@@ -13,7 +13,7 @@ jobs:
             github.actor != 'renovate[bot]'
         steps:
             - name: Automatically request reviews from Frontend Product
-              uses: doist/auto-request-reviews-action@v1
+              uses: doist/auto-request-reviews-action@v2
               with:
                   reviewers: 1
                   team: 'Doist/frontend-product'


### PR DESCRIPTION
Bumps `doist/auto-request-reviews-action` from v1 to v2 in the request-reviews workflow, for Node 24 runtime support.

This is the only remaining unmerged change from the stale `feat/node-24` branch — every other change on that branch (node >=24 / npm >=11 engines, `.nvmrc`, the 24 & 26 test matrix, the CODEBASE.md baseline, and the doctor bare-major engine check) is already on `main`. That branch is being deleted.