### PR TITLE
docs: advertise pwsh completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ When active, due dates get a `due:` prefix, deadlines get a `deadline:` prefix, 
 
 ## Shell Completions
 
-Tab completion is available for bash, zsh, and fish:
+Tab completion is available for bash, zsh, fish, and PowerShell:
 
 ```bash
 td completion install        # prompts for shell
-td completion install bash   # or: zsh, fish
+td completion install bash   # or: zsh, fish, pwsh
 ```
 
 Restart your shell or source your config file to activate. To remove:

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -388,6 +388,7 @@ td config view --json
 td config view --show-token
 
 td completion install zsh
+td completion install pwsh
 td completion uninstall
 
 td view https://app.todoist.com/app/task/buy-milk-abc123

--- a/src/commands/completion/helpers.ts
+++ b/src/commands/completion/helpers.ts
@@ -3,8 +3,6 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import type { SupportedShell } from '@pnpm/tabtab'
 
-// pwsh is included because tabtab supports it — installedShells() needs to
-// detect and clean up pwsh completion files even though we don't advertise it.
 export const COMPLETION_EXTENSIONS: Record<SupportedShell, string> = {
     bash: 'bash',
     zsh: 'zsh',

--- a/src/commands/completion/index.ts
+++ b/src/commands/completion/index.ts
@@ -8,7 +8,7 @@ export function registerCompletionCommand(program: Command): void {
 
     completion
         .command('install [shell]')
-        .description('Install shell completions (bash, zsh, fish)')
+        .description('Install shell completions (bash, zsh, fish, pwsh)')
         .action(async (shell?: string) => {
             await installAction(shell)
         })

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -384,6 +384,7 @@ td config view --json
 td config view --show-token
 
 td completion install zsh
+td completion install pwsh
 td completion uninstall
 
 td view https://app.todoist.com/app/task/buy-milk-abc123


### PR DESCRIPTION
`td completion install` has always supported PowerShell (tabtab handles `pwsh`, and the interactive prompt lists it), but the command help and README only mentioned bash, zsh and fish — so the option was invisible to anyone reading `td completion --help`.

- `td completion install` description now reads `(bash, zsh, fish, pwsh)`
- README completion section mentions PowerShell and shows `pwsh` in the example
- Dropped the stale "we don't advertise it" comment in `helpers.ts`

Closes #434