### PR TITLE
fix(auth): require explicit plaintext credential storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,18 @@ This opens your browser to authenticate with Todoist. Once approved, the token i
 - Windows: Credential Manager
 - Linux: Secret Service/libsecret
 
-If secure storage is unavailable, the CLI warns and falls back to `~/.config/todoist-cli/config.json`. Existing plaintext tokens are migrated automatically the next time the CLI reads them successfully from the config file.
+Secure storage is required by default. If it is unavailable, login fails without writing a credential to disk. To explicitly use plaintext config-file storage, pass `--credential-store=plaintext`; the CLI always prints a warning when it writes a credential this way. Existing plaintext tokens are migrated automatically the next time the CLI reads them successfully from the config file.
 
 For a read-only OAuth token (scope `data:read`), run:
 
 ```bash
 td auth login --read-only
+```
+
+To explicitly store a credential in plaintext instead of the OS credential manager:
+
+```bash
+td auth login --credential-store=plaintext
 ```
 
 In read-only mode, commands that change Todoist data (create/update/delete/complete/move/archive, etc.) are blocked by the CLI.
@@ -100,6 +106,9 @@ Run `td auth login --help` for the full list. When a command fails for lack of a
 ```bash
 td auth token "your-token"
 ```
+
+Manual tokens use the system credential manager by default too. To explicitly store one
+in plaintext, add `--credential-store=plaintext`; the CLI prints a warning after the write.
 
 **Environment variable:**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@doist/cli-core": "1.0.1",
+        "@doist/cli-core": "1.1.0",
         "@doist/todoist-sdk": "12.0.0",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
@@ -148,9 +148,9 @@
       }
     },
     "node_modules/@doist/cli-core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-1.0.1.tgz",
-      "integrity": "sha512-tJamXPJt3LSA1sQHfC9IHdZbODJ5pVklqXY7NjbVI5cNhd0vCfSNb/gAQEOUD0+05oV/LByc757H7H0byVtjag==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-1.1.0.tgz",
+      "integrity": "sha512-lSKRM2RmGkq8KUHAoBbFCLltgaCEgjkoUeTmfoDmqB279H6Al5fE3DpTV1zdyvkJkSTQW1onMYp7ZQClzY1PYA==",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@doist/cli-core": "1.0.1",
+    "@doist/cli-core": "1.1.0",
     "@doist/todoist-sdk": "12.0.0",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -43,9 +43,11 @@ td auth login --additional-scopes=billing
 td auth login --additional-scopes=app-management,backups
 td auth login --callback-port 9000           # override the OAuth callback port
 td auth login --no-browser-open              # print the authorize URL instead of opening a browser
+td auth login --credential-store=plaintext   # explicitly store the credential in plaintext
 td auth login --json                         # emit the new account record as JSON
 td auth login --ndjson                       # one-line newline-delimited JSON
 td auth token
+td auth token "$TOKEN" --credential-store=plaintext
 td auth status
 td auth status --json                        # full status payload as JSON (--ndjson also supported)
 TOKEN=$(td auth token view)
@@ -54,7 +56,7 @@ td auth logout
 td auth logout --json                        # emits `{"ok": true}` (--ndjson is silent)
 ```
 
-`td auth login`, `td auth status`, and `td auth logout` all accept the standard `--json` / `--ndjson` machine-output flags. For `login` and `status` the body carries the account record (id, email, auth metadata, plus `storedUsers` and `source` from status); `logout` emits a `{"ok": true}` envelope under `--json` and stays silent under `--ndjson`. Across all three, keyring-fallback warnings are written to stderr so stdout stays parseable. `td auth login` additionally accepts `--callback-port <n>` (default `8765`, with a small fallback range when the port is busy) and `--no-browser-open`, which prints the authorization URL for manual copy-paste instead of opening a browser (useful on headless or remote hosts).
+`td auth login`, `td auth status`, and `td auth logout` all accept the standard `--json` / `--ndjson` machine-output flags. For `login` and `status` the body carries the account record (id, email, auth metadata, plus `storedUsers` and `source` from status); `logout` emits a `{"ok": true}` envelope under `--json` and stays silent under `--ndjson`. `td auth login` additionally accepts `--callback-port <n>` (default `8765`, with a small fallback range when the port is busy) and `--no-browser-open`, which prints the authorization URL for manual copy-paste instead of opening a browser (useful on headless or remote hosts).
 
 Opt-in OAuth scopes are requested via `--additional-scopes=<list>` (comma-separated). Run `td auth login --help` for the full list. Currently supported:
 
@@ -64,7 +66,7 @@ Opt-in OAuth scopes are requested via `--additional-scopes=<list>` (comma-separa
 
 Combine freely with `--read-only` to keep data access read-only while still granting an opt-in scope (e.g. `td auth login --read-only --additional-scopes=backups`). When a command fails for lack of a scope, the error suggests a re-login command that preserves whichever flags were originally used.
 
-Tokens are stored in the OS credential manager when available, with fallback to `~/.config/todoist-cli/config.json`. `TODOIST_API_TOKEN` takes precedence over stored credentials.
+Tokens are stored in the OS credential manager by default. If it is unavailable, credential writes fail without a plaintext fallback. Pass `--credential-store=plaintext` to `td auth login` or `td auth token` only when you explicitly accept plaintext config-file storage; every such write emits a warning to stderr. `TODOIST_API_TOKEN` takes precedence over stored credentials.
 
 `td auth token view` writes the stored token to stdout for use in scripts. **Always capture it into a shell variable** (e.g. `TOKEN=$(td auth token view)`) — never invoke it bare in an agent transcript or piped to a shell that echoes its output, since that would leak the secret. Honors `--user <id|email>` for multi-account installs and refuses when `TODOIST_API_TOKEN` is set in the environment (the token is already available there).
 

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -14,12 +14,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // `makeTodoistStore` helper below), so the store's entries/spies are per-test.
 const holder = vi.hoisted(() => ({
     store: undefined as import('../../lib/auth-store.js').TodoistTokenStore | undefined,
+    factoryOptions: [] as Array<{ credentialStore?: 'system' | 'plaintext' } | undefined>,
 }))
 vi.mock('../../lib/auth-store.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../../lib/auth-store.js')>()
     return {
         ...actual,
-        createTodoistTokenStore: () => {
+        createTodoistTokenStore: (options?: { credentialStore?: 'system' | 'plaintext' }) => {
+            holder.factoryOptions.push(options)
             if (!holder.store) {
                 throw new Error('test store not set; call useStore() before createProgram()')
             }
@@ -179,6 +181,7 @@ describe('auth command', () => {
         // hits the factory's "not set" throw rather than silently falling back
         // to the logged-out path and mis-covering a stored/snapshot branch.
         holder.store = undefined
+        holder.factoryOptions.length = 0
     })
 
     afterEach(() => {
@@ -222,6 +225,23 @@ describe('auth command', () => {
 
             expect(mockCreateApiForToken).toHaveBeenCalledWith(expectedToken)
             expect(harness.state.entries[0]?.token).toBe(expectedToken)
+        })
+
+        it('passes --credential-store to the token store', async () => {
+            useStore({ lastStorage: { storage: 'config-file' } })
+            const program = createProgram()
+            stubProbeApiForUser()
+
+            await program.parseAsync([
+                'node',
+                'td',
+                'auth',
+                'token',
+                'some_token_123456789',
+                '--credential-store=plaintext',
+            ])
+
+            expect(holder.factoryOptions).toContainEqual({ credentialStore: 'plaintext' })
         })
 
         it('prompts interactively when no token argument given', async () => {

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -1,6 +1,10 @@
 import { attachTokenViewCommand } from '@doist/cli-core/auth'
 import type { Command } from 'commander'
-import { createTodoistTokenStore, TOKEN_ENV_VAR } from '../../lib/auth-store.js'
+import {
+    createTodoistTokenStore,
+    parseCredentialStore,
+    TOKEN_ENV_VAR,
+} from '../../lib/auth-store.js'
 import { attachTodoistLoginCommand } from './login.js'
 import { attachTodoistLogoutCommand } from './logout.js'
 import { attachTodoistStatusCommand } from './status.js'
@@ -10,10 +14,10 @@ import { loginWithToken } from './token.js'
 export function registerAuthCommand(program: Command): void {
     const auth = program.command('auth').description('Manage authentication')
 
-    // Two stores share storage but expose different reads:
-    //   - `store` is the raw cli-core `TokenStore` — login uses it to `set()`,
-    //     status uses `active()` (with env-token short-circuit) as the
-    //     authenticated-snapshot gate.
+    // `store` is the raw cli-core `TokenStore` used by status, with an
+    // env-token short-circuit on authenticated reads. Login creates its own
+    // store so its --credential-store choice controls the write policy.
+    //
     //   - `refAware` substitutes `getRequestedUserRef()` for the `--user
     //     <ref>` that `index.ts` strips from argv before commander runs, and
     //     turns ref-misses into typed `UserNotFoundError`. Used by every
@@ -22,7 +26,7 @@ export function registerAuthCommand(program: Command): void {
     const store = createTodoistTokenStore()
     const refAware = withUserRefAware(store)
 
-    attachTodoistLoginCommand(auth, store)
+    attachTodoistLoginCommand(auth)
     attachTodoistLogoutCommand(auth, refAware)
     attachTodoistStatusCommand(auth, store)
 
@@ -33,6 +37,12 @@ export function registerAuthCommand(program: Command): void {
     const tokenCmd = auth
         .command('token [token]')
         .description('Save API token for CLI authentication (or use a subcommand: `view`)')
+        .option(
+            '--credential-store <store>',
+            'Where to store the credential: system (default) or plaintext',
+            parseCredentialStore,
+            'system',
+        )
         .action(loginWithToken)
 
     attachTokenViewCommand(tokenCmd, {

--- a/src/commands/auth/login.test.ts
+++ b/src/commands/auth/login.test.ts
@@ -41,7 +41,6 @@ vi.mock('@doist/cli-core/auth', async (importOriginal) => {
     }
 })
 
-import { createTodoistTokenStore } from '../../lib/auth-store.js'
 import { attachTodoistLoginCommand } from './login.js'
 
 type AttachOptions = {
@@ -57,15 +56,13 @@ type AttachOptions = {
 
 function attachAndCapture(): AttachOptions {
     capturedAttachOptions.length = 0
-    createTestProgram((program) => attachTodoistLoginCommand(program, createTodoistTokenStore()))
+    createTestProgram((program) => attachTodoistLoginCommand(program))
     return capturedAttachOptions[capturedAttachOptions.length - 1].options as AttachOptions
 }
 
 function attachAndCaptureLogin(): { options: AttachOptions; program: Command } {
     capturedAttachOptions.length = 0
-    const program = createTestProgram((p) =>
-        attachTodoistLoginCommand(p, createTodoistTokenStore()),
-    )
+    const program = createTestProgram((p) => attachTodoistLoginCommand(p))
     return {
         options: capturedAttachOptions[capturedAttachOptions.length - 1].options as AttachOptions,
         program,
@@ -185,5 +182,25 @@ describe('attachTodoistLoginCommand: --no-browser-open', () => {
         // cli-core still surfaces the URL itself; the local hook just declines
         // to spawn a browser, leaving the printed URL for manual copy-paste.
         expect(openMock).not.toHaveBeenCalled()
+    })
+})
+
+describe('attachTodoistLoginCommand: --credential-store', () => {
+    afterEach(() => {
+        capturedAttachOptions.length = 0
+    })
+
+    it('defaults to system storage', async () => {
+        const { program } = attachAndCaptureLogin()
+        await program.parseAsync(['login'], { from: 'user' })
+
+        expect(program.commands[0]?.opts().credentialStore).toBe('system')
+    })
+
+    it('accepts explicit plaintext storage', async () => {
+        const { program } = attachAndCaptureLogin()
+        await program.parseAsync(['login', '--credential-store=plaintext'], { from: 'user' })
+
+        expect(program.commands[0]?.opts().credentialStore).toBe('plaintext')
     })
 })

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -4,7 +4,12 @@ import chalk from 'chalk'
 import type { Command } from 'commander'
 import { renderAuthErrorPage, renderAuthSuccessPage } from '../../lib/auth-html.js'
 import { createTodoistAuthProvider } from '../../lib/auth-provider.js'
-import type { TodoistAccount, TodoistTokenStore } from '../../lib/auth-store.js'
+import {
+    createTodoistTokenStore,
+    parseCredentialStore,
+    type CredentialStore,
+    type TodoistAccount,
+} from '../../lib/auth-store.js'
 import { openInBrowser } from '../../lib/browser.js'
 import {
     extractAdditionalScopes,
@@ -27,7 +32,7 @@ const TODOIST_CALLBACK_PORT_FALLBACK = 5
  * the same Commander view; cli-core surfaces it through the `flags` argument
  * to `resolveScopes`.
  */
-export function attachTodoistLoginCommand(auth: Command, store: TodoistTokenStore): Command {
+export function attachTodoistLoginCommand(auth: Command): Command {
     // `--no-browser-open` lets the user finish the flow by copy-pasting the
     // printed authorize URL (headless host, remote shell, or simply not wanting
     // the browser hijacked). cli-core always surfaces the URL before the
@@ -36,6 +41,8 @@ export function attachTodoistLoginCommand(auth: Command, store: TodoistTokenStor
     // the command at call time via this forward reference (assigned below,
     // before any login can run).
     let loginCommand: Command | undefined
+    let credentialStore: CredentialStore = 'system'
+    const store = createTodoistTokenStore({ credentialStore: () => credentialStore })
 
     const login = attachLoginCommand<TodoistAccount>(auth, {
         provider: createTodoistAuthProvider(),
@@ -101,6 +108,15 @@ export function attachTodoistLoginCommand(auth: Command, store: TodoistTokenStor
             // parseScopesOption split/dedupe/validate as usual.
             (value: string, prev: string | undefined) =>
                 prev && prev.length > 0 ? `${prev},${value}` : value,
+        )
+        .option(
+            '--credential-store <store>',
+            'Where to store the credential: system (default) or plaintext',
+            (value: string) => {
+                credentialStore = parseCredentialStore(value)
+                return credentialStore
+            },
+            'system',
         )
         .addHelpText('after', formatScopesHelp())
 }

--- a/src/commands/auth/token.ts
+++ b/src/commands/auth/token.ts
@@ -1,9 +1,16 @@
 import chalk from 'chalk'
 import { createApiForToken } from '../../lib/api/core.js'
-import { createTodoistTokenStore, toTodoistAccount } from '../../lib/auth-store.js'
+import {
+    createTodoistTokenStore,
+    type CredentialStore,
+    toTodoistAccount,
+} from '../../lib/auth-store.js'
 import { logTokenStorageResult, promptHiddenInput } from './helpers.js'
 
-export async function loginWithToken(token?: string): Promise<void> {
+export async function loginWithToken(
+    token?: string,
+    options: { credentialStore?: CredentialStore } = {},
+): Promise<void> {
     if (!token) {
         token = await promptHiddenInput('API token: ')
         if (!token.trim()) {
@@ -18,7 +25,7 @@ export async function loginWithToken(token?: string): Promise<void> {
     const probeApi = createApiForToken(trimmed)
     const user = await probeApi.getUser()
 
-    const store = createTodoistTokenStore()
+    const store = createTodoistTokenStore({ credentialStore: options.credentialStore })
     await store.set(
         toTodoistAccount({ id: user.id, email: user.email, authMode: 'unknown' }),
         trimmed,

--- a/src/lib/auth-store.ts
+++ b/src/lib/auth-store.ts
@@ -5,6 +5,7 @@ import {
     type KeyringTokenStore,
 } from '@doist/cli-core/auth'
 import { type AuthFlag, type AuthMode, getConfigPath, readConfig } from './config.js'
+import { CliError } from './errors.js'
 import { createTodoistUserRecordStore } from './user-records.js'
 import { getStoredUsers, matchUserRef } from './users.js'
 
@@ -17,6 +18,20 @@ import { getStoredUsers, matchUserRef } from './users.js'
 export const SERVICE_NAME = 'todoist-cli'
 export const LEGACY_ACCOUNT = 'api-token'
 export const TOKEN_ENV_VAR = 'TODOIST_API_TOKEN'
+export type CredentialStore = 'system' | 'plaintext'
+
+export function parseCredentialStore(value: string): CredentialStore {
+    switch (value) {
+        case 'system':
+        case 'plaintext':
+            return value
+        default:
+            throw new CliError('INVALID_CREDENTIAL_STORE', `Invalid credential store '${value}'.`, [
+                'Expected one of: system, plaintext.',
+            ])
+    }
+}
+
 export function accountForUser(id: string): string {
     return `user-${id}`
 }
@@ -59,9 +74,14 @@ export function toTodoistAccount(input: TodoistAccountInput): TodoistAccount {
 
 export type TodoistTokenStore = KeyringTokenStore<TodoistAccount>
 
+type CreateTodoistTokenStoreOptions = {
+    credentialStore?: CredentialStore | (() => CredentialStore)
+}
+
 /**
  * cli-core's keyring-backed `TokenStore`, wired to todoist-cli's
- * `UserRecordStore` adapter. Two Todoist-specific overlays on top of the
+ * `UserRecordStore` adapter. It passes Todoist's strict-by-default credential
+ * policy through to cli-core, plus two Todoist-specific overlays on top of the
  * defaults:
  *
  *   - `active()` / `activeBundle()` short-circuit to `null` when
@@ -80,18 +100,23 @@ export type TodoistTokenStore = KeyringTokenStore<TodoistAccount>
  * inherited from `inner` via the prototype chain — a future cli-core method
  * addition resolves automatically instead of being silently dropped.
  */
-export function createTodoistTokenStore(): TodoistTokenStore {
+export function createTodoistTokenStore(
+    options: CreateTodoistTokenStoreOptions = {},
+): TodoistTokenStore {
+    const userRecords = createTodoistUserRecordStore()
     const inner = createKeyringTokenStore<TodoistAccount>({
         serviceName: SERVICE_NAME,
-        userRecords: createTodoistUserRecordStore(),
+        userRecords,
         recordsLocation: getConfigPath(),
         accountForUser,
         matchAccount: (account: TodoistAccount, ref: AccountRef) =>
             matchUserRef({ id: account.id, email: account.email }, ref),
+        credentialStore: options.credentialStore ?? 'system',
     })
     function envTokenSet(): boolean {
         return Boolean(process.env[TOKEN_ENV_VAR])
     }
+
     return Object.assign(Object.create(inner) as TodoistTokenStore, {
         active: async (ref?: AccountRef) => (envTokenSet() ? null : inner.active(ref)),
         activeBundle: async (ref?: AccountRef) => (envTokenSet() ? null : inner.activeBundle(ref)),

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -47,7 +47,7 @@ export type AuthFlag = (typeof AUTH_FLAG_ORDER)[number]
 /**
  * Per-user record stored in `config.users`. The token itself lives in the OS
  * credential manager under account `user-<id>`; `api_token` only appears here
- * when the credential manager was unavailable at save time (plaintext fallback).
+ * when plaintext storage is explicitly selected.
  */
 export interface StoredUser {
     id: string

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -39,9 +39,11 @@ td auth login --additional-scopes=billing
 td auth login --additional-scopes=app-management,backups
 td auth login --callback-port 9000           # override the OAuth callback port
 td auth login --no-browser-open              # print the authorize URL instead of opening a browser
+td auth login --credential-store=plaintext   # explicitly store the credential in plaintext
 td auth login --json                         # emit the new account record as JSON
 td auth login --ndjson                       # one-line newline-delimited JSON
 td auth token
+td auth token "$TOKEN" --credential-store=plaintext
 td auth status
 td auth status --json                        # full status payload as JSON (--ndjson also supported)
 TOKEN=$(td auth token view)
@@ -50,7 +52,7 @@ td auth logout
 td auth logout --json                        # emits \`{"ok": true}\` (--ndjson is silent)
 \`\`\`
 
-\`td auth login\`, \`td auth status\`, and \`td auth logout\` all accept the standard \`--json\` / \`--ndjson\` machine-output flags. For \`login\` and \`status\` the body carries the account record (id, email, auth metadata, plus \`storedUsers\` and \`source\` from status); \`logout\` emits a \`{"ok": true}\` envelope under \`--json\` and stays silent under \`--ndjson\`. Across all three, keyring-fallback warnings are written to stderr so stdout stays parseable. \`td auth login\` additionally accepts \`--callback-port <n>\` (default \`8765\`, with a small fallback range when the port is busy) and \`--no-browser-open\`, which prints the authorization URL for manual copy-paste instead of opening a browser (useful on headless or remote hosts).
+\`td auth login\`, \`td auth status\`, and \`td auth logout\` all accept the standard \`--json\` / \`--ndjson\` machine-output flags. For \`login\` and \`status\` the body carries the account record (id, email, auth metadata, plus \`storedUsers\` and \`source\` from status); \`logout\` emits a \`{"ok": true}\` envelope under \`--json\` and stays silent under \`--ndjson\`. \`td auth login\` additionally accepts \`--callback-port <n>\` (default \`8765\`, with a small fallback range when the port is busy) and \`--no-browser-open\`, which prints the authorization URL for manual copy-paste instead of opening a browser (useful on headless or remote hosts).
 
 Opt-in OAuth scopes are requested via \`--additional-scopes=<list>\` (comma-separated). Run \`td auth login --help\` for the full list. Currently supported:
 
@@ -60,7 +62,7 @@ Opt-in OAuth scopes are requested via \`--additional-scopes=<list>\` (comma-sepa
 
 Combine freely with \`--read-only\` to keep data access read-only while still granting an opt-in scope (e.g. \`td auth login --read-only --additional-scopes=backups\`). When a command fails for lack of a scope, the error suggests a re-login command that preserves whichever flags were originally used.
 
-Tokens are stored in the OS credential manager when available, with fallback to \`~/.config/todoist-cli/config.json\`. \`TODOIST_API_TOKEN\` takes precedence over stored credentials.
+Tokens are stored in the OS credential manager by default. If it is unavailable, credential writes fail without a plaintext fallback. Pass \`--credential-store=plaintext\` to \`td auth login\` or \`td auth token\` only when you explicitly accept plaintext config-file storage; every such write emits a warning to stderr. \`TODOIST_API_TOKEN\` takes precedence over stored credentials.
 
 \`td auth token view\` writes the stored token to stdout for use in scripts. **Always capture it into a shell variable** (e.g. \`TOKEN=$(td auth token view)\`) — never invoke it bare in an agent transcript or piped to a shell that echoes its output, since that would leak the secret. Honors \`--user <id|email>\` for multi-account installs and refuses when \`TODOIST_API_TOKEN\` is set in the environment (the token is already available there).
 

--- a/src/lib/user-records.test.ts
+++ b/src/lib/user-records.test.ts
@@ -83,7 +83,7 @@ describe('createTodoistUserRecordStore', () => {
         expect(persisted.users[0].api_token).toBeUndefined()
     })
 
-    it('upsert preserves fallbackToken when supplied (keyring-offline write)', async () => {
+    it('upsert preserves fallbackToken when supplied (plaintext credential write)', async () => {
         const { createTodoistUserRecordStore } = await import('./user-records.js')
         await createTodoistUserRecordStore().upsert({
             account: ACCOUNT_A,


### PR DESCRIPTION
Closes https://github.com/Doist/todoist-cli/issues/424

## Summary

- Upgrade to `@doist/cli-core@1.1.0`, which owns the keyring storage policy.
- Default Todoist CLI credential writes to strict system storage: an unavailable credential manager fails the write without creating a plaintext config entry.
- Keep `--credential-store=plaintext` as the explicit opt-in for both OAuth and manual-token authentication; cli-core returns a warning for every successful plaintext credential write.

## Usage

Default, system-only storage:

```sh
td auth login
td auth token "YOUR_TOKEN"
```

Explicit plaintext storage:

```sh
td auth login --credential-store=plaintext
td auth token "YOUR_TOKEN" --credential-store=plaintext
# Warning: credential stored as plaintext in ~/.config/todoist-cli/config.json
```

## Verification

- Clean dependency install: `npm ci`
- `npm run build`
- `npm run type-check`
- Full test suite: 66 files, 1,740 tests
- `npm run check`
- Verified `td auth login --help` and `td auth token --help` show the new flag