### PR TITLE
feat(task): add explicit --first-due

### DIFF
--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -150,7 +150,7 @@ Choosing between `task add` and `task quickadd`:
 - Use `td task add` when you need flags that Quick Add syntax can't express (`--deadline`, `--description`, `--parent`, `--duration`, `--uncompletable`, `--order`), when the text is being composed programmatically, or when you need explicit `id:` / URL references for project/section/parent.
 - `td task quickadd` supports `--stdin`, `--json`, and `--dry-run` only; everything else is embedded in the text.
 - The top-level `td add <text>` is a human shorthand for `td task quickadd` — same parser, same flag surface (`--stdin`, `--json`, `--dry-run`). Agents should prefer `td task quickadd` / `qa` for discoverability alongside the other task subcommands.
-- `--due` on `task add` / `task update` is **sent verbatim** to the API as `due_string` — the CLI does not parse or rewrite it. The server's `due_string` parser handles simple inputs ("2026-06-01", "tomorrow", "every Monday") but does **not** unpack some more complex clauses (i.e. `starting <date>`).
+- Use `--first-due YYYY-MM-DD` with a recurring `--due` rule on `task add` / `task update` to set its initial occurrence while keeping the recurrence advancing (for example, `--due "every! 2 weeks" --first-due 2026-05-17`). `--first-due` requires `--due`; due values are otherwise sent to the API unchanged.
 
 Useful task flags:
 - `--stdin` on `task add` reads the task description from stdin; on `task quickadd` (and the top-level `td add`) it reads the full natural-language text from stdin.

--- a/src/commands/task/add.ts
+++ b/src/commands/task/add.ts
@@ -1,4 +1,4 @@
-import { getApi } from '../../lib/api/core.js'
+import { getApi, rescheduleTask as rescheduleTaskSync } from '../../lib/api/core.js'
 import { resolveAssigneeId } from '../../lib/collaborators.js'
 import { CliError } from '../../lib/errors.js'
 import { isQuiet } from '../../lib/global-args.js'
@@ -13,7 +13,7 @@ import {
 } from '../../lib/refs.js'
 import { readStdin } from '../../lib/stdin.js'
 import { parsePriority } from '../../lib/task-list.js'
-import { applyDuration, type DurationArgs } from './helpers.js'
+import { applyDuration, type DurationArgs, validateFirstDueDate } from './helpers.js'
 
 export interface AddOptions {
     content: string
@@ -32,18 +32,18 @@ export interface AddOptions {
     order?: number
     json?: boolean
     dryRun?: boolean
+    firstDue?: string
 }
 
 export async function addTask(options: AddOptions): Promise<void> {
+    const firstDue = validateFirstDueDate(options.firstDue, options.due)
     const api = await getApi()
 
     const args: Parameters<typeof api.addTask>[0] = {
         content: options.content,
     }
 
-    if (options.due) {
-        args.dueString = options.due
-    }
+    if (options.due) args.dueString = options.due
 
     if (options.deadline) {
         args.deadlineDate = options.deadline
@@ -141,6 +141,7 @@ export async function addTask(options: AddOptions): Promise<void> {
             Content: args.content,
             Description: args.description,
             Due: args.dueString,
+            'First occurrence': firstDue,
             Deadline: args.deadlineDate ?? undefined,
             Priority: options.priority,
             Project: options.project,
@@ -155,7 +156,29 @@ export async function addTask(options: AddOptions): Promise<void> {
         return
     }
 
-    const task = await api.addTask(args)
+    let task = await api.addTask(args)
+
+    if (firstDue) {
+        if (!task.due) {
+            throw new CliError(
+                'FIRST_DUE_NOT_APPLIED',
+                `Task "${task.id}" was created without a due date, so its first occurrence could not be set.`,
+            )
+        }
+        try {
+            await rescheduleTaskSync(task.id, firstDue, task.due)
+        } catch (error) {
+            throw new CliError(
+                'FIRST_DUE_NOT_APPLIED',
+                `Task "${task.id}" was created, but its first occurrence could not be set.`,
+                [
+                    `Recover with: td task reschedule id:${task.id} ${firstDue}`,
+                    `Underlying error: ${(error as Error).message}`,
+                ],
+            )
+        }
+        task = await api.getTask(task.id)
+    }
 
     if (options.json) {
         console.log(formatJson(task, 'task'))

--- a/src/commands/task/helpers.ts
+++ b/src/commands/task/helpers.ts
@@ -3,6 +3,39 @@ import { CliError } from '../../lib/errors.js'
 
 export type DurationArgs = { duration?: number; durationUnit?: 'minute' | 'day' }
 
+export function validateFirstDueDate(
+    firstDue: string | undefined,
+    due: string | false | undefined,
+): string | undefined {
+    if (firstDue === undefined) return undefined
+
+    if (due === false) {
+        throw new CliError('CONFLICTING_OPTIONS', 'Cannot use --first-due and --no-due together.')
+    }
+
+    if (typeof due !== 'string' || !due.trim()) {
+        throw new CliError('FIRST_DUE_REQUIRES_DUE', 'The --first-due flag requires --due.', [
+            'Example: td task add "Task" --due "every 2 weeks" --first-due 2026-05-17',
+        ])
+    }
+
+    const date = firstDue.trim()
+    const parsed = new Date(`${date}T00:00:00Z`)
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(parsed.getTime())) {
+        throw new CliError('INVALID_FIRST_DUE', `Invalid first due date: "${firstDue}"`, [
+            'Use YYYY-MM-DD (for example, 2026-05-17).',
+        ])
+    }
+
+    if (parsed.toISOString().slice(0, 10) !== date) {
+        throw new CliError('INVALID_FIRST_DUE', `Invalid first due date: "${firstDue}"`, [
+            'Use a valid calendar date in YYYY-MM-DD format (for example, 2026-05-17).',
+        ])
+    }
+
+    return date
+}
+
 export function applyDuration(args: DurationArgs, durationStr: string): void {
     const minutes = parseDuration(durationStr)
     if (minutes === null) {

--- a/src/commands/task/index.ts
+++ b/src/commands/task/index.ts
@@ -119,7 +119,8 @@ Examples:
         .command('add [content]')
         .description('Add a task')
         .option('--content <text>', 'Task content (legacy, prefer positional argument)')
-        .option('--due <date>', 'Due date (YYYY-MM-DD or simple natural language; see Notes below)')
+        .option('--due <date>', 'Due date (YYYY-MM-DD or simple natural language)')
+        .option('--first-due <date>', 'First occurrence date (YYYY-MM-DD; requires --due)')
         .option('--deadline <date>', 'Deadline date (YYYY-MM-DD)')
         .addOption(
             withCaseInsensitiveChoices(
@@ -165,9 +166,8 @@ Examples:
             'after',
             `
 Notes:
-  --due is sent verbatim as the task's due_string. The server's due_string
-  parser handles simple inputs ("2026-06-01", "tomorrow", "every Monday") but
-  does not unpack some more complex clauses (i.e. "starting <date>").`,
+  Use --first-due with a recurring --due rule to set its initial occurrence:
+  td task add "Task" --due "every! 2 weeks" --first-due 2026-05-17`,
         )
 
     const quickaddCmd = task
@@ -191,10 +191,8 @@ Notes:
         .command('update [ref]')
         .description('Update a task')
         .option('--content <text>', 'New content')
-        .option(
-            '--due <date>',
-            'New due date (YYYY-MM-DD or simple natural language; see Notes below)',
-        )
+        .option('--due <date>', 'New due date (YYYY-MM-DD or simple natural language)')
+        .option('--first-due <date>', 'First occurrence date (YYYY-MM-DD; requires --due)')
         .option('--no-due', 'Remove due date')
         .option('--deadline <date>', 'Deadline date (YYYY-MM-DD)')
         .option('--no-deadline', 'Remove deadline')
@@ -235,9 +233,8 @@ Notes:
             'after',
             `
 Notes:
-  --due is sent verbatim as the task's due_string, with the same caveats as
-  "task add --due": the server's due_string parser does not unpack some more
-  complex clauses (i.e. "starting <date>").`,
+  Use --first-due with a recurring --due rule to set its initial occurrence.
+  See "task add --due" for an example.`,
         )
 
     const moveCmd = task

--- a/src/commands/task/task.test.ts
+++ b/src/commands/task/task.test.ts
@@ -706,6 +706,95 @@ describe('task add', () => {
         expect(consoleSpy).toHaveBeenCalledWith('Due: tomorrow')
     })
 
+    it('creates recurring task with --first-due that advances on completion', async () => {
+        const program = createProgram()
+        captureConsole()
+        const initialDue = {
+            date: '2026-07-31',
+            string: 'every! 2 weeks',
+            isRecurring: true,
+            timezone: null,
+            lang: 'en',
+        }
+
+        mockApi.addTask.mockResolvedValue({ id: 'task-new', content: 'Task', due: initialDue })
+        mockApi.getTask.mockResolvedValue({
+            id: 'task-new',
+            content: 'Task',
+            due: { ...initialDue, date: '2026-05-17' },
+        })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'task',
+            'add',
+            'Task',
+            '--due',
+            'every! 2 weeks',
+            '--first-due',
+            '2026-05-17',
+        ])
+
+        expect(mockApi.addTask).toHaveBeenCalledWith(
+            expect.objectContaining({ dueString: 'every! 2 weeks' }),
+        )
+        expect(mockRescheduleTask).toHaveBeenCalledWith('task-new', '2026-05-17', initialDue)
+        expect(mockApi.getTask).toHaveBeenCalledWith('task-new')
+    })
+
+    it('passes due strings through unchanged without --first-due', async () => {
+        const program = createProgram()
+        captureConsole()
+
+        mockApi.addTask.mockResolvedValue({ id: 'task-new', content: 'Task', due: null })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'task',
+            'add',
+            'Task',
+            '--due',
+            'every! 2 weeks starting 2026-05-17',
+        ])
+
+        expect(mockApi.addTask).toHaveBeenCalledWith(
+            expect.objectContaining({ dueString: 'every! 2 weeks starting 2026-05-17' }),
+        )
+        expect(mockRescheduleTask).not.toHaveBeenCalled()
+    })
+
+    it('rejects --first-due without --due before creating a task', async () => {
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'td', 'task', 'add', 'Task', '--first-due', '2026-05-17']),
+        ).rejects.toThrow('The --first-due flag requires --due.')
+
+        expect(mockApi.addTask).not.toHaveBeenCalled()
+    })
+
+    it('rejects an invalid --first-due date before creating a task', async () => {
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'task',
+                'add',
+                'Task',
+                '--due',
+                'every 2 weeks',
+                '--first-due',
+                '2026-02-29',
+            ]),
+        ).rejects.toThrow('Invalid first due date: "2026-02-29"')
+
+        expect(mockApi.addTask).not.toHaveBeenCalled()
+    })
+
     it('creates task with --priority', async () => {
         const program = createProgram()
         captureConsole()
@@ -1111,6 +1200,64 @@ describe('task update', () => {
         expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', {
             dueString: 'next week',
         })
+    })
+
+    it('updates a recurring task with --first-due that advances on completion', async () => {
+        const program = createProgram()
+        captureConsole()
+        const initialDue = {
+            date: '2026-07-31',
+            string: 'every! 2 weeks',
+            isRecurring: true,
+            timezone: null,
+            lang: 'en',
+        }
+
+        mockApi.getTask
+            .mockResolvedValueOnce({ id: 'task-1', content: 'Task' })
+            .mockResolvedValueOnce({
+                id: 'task-1',
+                content: 'Task',
+                due: { ...initialDue, date: '2026-05-17' },
+            })
+        mockApi.updateTask.mockResolvedValue({ id: 'task-1', content: 'Task', due: initialDue })
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'task',
+            'update',
+            'id:task-1',
+            '--due',
+            'every! 2 weeks',
+            '--first-due',
+            '2026-05-17',
+        ])
+
+        expect(mockApi.updateTask).toHaveBeenCalledWith('task-1', {
+            dueString: 'every! 2 weeks',
+        })
+        expect(mockRescheduleTask).toHaveBeenCalledWith('task-1', '2026-05-17', initialDue)
+        expect(mockApi.getTask).toHaveBeenLastCalledWith('task-1')
+    })
+
+    it('rejects --first-due with --no-due before updating a task', async () => {
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'td',
+                'task',
+                'update',
+                'id:task-1',
+                '--no-due',
+                '--first-due',
+                '2026-05-17',
+            ]),
+        ).rejects.toThrow('Cannot use --first-due and --no-due together.')
+
+        expect(mockApi.updateTask).not.toHaveBeenCalled()
     })
 
     it('updates task priority', async () => {
@@ -2740,23 +2887,23 @@ describe('task add/update --due help text', () => {
         return output
     }
 
-    it('task add --help documents the verbatim caveat for --due', async () => {
+    it('task add --help documents --first-due', async () => {
         const output = await captureHelp(['task', 'add', '--help'])
 
         expect(output).toContain('--due')
         expect(output).toContain('Notes:')
-        expect(output).toContain('sent verbatim')
-        expect(output).toContain('"starting <date>"')
+        expect(output).toContain('--first-due')
+        expect(output).toContain('initial occurrence')
+        expect(output).toContain('every! 2 weeks')
     })
 
-    it('task update --help documents the verbatim caveat and refers back to task add --due', async () => {
+    it('task update --help documents --first-due', async () => {
         const output = await captureHelp(['task', 'update', '--help'])
 
         expect(output).toContain('--due')
         expect(output).toContain('Notes:')
-        expect(output).toContain('sent verbatim')
-        expect(output).toContain('"starting <date>"')
-        expect(output).toContain('same caveats as')
+        expect(output).toContain('--first-due')
+        expect(output).toContain('initial occurrence')
         expect(output).toContain('"task add --due"')
     })
 })

--- a/src/commands/task/update.ts
+++ b/src/commands/task/update.ts
@@ -1,4 +1,4 @@
-import { getApi } from '../../lib/api/core.js'
+import { getApi, rescheduleTask as rescheduleTaskSync } from '../../lib/api/core.js'
 import { resolveAssigneeId } from '../../lib/collaborators.js'
 import { CliError } from '../../lib/errors.js'
 import { isQuiet } from '../../lib/global-args.js'
@@ -6,7 +6,7 @@ import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveTaskRef } from '../../lib/refs.js'
 import { readStdin } from '../../lib/stdin.js'
 import { parsePriority } from '../../lib/task-list.js'
-import { applyDuration, type DurationArgs } from './helpers.js'
+import { applyDuration, type DurationArgs, validateFirstDueDate } from './helpers.js'
 
 export interface UpdateOptions {
     content?: string
@@ -24,9 +24,11 @@ export interface UpdateOptions {
     order?: number
     json?: boolean
     dryRun?: boolean
+    firstDue?: string
 }
 
 export async function updateTask(ref: string, options: UpdateOptions): Promise<void> {
+    const firstDue = validateFirstDueDate(options.firstDue, options.due)
     const api = await getApi()
     const task = await resolveTaskRef(api, ref)
 
@@ -91,6 +93,7 @@ export async function updateTask(ref: string, options: UpdateOptions): Promise<v
             Content: args.content,
             Description: args.description ?? undefined,
             Due: args.dueString ?? undefined,
+            'First occurrence': firstDue,
             Deadline: args.deadlineDate ?? undefined,
             Priority: options.priority,
             Labels: options.labels === false ? '(remove all)' : options.labels,
@@ -104,7 +107,29 @@ export async function updateTask(ref: string, options: UpdateOptions): Promise<v
         return
     }
 
-    const updated = await api.updateTask(task.id, args)
+    let updated = await api.updateTask(task.id, args)
+
+    if (firstDue) {
+        if (!updated.due) {
+            throw new CliError(
+                'FIRST_DUE_NOT_APPLIED',
+                `Task "${updated.id}" was updated without a due date, so its first occurrence could not be set.`,
+            )
+        }
+        try {
+            await rescheduleTaskSync(updated.id, firstDue, updated.due)
+        } catch (error) {
+            throw new CliError(
+                'FIRST_DUE_NOT_APPLIED',
+                `Task "${updated.id}" was updated, but its first occurrence could not be set.`,
+                [
+                    `Recover with: td task reschedule id:${updated.id} ${firstDue}`,
+                    `Underlying error: ${(error as Error).message}`,
+                ],
+            )
+        }
+        updated = await api.getTask(updated.id)
+    }
 
     if (options.json) {
         console.log(formatJson(updated, 'task'))

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -146,7 +146,7 @@ Choosing between \`task add\` and \`task quickadd\`:
 - Use \`td task add\` when you need flags that Quick Add syntax can't express (\`--deadline\`, \`--description\`, \`--parent\`, \`--duration\`, \`--uncompletable\`, \`--order\`), when the text is being composed programmatically, or when you need explicit \`id:\` / URL references for project/section/parent.
 - \`td task quickadd\` supports \`--stdin\`, \`--json\`, and \`--dry-run\` only; everything else is embedded in the text.
 - The top-level \`td add <text>\` is a human shorthand for \`td task quickadd\` — same parser, same flag surface (\`--stdin\`, \`--json\`, \`--dry-run\`). Agents should prefer \`td task quickadd\` / \`qa\` for discoverability alongside the other task subcommands.
-- \`--due\` on \`task add\` / \`task update\` is **sent verbatim** to the API as \`due_string\` — the CLI does not parse or rewrite it. The server's \`due_string\` parser handles simple inputs ("2026-06-01", "tomorrow", "every Monday") but does **not** unpack some more complex clauses (i.e. \`starting <date>\`).
+- Use \`--first-due YYYY-MM-DD\` with a recurring \`--due\` rule on \`task add\` / \`task update\` to set its initial occurrence while keeping the recurrence advancing (for example, \`--due "every! 2 weeks" --first-due 2026-05-17\`). \`--first-due\` requires \`--due\`; due values are otherwise sent to the API unchanged.
 
 Useful task flags:
 - \`--stdin\` on \`task add\` reads the task description from stdin; on \`task quickadd\` (and the top-level \`td add\`) it reads the full natural-language text from stdin.


### PR DESCRIPTION
Adds an explicit --first-due option for task add and update, avoiding implicit parsing of natural-language due strings.

Closes #342