### PR TITLE
feat(filter): expose view options (board/list, group by, sort)

### DIFF
--- a/src/commands/filter/create.ts
+++ b/src/commands/filter/create.ts
@@ -1,9 +1,15 @@
 import chalk from 'chalk'
 import { addFilter, type UpdateFilterArgs } from '../../lib/api/filters.js'
+import { setViewOptions } from '../../lib/api/view-options.js'
 import { isQuiet } from '../../lib/global-args.js'
 import { formatJson, printDryRun } from '../../lib/output.js'
+import {
+    describeViewOptions,
+    parseViewOptionFlags,
+    type ViewOptionFlags,
+} from '../../lib/view-options.js'
 
-export interface CreateOptions {
+export interface CreateOptions extends ViewOptionFlags {
     name: string
     query: string
     color?: UpdateFilterArgs['color']
@@ -13,12 +19,15 @@ export interface CreateOptions {
 }
 
 export async function createFilter(options: CreateOptions): Promise<void> {
+    const viewOptions = parseViewOptionFlags(options)
+
     if (options.dryRun) {
         printDryRun('create filter', {
             Name: options.name,
             Query: options.query,
             Color: options.color,
             Favorite: options.favorite ? 'yes' : undefined,
+            View: viewOptions ? describeViewOptions(viewOptions) : undefined,
         })
         return
     }
@@ -29,6 +38,10 @@ export async function createFilter(options: CreateOptions): Promise<void> {
         color: options.color,
         isFavorite: options.favorite,
     })
+
+    if (viewOptions) {
+        await setViewOptions({ viewType: 'FILTER', objectId: filter.id, ...viewOptions })
+    }
 
     if (options.json) {
         console.log(formatJson(filter, 'filter'))
@@ -43,4 +56,5 @@ export async function createFilter(options: CreateOptions): Promise<void> {
     console.log(`Created: ${filter.name}`)
     console.log(chalk.dim(`ID: id:${filter.id}`))
     console.log(chalk.dim(`Query: ${filter.query}`))
+    if (viewOptions) console.log(chalk.dim(`View: ${describeViewOptions(viewOptions)}`))
 }

--- a/src/commands/filter/filter.test.ts
+++ b/src/commands/filter/filter.test.ts
@@ -12,7 +12,12 @@ vi.mock('../../lib/api/filters.js', () => ({
     deleteFilter: vi.fn(),
 }))
 
+vi.mock('../../lib/api/view-options.js', () => ({
+    setViewOptions: vi.fn(),
+}))
+
 import { addFilter, deleteFilter, fetchFilters, updateFilter } from '../../lib/api/filters.js'
+import { setViewOptions } from '../../lib/api/view-options.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
 import { makeFilter } from '../../test-support/fixtures.js'
 import { type MockApi } from '../../test-support/mock-api.js'
@@ -22,6 +27,7 @@ const mockFetchFilters = vi.mocked(fetchFilters)
 const mockAddFilter = vi.mocked(addFilter)
 const mockUpdateFilter = vi.mocked(updateFilter)
 const mockDeleteFilter = vi.mocked(deleteFilter)
+const mockSetViewOptions = vi.mocked(setViewOptions)
 
 function createProgram() {
     return createTestProgram(registerFilterCommand)
@@ -819,5 +825,125 @@ describe('filter --dry-run', () => {
 
         expect(mockUpdateFilter).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would update filter'))
+    })
+})
+
+describe('filter view options', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('sets board layout grouped by assignee on create', async () => {
+        const program = createProgram()
+        captureConsole()
+
+        mockAddFilter.mockResolvedValue(
+            makeFilter({ id: 'filter-team', name: 'Team', query: 'p1 | p2' }),
+        )
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'filter',
+            'create',
+            '--name',
+            'Team',
+            '--query',
+            'p1 | p2',
+            '--view-mode',
+            'board',
+            '--group-by',
+            'assignee',
+        ])
+
+        expect(mockSetViewOptions).toHaveBeenCalledWith({
+            viewType: 'FILTER',
+            objectId: 'filter-team',
+            viewMode: 'BOARD',
+            groupedBy: 'ASSIGNEE',
+        })
+    })
+
+    it('normalizes kebab-case values to the uppercase enums the API expects', async () => {
+        const program = createProgram()
+        captureConsole()
+
+        mockFetchFilters.mockResolvedValue([
+            makeFilter({ id: 'filter-1', name: 'Work', query: '@work' }),
+        ])
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'filter',
+            'update',
+            'Work',
+            '--sort-by',
+            'due-date',
+            '--sort-order',
+            'desc',
+        ])
+
+        expect(mockSetViewOptions).toHaveBeenCalledWith({
+            viewType: 'FILTER',
+            objectId: 'filter-1',
+            sortedBy: 'DUE_DATE',
+            sortOrder: 'DESC',
+        })
+    })
+
+    it('updates view options without touching the filter itself', async () => {
+        const program = createProgram()
+        captureConsole()
+
+        mockFetchFilters.mockResolvedValue([
+            makeFilter({ id: 'filter-1', name: 'Work', query: '@work' }),
+        ])
+
+        await program.parseAsync(['node', 'td', 'filter', 'update', 'Work', '--view-mode', 'list'])
+
+        expect(mockUpdateFilter).not.toHaveBeenCalled()
+        expect(mockSetViewOptions).toHaveBeenCalledWith({
+            viewType: 'FILTER',
+            objectId: 'filter-1',
+            viewMode: 'LIST',
+        })
+    })
+
+    it('rejects an unknown value and lists the allowed ones', async () => {
+        const program = createProgram()
+        captureConsole()
+
+        mockFetchFilters.mockResolvedValue([
+            makeFilter({ id: 'filter-1', name: 'Work', query: '@work' }),
+        ])
+
+        await expect(
+            program.parseAsync(['node', 'td', 'filter', 'update', 'Work', '--group-by', 'colour']),
+        ).rejects.toThrow(/colour/)
+
+        expect(mockSetViewOptions).not.toHaveBeenCalled()
+    })
+
+    it('does not call the view options API when no view flag is given', async () => {
+        const program = createProgram()
+        captureConsole()
+
+        mockAddFilter.mockResolvedValue(
+            makeFilter({ id: 'filter-plain', name: 'Plain', query: 'today' }),
+        )
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'filter',
+            'create',
+            '--name',
+            'Plain',
+            '--query',
+            'today',
+        ])
+
+        expect(mockSetViewOptions).not.toHaveBeenCalled()
     })
 })

--- a/src/commands/filter/index.ts
+++ b/src/commands/filter/index.ts
@@ -28,6 +28,16 @@ export function registerFilterCommand(program: Command): void {
         .option('--query <query>', 'Filter query (required, e.g., "today | overdue")')
         .option('--color <color>', 'Filter color')
         .option('--favorite', 'Mark as favorite')
+        .option('--view-mode <mode>', 'Layout: list, board or calendar')
+        .option(
+            '--group-by <field>',
+            'Group tasks by: assignee, added-date, due-date, deadline, label, priority, project, workspace',
+        )
+        .option(
+            '--sort-by <field>',
+            'Sort tasks by: manual, alphabetically, assignee, due-date, deadline, added-date, priority, project, workspace',
+        )
+        .option('--sort-order <order>', 'Sort direction: asc or desc')
         .option('--json', 'Output the created filter as JSON')
         .option('--dry-run', 'Preview what would happen without executing')
         .action((options) => {
@@ -59,6 +69,16 @@ export function registerFilterCommand(program: Command): void {
         .option('--color <color>', 'New color')
         .option('--favorite', 'Mark as favorite')
         .option('--no-favorite', 'Remove from favorites')
+        .option('--view-mode <mode>', 'Layout: list, board or calendar')
+        .option(
+            '--group-by <field>',
+            'Group tasks by: assignee, added-date, due-date, deadline, label, priority, project, workspace',
+        )
+        .option(
+            '--sort-by <field>',
+            'Sort tasks by: manual, alphabetically, assignee, due-date, deadline, added-date, priority, project, workspace',
+        )
+        .option('--sort-order <order>', 'Sort direction: asc or desc')
         .option('--dry-run', 'Preview what would happen without executing')
         .action((ref, options) => {
             if (!ref) {

--- a/src/commands/filter/update.ts
+++ b/src/commands/filter/update.ts
@@ -1,10 +1,16 @@
 import { type UpdateFilterArgs, updateFilter } from '../../lib/api/filters.js'
+import { setViewOptions } from '../../lib/api/view-options.js'
 import { CliError } from '../../lib/errors.js'
 import { isQuiet } from '../../lib/global-args.js'
 import { printDryRun } from '../../lib/output.js'
+import {
+    describeViewOptions,
+    parseViewOptionFlags,
+    type ViewOptionFlags,
+} from '../../lib/view-options.js'
 import { resolveFilterRef } from './helpers.js'
 
-export interface UpdateOptions {
+export interface UpdateOptions extends ViewOptionFlags {
     name?: string
     query?: string
     color?: UpdateFilterArgs['color']
@@ -14,6 +20,7 @@ export interface UpdateOptions {
 
 export async function updateFilterCmd(nameOrId: string, options: UpdateOptions): Promise<void> {
     const filter = await resolveFilterRef(nameOrId)
+    const viewOptions = parseViewOptionFlags(options)
 
     const args: UpdateFilterArgs = {}
     if (options.name) args.name = options.name
@@ -21,7 +28,7 @@ export async function updateFilterCmd(nameOrId: string, options: UpdateOptions):
     if (options.color) args.color = options.color
     if (options.favorite !== undefined) args.isFavorite = options.favorite
 
-    if (Object.keys(args).length === 0) {
+    if (Object.keys(args).length === 0 && !viewOptions) {
         throw new CliError('NO_CHANGES', 'No changes specified.')
     }
 
@@ -32,11 +39,18 @@ export async function updateFilterCmd(nameOrId: string, options: UpdateOptions):
             Query: args.query,
             Color: args.color,
             Favorite: args.isFavorite !== undefined ? String(args.isFavorite) : undefined,
+            View: viewOptions ? describeViewOptions(viewOptions) : undefined,
         })
         return
     }
 
-    await updateFilter(filter.id, args)
+    if (Object.keys(args).length > 0) {
+        await updateFilter(filter.id, args)
+    }
+    if (viewOptions) {
+        await setViewOptions({ viewType: 'FILTER', objectId: filter.id, ...viewOptions })
+    }
+
     if (!isQuiet())
         console.log(
             `Updated: ${filter.name}${options.name ? ` -> ${options.name}` : ''} (id:${filter.id})`,

--- a/src/lib/api/view-options.ts
+++ b/src/lib/api/view-options.ts
@@ -1,0 +1,32 @@
+import { createCommand, type ViewType } from '@doist/todoist-sdk'
+import type { ParsedViewOptions } from '../view-options.js'
+import { getApi, pickDefined } from './core.js'
+
+export interface SetViewOptionsArgs extends ParsedViewOptions {
+    viewType: ViewType
+    objectId?: string
+}
+
+/**
+ * Sets the presentation of a view (layout, grouping, sorting).
+ *
+ * View options are stored per user, so this only affects the authenticated
+ * account even when the underlying object is shared.
+ */
+export async function setViewOptions(args: SetViewOptionsArgs): Promise<void> {
+    const api = await getApi()
+    await api.sync({
+        commands: [
+            createCommand('view_options_set', {
+                viewType: args.viewType,
+                ...pickDefined({
+                    objectId: args.objectId,
+                    viewMode: args.viewMode,
+                    groupedBy: args.groupedBy,
+                    sortedBy: args.sortedBy,
+                    sortOrder: args.sortOrder,
+                }),
+            }),
+        ],
+    })
+}

--- a/src/lib/view-options.ts
+++ b/src/lib/view-options.ts
@@ -1,0 +1,78 @@
+import {
+    GROUPED_BY_OPTIONS,
+    SORT_ORDERS,
+    SORTED_BY_OPTIONS,
+    VIEW_MODES,
+    type GroupedBy,
+    type SortOrder,
+    type SortedBy,
+    type ViewMode,
+} from '@doist/todoist-sdk'
+import { CliError } from './errors.js'
+
+/**
+ * The Sync API expects these enums in UPPERCASE (`BOARD`, `ASSIGNEE`, ...), and
+ * rejects anything else with `error_code: 20`. Users type lowercase and kebab-case
+ * on the command line, so normalize before sending: `due-date` -> `DUE_DATE`.
+ */
+function normalize(value: string): string {
+    return value.trim().toUpperCase().replaceAll('-', '_')
+}
+
+function parseEnum<T extends string>(value: string, allowed: readonly T[], option: string): T {
+    const normalized = normalize(value)
+    const match = allowed.find((a) => a === normalized)
+    if (!match) {
+        throw new CliError('INVALID_OPTIONS', `Invalid value "${value}" for ${option}.`, [
+            `Allowed: ${allowed.map((a) => a.toLowerCase().replaceAll('_', '-')).join(', ')}`,
+        ])
+    }
+    return match
+}
+
+export function parseViewMode(value: string): ViewMode {
+    return parseEnum(value, VIEW_MODES, '--view-mode')
+}
+
+export function parseGroupedBy(value: string): GroupedBy {
+    return parseEnum(value, GROUPED_BY_OPTIONS, '--group-by')
+}
+
+export function parseSortedBy(value: string): SortedBy {
+    return parseEnum(value, SORTED_BY_OPTIONS, '--sort-by')
+}
+
+export function parseSortOrder(value: string): SortOrder {
+    return parseEnum(value, SORT_ORDERS, '--sort-order')
+}
+
+export interface ViewOptionFlags {
+    viewMode?: string
+    groupBy?: string
+    sortBy?: string
+    sortOrder?: string
+}
+
+export interface ParsedViewOptions {
+    viewMode?: ViewMode
+    groupedBy?: GroupedBy
+    sortedBy?: SortedBy
+    sortOrder?: SortOrder
+}
+
+/** Returns `undefined` when no view-option flag was supplied. */
+export function parseViewOptionFlags(flags: ViewOptionFlags): ParsedViewOptions | undefined {
+    const parsed: ParsedViewOptions = {}
+    if (flags.viewMode) parsed.viewMode = parseViewMode(flags.viewMode)
+    if (flags.groupBy) parsed.groupedBy = parseGroupedBy(flags.groupBy)
+    if (flags.sortBy) parsed.sortedBy = parseSortedBy(flags.sortBy)
+    if (flags.sortOrder) parsed.sortOrder = parseSortOrder(flags.sortOrder)
+    return Object.keys(parsed).length > 0 ? parsed : undefined
+}
+
+/** Human-readable summary for `--dry-run` output. */
+export function describeViewOptions(options: ParsedViewOptions): string {
+    return Object.entries(options)
+        .map(([key, value]) => `${key}=${String(value).toLowerCase()}`)
+        .join(', ')
+}


### PR DESCRIPTION
Implements **Option A** from #462 — flags on the existing commands, since that was the smallest surface that covers the common cases. Happy to reshape into a dedicated subcommand (Option B) if you'd rather reach `TODAY`/`UPCOMING` too; the parsing and API layers are already separate from the filter commands, so moving them is cheap.

## What this adds

```bash
td filter create --name "Team" --query "(p1 | p2 | !no deadline)" \
    --view-mode board --group-by assignee --sort-by priority --sort-order desc

td filter update "Team" --view-mode list
```

Four new flags on `filter create` and `filter update`: `--view-mode`, `--group-by`, `--sort-by`, `--sort-order`.

## Notes on the implementation

- **Wiring, not new capability.** `@doist/todoist-sdk` already types `view_options_set` and re-exports `VIEW_MODES` / `GROUPED_BY_OPTIONS` / `SORTED_BY_OPTIONS` / `SORT_ORDERS`. Allowed values are derived from those constants rather than restated, so the CLI can't drift from the SDK.
- **Casing is handled for the user.** The Sync API requires uppercase enums and rejects anything else with `error_code: 20`, while the API reference documents lowercase. Flags accept lowercase kebab-case and normalise (`due-date` → `DUE_DATE`). Invalid values fail before any request with the allowed list echoed back.
- **`update` with only view flags no longer trips `NO_CHANGES`**, and skips the `filter_update` call when nothing about the filter itself changed — one command, one request.
- `src/lib/api/view-options.ts` takes a `viewType`/`objectId` rather than being filter-specific, so `project`/`label` can reuse it.
- View options are stored per user; the doc comment says so, since it is easy to assume they travel with a shared project.

## Verification

- `npm run check`, `npm run type-check`, `npm run build` — clean
- `npm test` — 1784 passing (5 added)
- Exercised end-to-end against the live API: after `filter create ... --view-mode board --group-by assignee --sort-by priority --sort-order desc`, a `view_options` sync read returns

  ```json
  {"view_type": "FILTER", "object_id": "...", "view_mode": "BOARD",
   "grouped_by": "ASSIGNEE", "sorted_by": "PRIORITY", "sort_order": "DESC"}
  ```

- Dry-run and validation output:

  ```
  $ td filter create --name "Team" --query today --view-mode board --group-by assignee --dry-run
  [dry-run] Would create filter:
    Name: Team
    Query: today
    View: viewMode=board, groupedBy=assignee

  $ td filter create --name X --query today --group-by colour
  Error: INVALID_OPTIONS
  Invalid value "colour" for --group-by.
    - Allowed: assignee, added-date, due-date, deadline, label, priority, project, workspace
  ```

Closes #462
