### PR TITLE
fix: set Comms audience to thread

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,4 +138,5 @@ jobs:
                   workspace-id: 69
                   thread-id: CZECS4Yebwx7c1c8hDRmB
                   content: ${{ steps.announcement.outputs.message }}
+                  audience: thread
               continue-on-error: true


### PR DESCRIPTION
## Summary

Set the Comms post-comment action's `audience` input to `thread`.