### PR TITLE
feat(comment): notify collaborators when adding a comment

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -177,7 +177,9 @@ New subcommand? Copy a sibling in the target group, wire it in that group's
 - **`markdown.ts`** — `preloadMarkdown`, markdown → terminal renderer
 - **`errors.ts`** — `CliError(code, message, hints?)`, `ErrorType` union
 - **`collaborators.ts`** — `CollaboratorCache`, `formatAssignee`,
-  `resolveAssigneeId`
+  `resolveAssigneeId`, `fetchCollaboratorsForProject`, `resolveNotifyIds`
+- **`comment-recipients.ts`** — `getDefaultCommentRecipients`: who a new
+  comment notifies when the caller does not say
 - **`global-args.ts`** — `isJsonMode`, `isNdjsonMode`, `isRawMode`,
   `isQuiet`, `isAccessible`, progress-jsonl target
 - **`logger.ts`** — verbose levels 0–4, `initializeLogger`

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -269,6 +269,8 @@ td comment list "Plan sprint"
 td comment list "Roadmap" --project
 td comment add "Plan sprint" --content "See attached" --file ./report.pdf
 td comment add "Plan sprint" --content "See attached" --file ./report.pdf --file-name "Quarterly report.pdf"
+td comment add "Plan sprint" --content "@Ana could you review?" --notify "Ana"
+td comment add "Plan sprint" --content "Note to self" --no-notify
 td comment update id:123 --content "Updated text"
 td comment delete id:123 --yes
 td comment browse id:123
@@ -296,6 +298,8 @@ td reminder location get id:456
 ```
 
 `td attachment view` prints text attachments directly and encodes binary content as base64. Use `--json` for metadata plus content. Prefer this over `curl` + `Read` on Todoist file URLs — for images in particular, `Read` will try to decode the file through the vision pipeline, and if that fails the image stays pinned in conversation context and every retry hits the same error.
+
+Comments notify only the people `comment add` is handed. Writing "@Ana" in the text notifies nobody — name her with `--notify`. Omit `--notify` to notify whoever the Todoist apps would (the task's assignee, assigner and creator on a first comment, or the previous comment's participants on a reply), or pass `--no-notify` to stay silent. Notification cannot be sent when editing a comment, only when adding one.
 
 `td comment view` flags image attachments with a `Hint` line pointing at `td attachment view`. In `--json` mode the hint is written to stderr so stdout stays parseable — watch the tool output, not just the JSON body.
 

--- a/src/commands/comment/add.ts
+++ b/src/commands/comment/add.ts
@@ -93,12 +93,6 @@ export async function addComment(ref: string, options: AddOptions): Promise<void
     } else if (options.notify) {
         const project = await api.getProject(targetProjectId)
         notifyCollaborators = await fetchCollaboratorsForProject(api, project)
-        if (notifyCollaborators.length === 0) {
-            throw new CliError(
-                'NOT_SHARED',
-                `Cannot notify anyone on "${project.name}" — it is not shared with anybody.`,
-            )
-        }
         uidsToNotify = resolveNotifyIds({
             refs: options.notify.split(','),
             collaborators: notifyCollaborators,

--- a/src/commands/comment/add.ts
+++ b/src/commands/comment/add.ts
@@ -1,5 +1,12 @@
 import chalk from 'chalk'
-import { getApi } from '../../lib/api/core.js'
+import { getApi, getCurrentUserId } from '../../lib/api/core.js'
+import {
+    type CollaboratorInfo,
+    fetchCollaboratorsForProject,
+    formatUserShortName,
+    resolveNotifyIds,
+} from '../../lib/collaborators.js'
+import { getDefaultCommentRecipients } from '../../lib/comment-recipients.js'
 import { CliError } from '../../lib/errors.js'
 import { isQuiet } from '../../lib/global-args.js'
 import { openLocalFileAsBlob } from '../../lib/local-file.js'
@@ -13,6 +20,9 @@ interface AddOptions {
     file?: string
     fileName?: string
     project?: boolean
+    // Commander sets this to false for --no-notify, and to the raw
+    // comma-separated string for --notify.
+    notify?: string | false
     json?: boolean
     dryRun?: boolean
 }
@@ -51,6 +61,9 @@ export async function addComment(ref: string, options: AddOptions): Promise<void
             'Target type': options.project ? 'project' : 'task',
             Content: content.length > 80 ? `${content.slice(0, 80)}...` : content,
             File: options.file,
+            // Printed unresolved: the dry-run deliberately runs before getApi(),
+            // so no lookup has happened at this point.
+            Notify: describeNotifyOption(options.notify),
         })
         return
     }
@@ -59,14 +72,41 @@ export async function addComment(ref: string, options: AddOptions): Promise<void
 
     let targetArgs: { taskId: string } | { projectId: string }
     let targetName: string
+    let targetProjectId: string
     if (options.project) {
         const project = await resolveProjectRef(api, ref)
         targetArgs = { projectId: project.id }
         targetName = project.name
+        targetProjectId = project.id
     } else {
         const task = await resolveTaskRef(api, ref)
         targetArgs = { taskId: task.id }
         targetName = task.content
+        targetProjectId = task.projectId
+    }
+
+    // Held so the confirmation line can name people without a second fetch.
+    let notifyCollaborators: CollaboratorInfo[] | undefined
+    let uidsToNotify: string[]
+    if (options.notify === false) {
+        uidsToNotify = []
+    } else if (options.notify) {
+        const project = await api.getProject(targetProjectId)
+        notifyCollaborators = await fetchCollaboratorsForProject(api, project)
+        if (notifyCollaborators.length === 0) {
+            throw new CliError(
+                'NOT_SHARED',
+                `Cannot notify anyone on "${project.name}" — it is not shared with anybody.`,
+            )
+        }
+        uidsToNotify = resolveNotifyIds({
+            refs: options.notify.split(','),
+            collaborators: notifyCollaborators,
+            currentUserId: await getCurrentUserId(),
+            projectName: project.name,
+        })
+    } else {
+        uidsToNotify = await getDefaultCommentRecipients(api, targetArgs, await getCurrentUserId())
     }
 
     let attachment:
@@ -98,6 +138,7 @@ export async function addComment(ref: string, options: AddOptions): Promise<void
         ...targetArgs,
         content,
         ...(attachment && { attachment }),
+        ...(uidsToNotify.length > 0 && { uidsToNotify }),
     })
 
     if (options.json) {
@@ -114,5 +155,41 @@ export async function addComment(ref: string, options: AddOptions): Promise<void
     if (attachment) {
         console.log(chalk.dim(`Attached: ${attachment.fileName}`))
     }
+    if (uidsToNotify.length > 0) {
+        const names = await describeRecipients(
+            api,
+            uidsToNotify,
+            targetProjectId,
+            notifyCollaborators,
+        )
+        console.log(chalk.dim(`Notified: ${names}`))
+    }
     console.log(chalk.dim(`ID: ${comment.id}`))
+}
+
+function describeNotifyOption(notify: string | false | undefined): string | undefined {
+    if (notify === false) return '(nobody)'
+    if (notify) return notify
+    return undefined
+}
+
+/**
+ * Render recipients as short names, falling back to the raw ID for anyone the
+ * collaborator list does not cover — the same fallback `formatAssignee` makes.
+ */
+async function describeRecipients(
+    api: Awaited<ReturnType<typeof getApi>>,
+    userIds: string[],
+    projectId: string,
+    known: CollaboratorInfo[] | undefined,
+): Promise<string> {
+    try {
+        const collaborators =
+            known ?? (await fetchCollaboratorsForProject(api, await api.getProject(projectId)))
+        const names = new Map(collaborators.map((c) => [c.id, formatUserShortName(c.name)]))
+        return userIds.map((id) => names.get(id) ?? id).join(', ')
+    } catch {
+        // Naming people is a nicety; never fail a posted comment over it.
+        return userIds.join(', ')
+    }
 }

--- a/src/commands/comment/comment.test.ts
+++ b/src/commands/comment/comment.test.ts
@@ -7,6 +7,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 
 vi.mock('../../lib/api/core.js', () => ({
     getApi: vi.fn(),
+    getCurrentUserId: vi.fn(async () => CURRENT_USER_ID),
 }))
 
 import { getApi } from '../../lib/api/core.js'
@@ -29,8 +30,28 @@ afterAll(async () => {
     await rm(attachmentTmpDir, { recursive: true, force: true })
 })
 
+const CURRENT_USER_ID = 'user-me'
+
 function createProgram() {
     return createTestProgram(registerCommentCommand)
+}
+
+/**
+ * The API mock plus the lookups `comment add` makes to work out default
+ * recipients. Defaults describe a solo task with an empty thread, so nobody is
+ * notified unless a test says otherwise.
+ */
+function setupCommentApi(): MockApi {
+    const mockApi = setupApiMock()
+    mockApi.getTask.mockResolvedValue({
+        id: 'task-1',
+        projectId: 'proj-1',
+        responsibleUid: null,
+        assignedByUid: null,
+        addedByUid: CURRENT_USER_ID,
+    })
+    mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Work', isShared: true })
+    return mockApi
 }
 
 describe('comment list', () => {
@@ -38,7 +59,7 @@ describe('comment list', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = setupApiMock()
+        mockApi = setupCommentApi()
     })
 
     it('resolves task and lists comments', async () => {
@@ -121,12 +142,237 @@ describe('comment list', () => {
     })
 })
 
+describe('comment add --notify', () => {
+    let mockApi: MockApi
+
+    const collaborators = [
+        { id: 'user-ana', name: 'Ana Lovelace', email: 'ana@example.com' },
+        { id: 'user-bo', name: 'Bo Turing', email: 'bo@example.com' },
+    ]
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockApi = setupCommentApi()
+        mockApi.getTask.mockResolvedValue({
+            id: 'task-1',
+            content: 'Buy milk',
+            projectId: 'proj-1',
+            responsibleUid: null,
+            assignedByUid: null,
+            addedByUid: CURRENT_USER_ID,
+        })
+        mockApi.getProjectCollaborators.mockResolvedValue({
+            results: collaborators,
+            nextCursor: null,
+        })
+        mockApi.addComment.mockResolvedValue({ id: 'comment-new', content: 'Get 2%' })
+    })
+
+    async function addWith(...args: string[]) {
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'td',
+            'comment',
+            'add',
+            'id:task-1',
+            '--content',
+            'Get 2%',
+            ...args,
+        ])
+    }
+
+    it('notifies users named by name, email and id', async () => {
+        captureConsole()
+
+        await addWith('--notify', 'Ana Lovelace,bo@example.com,id:user-zed')
+
+        expect(mockApi.addComment).toHaveBeenCalledWith({
+            taskId: 'task-1',
+            content: 'Get 2%',
+            uidsToNotify: ['user-ana', 'user-bo', 'user-zed'],
+        })
+        // Explicit recipients settle the question, so the thread is never read.
+        expect(mockApi.getComments).not.toHaveBeenCalled()
+    })
+
+    it('resolves "me" and a partial name', async () => {
+        captureConsole()
+
+        await addWith('--notify', 'Ana')
+
+        expect(mockApi.addComment).toHaveBeenCalledWith(
+            expect.objectContaining({ uidsToNotify: ['user-ana'] }),
+        )
+    })
+
+    it('collapses a user named more than once', async () => {
+        captureConsole()
+
+        await addWith('--notify', 'Ana Lovelace,ana@example.com, Ana ')
+
+        expect(mockApi.addComment).toHaveBeenCalledWith(
+            expect.objectContaining({ uidsToNotify: ['user-ana'] }),
+        )
+        // One collaborator fetch serves the whole list.
+        expect(mockApi.getProjectCollaborators).toHaveBeenCalledTimes(1)
+    })
+
+    it('notifies you when you explicitly ask for it, collapsing "me" and your id', async () => {
+        captureConsole()
+
+        await addWith('--notify', `me,id:${CURRENT_USER_ID},Ana`)
+
+        expect(mockApi.addComment).toHaveBeenCalledWith(
+            expect.objectContaining({ uidsToNotify: [CURRENT_USER_ID, 'user-ana'] }),
+        )
+    })
+
+    it('names every unresolvable user in one error', async () => {
+        captureConsole()
+
+        await expect(addWith('--notify', 'Ghost,Phantom')).rejects.toMatchObject({
+            code: 'ASSIGNEE_NOT_FOUND',
+        })
+        expect(mockApi.addComment).not.toHaveBeenCalled()
+    })
+
+    it('reports an ambiguous name rather than guessing', async () => {
+        captureConsole()
+        mockApi.getProjectCollaborators.mockResolvedValue({
+            results: [
+                { id: 'user-a', name: 'Ana Lovelace', email: 'a@example.com' },
+                { id: 'user-b', name: 'Ana Turing', email: 'b@example.com' },
+            ],
+            nextCursor: null,
+        })
+
+        await expect(addWith('--notify', 'Ana')).rejects.toMatchObject({
+            code: 'AMBIGUOUS_ASSIGNEE',
+        })
+    })
+
+    it('omits uidsToNotify entirely with --no-notify', async () => {
+        captureConsole()
+
+        await addWith('--no-notify')
+
+        // An absent field, not an empty one.
+        expect(mockApi.addComment).toHaveBeenCalledWith({
+            taskId: 'task-1',
+            content: 'Get 2%',
+        })
+        expect(mockApi.getComments).not.toHaveBeenCalled()
+        expect(mockApi.getProjectCollaborators).not.toHaveBeenCalled()
+    })
+
+    it("defaults a first comment to the task's assignee, assigner and creator", async () => {
+        captureConsole()
+        mockApi.getTask.mockResolvedValue({
+            id: 'task-1',
+            content: 'Buy milk',
+            projectId: 'proj-1',
+            responsibleUid: 'user-ana',
+            assignedByUid: 'user-bo',
+            addedByUid: 'user-zed',
+        })
+
+        await addWith()
+
+        expect(mockApi.addComment).toHaveBeenCalledWith(
+            expect.objectContaining({ uidsToNotify: ['user-ana', 'user-bo', 'user-zed'] }),
+        )
+    })
+
+    it("defaults a reply to the previous comment's participants", async () => {
+        captureConsole()
+        mockApi.getComments.mockResolvedValue({
+            results: [
+                {
+                    id: 'older',
+                    postedAt: new Date('2024-01-01T09:00:00Z'),
+                    postedUid: 'stale-author',
+                    uidsToNotify: ['stale-participant'],
+                },
+                {
+                    id: 'newest',
+                    postedAt: new Date('2024-01-01T15:00:00Z'),
+                    postedUid: 'user-bo',
+                    uidsToNotify: ['user-ana', CURRENT_USER_ID],
+                },
+            ],
+            nextCursor: null,
+        })
+
+        await addWith()
+
+        expect(mockApi.addComment).toHaveBeenCalledWith(
+            expect.objectContaining({ uidsToNotify: ['user-ana', 'user-bo'] }),
+        )
+        // An existing thread settles the recipients, so the task is fetched
+        // only to resolve the ref -- never again for its assignee and creator.
+        expect(mockApi.getTask).toHaveBeenCalledTimes(1)
+    })
+
+    it('notifies nobody on a first project comment', async () => {
+        captureConsole()
+        mockApi.getProjects.mockResolvedValue({
+            results: [{ id: 'proj-1', name: 'Work' }],
+            nextCursor: null,
+        })
+        const program = createProgram()
+
+        await program.parseAsync([
+            'node',
+            'td',
+            'comment',
+            'add',
+            'id:proj-1',
+            '--project',
+            '--content',
+            'Project note',
+        ])
+
+        expect(mockApi.addComment).toHaveBeenCalledWith({
+            projectId: 'proj-1',
+            content: 'Project note',
+        })
+    })
+
+    it('reports who was notified, by short name', async () => {
+        const consoleSpy = captureConsole()
+
+        await addWith('--notify', 'Ana Lovelace,Bo Turing')
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Notified: Ana L., Bo T.'))
+    })
+
+    it('previews the notify option unresolved under --dry-run', async () => {
+        const consoleSpy = captureConsole()
+
+        await addWith('--notify', 'Ana Lovelace', '--dry-run')
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Ana Lovelace'))
+        expect(mockApi.addComment).not.toHaveBeenCalled()
+        expect(mockGetApi).not.toHaveBeenCalled()
+    })
+
+    it('previews --no-notify as nobody under --dry-run', async () => {
+        const consoleSpy = captureConsole()
+
+        await addWith('--no-notify', '--dry-run')
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('(nobody)'))
+        expect(mockGetApi).not.toHaveBeenCalled()
+    })
+})
+
 describe('comment add', () => {
     let mockApi: MockApi
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = setupApiMock()
+        mockApi = setupCommentApi()
     })
 
     it('adds comment to task', async () => {
@@ -177,7 +423,7 @@ describe('comment delete', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = setupApiMock()
+        mockApi = setupCommentApi()
     })
 
     it('rejects plain text references', async () => {
@@ -226,7 +472,7 @@ describe('comment update', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = setupApiMock()
+        mockApi = setupCommentApi()
     })
 
     it('rejects plain text references', async () => {
@@ -309,7 +555,7 @@ describe('comment add with attachment', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = setupApiMock()
+        mockApi = setupCommentApi()
     })
 
     it('uploads file and attaches to comment', async () => {
@@ -442,7 +688,7 @@ describe('comment list with attachments', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = setupApiMock()
+        mockApi = setupCommentApi()
     })
 
     it('shows [file] marker for comments with attachments', async () => {
@@ -556,7 +802,7 @@ describe('comment view', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = setupApiMock()
+        mockApi = setupCommentApi()
     })
 
     it('rejects plain text references', async () => {
@@ -814,7 +1060,7 @@ describe('project comment list', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = setupApiMock()
+        mockApi = setupCommentApi()
     })
 
     it('lists comments on a project with --project flag', async () => {
@@ -865,7 +1111,7 @@ describe('comment add with --stdin', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = setupApiMock()
+        mockApi = setupCommentApi()
     })
 
     it('reads content from stdin with --stdin flag', async () => {
@@ -954,7 +1200,7 @@ describe('comment add --json', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = setupApiMock()
+        mockApi = setupCommentApi()
     })
 
     it('outputs created comment as JSON', async () => {
@@ -1020,7 +1266,7 @@ describe('comment update --json', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = setupApiMock()
+        mockApi = setupCommentApi()
     })
 
     it('outputs updated comment as JSON', async () => {
@@ -1061,7 +1307,7 @@ describe('project comment add', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = setupApiMock()
+        mockApi = setupCommentApi()
     })
 
     it('adds comment to project with --project flag', async () => {
@@ -1136,7 +1382,7 @@ describe('comment --dry-run', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockApi = setupApiMock()
+        mockApi = setupCommentApi()
     })
 
     it('comment add --dry-run previews without calling API', async () => {

--- a/src/commands/comment/comment.test.ts
+++ b/src/commands/comment/comment.test.ts
@@ -347,6 +347,27 @@ describe('comment add --notify', () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Notified: Ana L., Bo T.'))
     })
 
+    it('notifies you on a personal project, where there are no collaborators', async () => {
+        captureConsole()
+        mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Personal', isShared: false })
+        mockApi.getProjectCollaborators.mockResolvedValue({ results: [], nextCursor: null })
+
+        await addWith('--notify', 'me')
+
+        // "me" and id: refs resolve without knowing who shares the project.
+        expect(mockApi.addComment).toHaveBeenCalledWith(
+            expect.objectContaining({ uidsToNotify: [CURRENT_USER_ID] }),
+        )
+    })
+
+    it('explains that a name cannot be resolved on an unshared project', async () => {
+        captureConsole()
+        mockApi.getProject.mockResolvedValue({ id: 'proj-1', name: 'Personal', isShared: false })
+        mockApi.getProjectCollaborators.mockResolvedValue({ results: [], nextCursor: null })
+
+        await expect(addWith('--notify', 'Ana')).rejects.toMatchObject({ code: 'NOT_SHARED' })
+    })
+
     it('previews the notify option unresolved under --dry-run', async () => {
         const consoleSpy = captureConsole()
 
@@ -811,6 +832,92 @@ describe('comment view', () => {
         await expect(
             program.parseAsync(['node', 'td', 'comment', 'view', 'my-comment']),
         ).rejects.toHaveProperty('code', 'INVALID_REF')
+    })
+
+    describe('the Notified line', () => {
+        async function viewComment() {
+            const program = createProgram()
+            await program.parseAsync(['node', 'td', 'comment', 'view', 'id:comment-1'])
+        }
+
+        beforeEach(() => {
+            mockApi.getComment.mockResolvedValue({
+                id: 'comment-1',
+                content: 'Please review',
+                postedAt: '2026-01-01T12:00:00Z',
+                taskId: 'task-1',
+                uidsToNotify: ['user-ana', 'user-bo'],
+            })
+            mockApi.getProjectCollaborators.mockResolvedValue({
+                results: [
+                    { id: 'user-ana', name: 'Ana Lovelace', email: 'ana@example.com' },
+                    { id: 'user-bo', name: 'Bo Turing', email: 'bo@example.com' },
+                ],
+                nextCursor: null,
+            })
+        })
+
+        it('names the recipients', async () => {
+            const consoleSpy = captureConsole()
+
+            await viewComment()
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Notified: Ana L., Bo T.'),
+            )
+        })
+
+        it('finds the project through the task when the comment is on one', async () => {
+            captureConsole()
+
+            await viewComment()
+
+            expect(mockApi.getTask).toHaveBeenCalledWith('task-1')
+            expect(mockApi.getProject).toHaveBeenCalledWith('proj-1')
+        })
+
+        it('reads a project comment without going via a task', async () => {
+            captureConsole()
+            mockApi.getComment.mockResolvedValue({
+                id: 'comment-1',
+                content: 'Please review',
+                postedAt: '2026-01-01T12:00:00Z',
+                projectId: 'proj-1',
+                uidsToNotify: ['user-ana'],
+            })
+
+            await viewComment()
+
+            expect(mockApi.getTask).not.toHaveBeenCalled()
+            expect(mockApi.getProject).toHaveBeenCalledWith('proj-1')
+        })
+
+        it('falls back to raw IDs when the collaborator lookup fails', async () => {
+            const consoleSpy = captureConsole()
+            mockApi.getProjectCollaborators.mockRejectedValue(new Error('no access'))
+
+            await viewComment()
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Notified: user-ana, user-bo'),
+            )
+        })
+
+        it('says nothing, and looks nothing up, when nobody was notified', async () => {
+            const consoleSpy = captureConsole()
+            mockApi.getComment.mockResolvedValue({
+                id: 'comment-1',
+                content: 'Please review',
+                postedAt: '2026-01-01T12:00:00Z',
+                taskId: 'task-1',
+                uidsToNotify: [],
+            })
+
+            await viewComment()
+
+            expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Notified:'))
+            expect(mockApi.getProjectCollaborators).not.toHaveBeenCalled()
+        })
     })
 
     it('implicit view: td comment <ref> behaves like td comment view <ref>', async () => {

--- a/src/commands/comment/index.ts
+++ b/src/commands/comment/index.ts
@@ -47,6 +47,11 @@ Examples:
         .option('--stdin', 'Read comment content from stdin')
         .option('--file <path>', 'Attach a file to the comment')
         .option('--file-name <name>', 'Override the file name sent to the API')
+        .option(
+            '--notify <a,b>',
+            'Notify these users (comma-separated: name, email, id:xxx, or "me")',
+        )
+        .option('--no-notify', 'Post without notifying anyone')
         .option('--json', 'Output the created comment as JSON')
         .option('--dry-run', 'Preview what would happen without executing')
         .action((ref, options) => {

--- a/src/commands/comment/view.ts
+++ b/src/commands/comment/view.ts
@@ -1,5 +1,7 @@
+import type { Comment, TodoistApi } from '@doist/todoist-sdk'
 import chalk from 'chalk'
 import { getApi } from '../../lib/api/core.js'
+import { fetchCollaboratorsForProject, formatUserShortName } from '../../lib/collaborators.js'
 import { renderMarkdown } from '../../lib/markdown.js'
 import type { ViewOptions } from '../../lib/options.js'
 import { formatFileSize, formatJson } from '../../lib/output.js'
@@ -46,9 +48,12 @@ export async function viewComment(commentId: string, options: ViewOptions): Prom
 
     console.log(chalk.bold('Comment'))
     console.log('')
-    console.log(`ID:      ${comment.id}`)
-    console.log(`Posted:  ${comment.postedAt}`)
-    if (url) console.log(`URL:     ${url}`)
+    console.log(`ID:       ${comment.id}`)
+    console.log(`Posted:   ${comment.postedAt}`)
+    if (comment.uidsToNotify?.length) {
+        console.log(`Notified: ${await describeNotified(api, comment)}`)
+    }
+    if (url) console.log(`URL:      ${url}`)
     console.log('')
     console.log('Content:')
     const content = options.raw ? comment.content : await renderMarkdown(comment.content)
@@ -65,5 +70,23 @@ export async function viewComment(commentId: string, options: ViewOptions): Prom
         if (att.fileUrl && isImageAttachment(att)) {
             console.log(chalk.dim(`  Hint:  ${IMAGE_HINT}`))
         }
+    }
+}
+
+/**
+ * Name the comment's recipients. Only called when there are some, so a thread
+ * that notifies nobody — the common case — costs no extra request. Anyone the
+ * collaborator list does not cover falls back to their raw ID.
+ */
+async function describeNotified(api: TodoistApi, comment: Comment): Promise<string> {
+    const userIds = comment.uidsToNotify ?? []
+    try {
+        const projectId = comment.projectId ?? (await api.getTask(comment.taskId ?? '')).projectId
+        const project = await api.getProject(projectId)
+        const collaborators = await fetchCollaboratorsForProject(api, project)
+        const names = new Map(collaborators.map((c) => [c.id, formatUserShortName(c.name)]))
+        return userIds.map((id) => names.get(id) ?? id).join(', ')
+    } catch {
+        return userIds.join(', ')
     }
 }

--- a/src/lib/collaborators.ts
+++ b/src/lib/collaborators.ts
@@ -219,6 +219,37 @@ export async function fetchCollaboratorsForProject(
     return []
 }
 
+/**
+ * Match one reference against a collaborator list by exact name, exact email,
+ * then unique partial name. Returns null when nothing matches; an ambiguous
+ * partial is an error rather than a guess.
+ *
+ * Shared by assignment and comment notification so the two cannot drift apart.
+ * Handles neither `me` nor `id:xxx` — both resolve without a collaborator list
+ * at all, so callers short-circuit them before fetching one.
+ */
+function matchCollaboratorRef(
+    ref: string,
+    collaborators: CollaboratorInfo[],
+): CollaboratorInfo | null {
+    const lower = ref.toLowerCase()
+
+    const exact =
+        collaborators.find((c) => c.name.toLowerCase() === lower) ??
+        collaborators.find((c) => c.email.toLowerCase() === lower)
+    if (exact) return exact
+
+    const partial = collaborators.filter((c) => c.name.toLowerCase().includes(lower))
+    if (partial.length > 1) {
+        throw new CliError(
+            'AMBIGUOUS_ASSIGNEE',
+            `Multiple users match "${ref}":`,
+            partial.slice(0, 5).map((c) => `"${c.name}" (id:${c.id})`),
+        )
+    }
+    return partial[0] ?? null
+}
+
 export async function resolveAssigneeId(
     api: TodoistApi,
     ref: string,
@@ -236,25 +267,12 @@ export async function resolveAssigneeId(
     if (collaborators.length === 0) {
         throw new CliError('NOT_SHARED', 'Cannot assign tasks in non-shared projects.')
     }
-    const lower = ref.toLowerCase()
 
-    const exactName = collaborators.find((c) => c.name.toLowerCase() === lower)
-    if (exactName) return exactName.id
-
-    const exactEmail = collaborators.find((c) => c.email.toLowerCase() === lower)
-    if (exactEmail) return exactEmail.id
-
-    const partialName = collaborators.filter((c) => c.name.toLowerCase().includes(lower))
-    if (partialName.length === 1) return partialName[0].id
-    if (partialName.length > 1) {
-        throw new CliError(
-            'AMBIGUOUS_ASSIGNEE',
-            `Multiple users match "${ref}":`,
-            partialName.slice(0, 5).map((c) => `"${c.name}" (id:${c.id})`),
-        )
+    const match = matchCollaboratorRef(ref, collaborators)
+    if (!match) {
+        throw new CliError('ASSIGNEE_NOT_FOUND', `User "${ref}" not found.`)
     }
-
-    throw new CliError('ASSIGNEE_NOT_FOUND', `User "${ref}" not found.`)
+    return match.id
 }
 
 /**
@@ -280,6 +298,7 @@ export function resolveNotifyIds({
     const seenRefs = new Set<string>()
     const resolved: string[] = []
     const unresolved: string[] = []
+    const needCollaborators: string[] = []
 
     for (const ref of refs) {
         const trimmed = ref.trim()
@@ -288,6 +307,8 @@ export function resolveNotifyIds({
         if (seenRefs.has(lower)) continue
         seenRefs.add(lower)
 
+        // Resolvable without knowing who shares the project, so these work even
+        // on a personal one.
         if (lower === 'me') {
             resolved.push(currentUserId)
             continue
@@ -297,34 +318,29 @@ export function resolveNotifyIds({
             continue
         }
 
-        const exact =
-            collaborators.find((c) => c.name.toLowerCase() === lower) ??
-            collaborators.find((c) => c.email.toLowerCase() === lower)
-        if (exact) {
-            resolved.push(exact.id)
+        if (collaborators.length === 0) {
+            needCollaborators.push(trimmed)
             continue
         }
 
-        const partial = collaborators.filter((c) => c.name.toLowerCase().includes(lower))
-        if (partial.length > 1) {
-            throw new CliError(
-                'AMBIGUOUS_ASSIGNEE',
-                `Multiple users match "${trimmed}":`,
-                partial.slice(0, 5).map((c) => `"${c.name}" (id:${c.id})`),
-            )
+        const match = matchCollaboratorRef(trimmed, collaborators)
+        if (match) {
+            resolved.push(match.id)
+        } else {
+            unresolved.push(trimmed)
         }
-        if (partial[0]) {
-            resolved.push(partial[0].id)
-            continue
-        }
-
-        unresolved.push(trimmed)
     }
 
+    if (needCollaborators.length > 0) {
+        throw new CliError(
+            'NOT_SHARED',
+            `Cannot notify ${formatRefs(needCollaborators)} — "${projectName}" is not shared with anybody.`,
+        )
+    }
     if (unresolved.length > 0) {
         throw new CliError(
             'ASSIGNEE_NOT_FOUND',
-            `Cannot notify ${unresolved.map((ref) => `"${ref}"`).join(', ')} — not a collaborator on "${projectName}".`,
+            `Cannot notify ${formatRefs(unresolved)} — not a collaborator on "${projectName}".`,
             ['Use `td project collaborators` to see who can be notified'],
         )
     }
@@ -333,4 +349,8 @@ export function resolveNotifyIds({
     // honoured. Leaving yourself out is only right when the recipients were
     // inferred rather than asked for -- see getDefaultCommentRecipients.
     return [...new Set(resolved)]
+}
+
+function formatRefs(refs: string[]): string {
+    return refs.map((ref) => `"${ref}"`).join(', ')
 }

--- a/src/lib/collaborators.ts
+++ b/src/lib/collaborators.ts
@@ -158,7 +158,14 @@ export function formatAssignee({
     return userId
 }
 
-async function fetchCollaboratorsForProject(
+/**
+ * Every user who can see a project: workspace members for a workspace project,
+ * collaborators for a shared personal one. A project that is neither has
+ * nobody but the owner, and returns an empty list — callers decide what that
+ * means for them, since "nobody to assign to" and "nobody to notify" want
+ * different wording.
+ */
+export async function fetchCollaboratorsForProject(
     api: TodoistApi,
     project: Project,
 ): Promise<CollaboratorInfo[]> {
@@ -209,7 +216,7 @@ async function fetchCollaboratorsForProject(
         return users
     }
 
-    throw new CliError('NOT_SHARED', 'Cannot assign tasks in non-shared projects.')
+    return []
 }
 
 export async function resolveAssigneeId(
@@ -226,6 +233,9 @@ export async function resolveAssigneeId(
     }
 
     const collaborators = await fetchCollaboratorsForProject(api, project)
+    if (collaborators.length === 0) {
+        throw new CliError('NOT_SHARED', 'Cannot assign tasks in non-shared projects.')
+    }
     const lower = ref.toLowerCase()
 
     const exactName = collaborators.find((c) => c.name.toLowerCase() === lower)
@@ -245,4 +255,82 @@ export async function resolveAssigneeId(
     }
 
     throw new CliError('ASSIGNEE_NOT_FOUND', `User "${ref}" not found.`)
+}
+
+/**
+ * Resolve a list of user references — names, emails, `id:xxx` or `me` — to the
+ * user IDs to notify about a comment.
+ *
+ * Pure over an already-fetched collaborator list, so the caller fetches once
+ * and can reuse the same list to render the names back. References are
+ * deduplicated, and every one that cannot be resolved is reported together so
+ * the caller fixes them all in one go rather than one per run.
+ */
+export function resolveNotifyIds({
+    refs,
+    collaborators,
+    currentUserId,
+    projectName,
+}: {
+    refs: string[]
+    collaborators: CollaboratorInfo[]
+    currentUserId: string
+    projectName: string
+}): string[] {
+    const seenRefs = new Set<string>()
+    const resolved: string[] = []
+    const unresolved: string[] = []
+
+    for (const ref of refs) {
+        const trimmed = ref.trim()
+        if (!trimmed) continue
+        const lower = trimmed.toLowerCase()
+        if (seenRefs.has(lower)) continue
+        seenRefs.add(lower)
+
+        if (lower === 'me') {
+            resolved.push(currentUserId)
+            continue
+        }
+        if (isIdRef(trimmed)) {
+            resolved.push(extractId(trimmed))
+            continue
+        }
+
+        const exact =
+            collaborators.find((c) => c.name.toLowerCase() === lower) ??
+            collaborators.find((c) => c.email.toLowerCase() === lower)
+        if (exact) {
+            resolved.push(exact.id)
+            continue
+        }
+
+        const partial = collaborators.filter((c) => c.name.toLowerCase().includes(lower))
+        if (partial.length > 1) {
+            throw new CliError(
+                'AMBIGUOUS_ASSIGNEE',
+                `Multiple users match "${trimmed}":`,
+                partial.slice(0, 5).map((c) => `"${c.name}" (id:${c.id})`),
+            )
+        }
+        if (partial[0]) {
+            resolved.push(partial[0].id)
+            continue
+        }
+
+        unresolved.push(trimmed)
+    }
+
+    if (unresolved.length > 0) {
+        throw new CliError(
+            'ASSIGNEE_NOT_FOUND',
+            `Cannot notify ${unresolved.map((ref) => `"${ref}"`).join(', ')} — not a collaborator on "${projectName}".`,
+            ['Use `td project collaborators` to see who can be notified'],
+        )
+    }
+
+    // No self-exclusion here: naming yourself is an explicit instruction and is
+    // honoured. Leaving yourself out is only right when the recipients were
+    // inferred rather than asked for -- see getDefaultCommentRecipients.
+    return [...new Set(resolved)]
 }

--- a/src/lib/comment-recipients.test.ts
+++ b/src/lib/comment-recipients.test.ts
@@ -1,0 +1,173 @@
+import type { Comment, TodoistApi } from '@doist/todoist-sdk'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultCommentRecipients } from './comment-recipients.js'
+
+const CURRENT_USER_ID = 'user-me'
+
+function comment(overrides: Partial<Comment> = {}): Comment {
+    return {
+        id: 'comment-1',
+        content: 'Existing',
+        postedAt: new Date('2024-01-01T12:00:00Z'),
+        postedUid: 'user-bo',
+        taskId: 'task-1',
+        projectId: undefined,
+        fileAttachment: null,
+        uidsToNotify: null,
+        reactions: null,
+        isDeleted: false,
+        ...overrides,
+    }
+}
+
+describe('getDefaultCommentRecipients', () => {
+    let api: TodoistApi
+
+    beforeEach(() => {
+        api = {
+            getComments: vi.fn().mockResolvedValue({ results: [], nextCursor: null }),
+            getTask: vi.fn().mockResolvedValue({
+                id: 'task-1',
+                responsibleUid: null,
+                assignedByUid: null,
+                addedByUid: null,
+            }),
+        } as unknown as TodoistApi
+    })
+
+    describe('a thread that already has comments', () => {
+        it("takes the newest comment's participants, not the first page's", async () => {
+            vi.mocked(api.getComments).mockResolvedValue({
+                results: [
+                    comment({
+                        postedAt: new Date('2024-03-01T09:00:00Z'),
+                        postedUid: 'recent-author',
+                        uidsToNotify: ['recent-participant'],
+                    }),
+                    comment({
+                        postedAt: new Date('2024-01-01T09:00:00Z'),
+                        postedUid: 'stale-author',
+                        uidsToNotify: ['stale-participant'],
+                    }),
+                ],
+                nextCursor: null,
+            })
+
+            const recipients = await getDefaultCommentRecipients(
+                api,
+                { taskId: 'task-1' },
+                CURRENT_USER_ID,
+            )
+
+            expect(recipients).toEqual(['recent-participant', 'recent-author'])
+            expect(api.getTask).not.toHaveBeenCalled()
+        })
+
+        it('keeps the chain alive from a comment that notified nobody', async () => {
+            vi.mocked(api.getComments).mockResolvedValue({
+                results: [comment({ postedUid: 'agent', uidsToNotify: null })],
+                nextCursor: null,
+            })
+
+            await expect(
+                getDefaultCommentRecipients(api, { taskId: 'task-1' }, CURRENT_USER_ID),
+            ).resolves.toEqual(['agent'])
+        })
+
+        it('excludes the author of the comment being posted', async () => {
+            vi.mocked(api.getComments).mockResolvedValue({
+                results: [
+                    comment({
+                        postedUid: CURRENT_USER_ID,
+                        uidsToNotify: [CURRENT_USER_ID, 'other'],
+                    }),
+                ],
+                nextCursor: null,
+            })
+
+            await expect(
+                getDefaultCommentRecipients(api, { taskId: 'task-1' }, CURRENT_USER_ID),
+            ).resolves.toEqual(['other'])
+        })
+
+        it('walks every page to reach the newest comment', async () => {
+            vi.mocked(api.getComments)
+                .mockResolvedValueOnce({
+                    results: [comment({ postedAt: new Date('2024-01-01'), postedUid: 'p1' })],
+                    nextCursor: 'page-2',
+                })
+                .mockResolvedValueOnce({
+                    results: [comment({ postedAt: new Date('2024-02-01'), postedUid: 'p2' })],
+                    nextCursor: 'page-3',
+                })
+                .mockResolvedValueOnce({
+                    results: [comment({ postedAt: new Date('2024-03-01'), postedUid: 'p3' })],
+                    nextCursor: null,
+                })
+
+            const recipients = await getDefaultCommentRecipients(
+                api,
+                { taskId: 'task-1' },
+                CURRENT_USER_ID,
+            )
+
+            expect(api.getComments).toHaveBeenCalledTimes(3)
+            expect(api.getComments).toHaveBeenLastCalledWith(
+                expect.objectContaining({ cursor: 'page-3' }),
+            )
+            expect(recipients).toEqual(['p3'])
+        })
+    })
+
+    describe('a task with no comments yet', () => {
+        it('takes the assignee, assigner and creator', async () => {
+            vi.mocked(api.getTask).mockResolvedValue({
+                responsibleUid: 'assignee',
+                assignedByUid: 'assigner',
+                addedByUid: 'creator',
+            } as Awaited<ReturnType<TodoistApi['getTask']>>)
+
+            await expect(
+                getDefaultCommentRecipients(api, { taskId: 'task-1' }, CURRENT_USER_ID),
+            ).resolves.toEqual(['assignee', 'assigner', 'creator'])
+        })
+
+        it('drops unset uids and collapses one person filling two roles', async () => {
+            vi.mocked(api.getTask).mockResolvedValue({
+                responsibleUid: 'ana',
+                assignedByUid: null,
+                addedByUid: 'ana',
+            } as Awaited<ReturnType<TodoistApi['getTask']>>)
+
+            await expect(
+                getDefaultCommentRecipients(api, { taskId: 'task-1' }, CURRENT_USER_ID),
+            ).resolves.toEqual(['ana'])
+        })
+
+        it('notifies nobody when the author is the only party', async () => {
+            vi.mocked(api.getTask).mockResolvedValue({
+                responsibleUid: CURRENT_USER_ID,
+                assignedByUid: null,
+                addedByUid: CURRENT_USER_ID,
+            } as Awaited<ReturnType<TodoistApi['getTask']>>)
+
+            await expect(
+                getDefaultCommentRecipients(api, { taskId: 'task-1' }, CURRENT_USER_ID),
+            ).resolves.toEqual([])
+        })
+    })
+
+    it('notifies nobody on a project with no comments, having no assignee to fall back on', async () => {
+        const recipients = await getDefaultCommentRecipients(
+            api,
+            { projectId: 'proj-1' },
+            CURRENT_USER_ID,
+        )
+
+        expect(api.getComments).toHaveBeenCalledWith(
+            expect.objectContaining({ projectId: 'proj-1' }),
+        )
+        expect(recipients).toEqual([])
+        expect(api.getTask).not.toHaveBeenCalled()
+    })
+})

--- a/src/lib/comment-recipients.ts
+++ b/src/lib/comment-recipients.ts
@@ -1,0 +1,78 @@
+import type { Comment, GetTaskCommentsArgs, TodoistApi } from '@doist/todoist-sdk'
+
+export type CommentTarget =
+    | { taskId: string; projectId?: never }
+    | { projectId: string; taskId?: never }
+
+/**
+ * Work out who Todoist's own clients would notify about a new comment.
+ *
+ * The API notifies exactly the people it is handed and derives nobody itself,
+ * so a comment posted without recipients notifies no one — and, because a reply
+ * takes its recipients from the comment before it, silences the next comment in
+ * the thread too. Mirroring the clients here keeps that chain intact:
+ *
+ * - replying to an existing thread notifies the previous comment's participants
+ * - the first comment on a task notifies its assignee, assigner and creator
+ * - the first comment on a project notifies nobody, as a project has no assignee
+ *
+ * The comment's own author is never a recipient.
+ */
+export async function getDefaultCommentRecipients(
+    api: TodoistApi,
+    target: CommentTarget,
+    currentUserId: string,
+): Promise<string[]> {
+    const previousComment = await getLatestComment(api, target)
+
+    if (previousComment) {
+        return dedupe(
+            [...(previousComment.uidsToNotify ?? []), previousComment.postedUid],
+            currentUserId,
+        )
+    }
+
+    if (!target.taskId) {
+        return []
+    }
+
+    const task = await api.getTask(target.taskId)
+    return dedupe([task.responsibleUid, task.assignedByUid, task.addedByUid], currentUserId)
+}
+
+async function getLatestComment(
+    api: TodoistApi,
+    target: CommentTarget,
+): Promise<Comment | undefined> {
+    let latest: Comment | undefined
+    let cursor: string | undefined
+
+    // Walked a page at a time, keeping only the newest comment seen. A thread
+    // can be arbitrarily long and all we want from it is its last participant,
+    // so there is no reason to hold the whole history in memory — which is why
+    // this does not use paginate(). Page order is not guaranteed, so every page
+    // is still compared.
+    while (true) {
+        const response = await api.getComments({
+            ...(target.taskId ? { taskId: target.taskId } : { projectId: target.projectId }),
+            cursor,
+        } as GetTaskCommentsArgs)
+
+        for (const comment of response.results) {
+            if (!latest || comment.postedAt > latest.postedAt) latest = comment
+        }
+
+        if (!response.nextCursor) break
+        cursor = response.nextCursor
+    }
+
+    return latest
+}
+
+function dedupe(userIds: (string | null | undefined)[], currentUserId: string): string[] {
+    const seen = new Set<string>()
+    for (const userId of userIds) {
+        if (userId && userId !== currentUserId) seen.add(userId)
+    }
+    return [...seen]
+}

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -320,6 +320,8 @@ const COMMENT_ESSENTIAL_FIELDS = [
     'id',
     'content',
     'postedAt',
+    'postedUid',
+    'uidsToNotify',
     'taskId',
     'projectId',
     'fileAttachment',

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -266,6 +266,8 @@ td comment list "Plan sprint"
 td comment list "Roadmap" --project
 td comment add "Plan sprint" --content "See attached" --file ./report.pdf
 td comment add "Plan sprint" --content "See attached" --file ./report.pdf --file-name "Quarterly report.pdf"
+td comment add "Plan sprint" --content "@Ana could you review?" --notify "Ana"
+td comment add "Plan sprint" --content "Note to self" --no-notify
 td comment update id:123 --content "Updated text"
 td comment delete id:123 --yes
 td comment browse id:123
@@ -293,6 +295,8 @@ td reminder location get id:456
 \`\`\`
 
 \`td attachment view\` prints text attachments directly and encodes binary content as base64. Use \`--json\` for metadata plus content. Prefer this over \`curl\` + \`Read\` on Todoist file URLs — for images in particular, \`Read\` will try to decode the file through the vision pipeline, and if that fails the image stays pinned in conversation context and every retry hits the same error.
+
+Comments notify only the people \`comment add\` is handed. Writing "@Ana" in the text notifies nobody — name her with \`--notify\`. Omit \`--notify\` to notify whoever the Todoist apps would (the task's assignee, assigner and creator on a first comment, or the previous comment's participants on a reply), or pass \`--no-notify\` to stay silent. Notification cannot be sent when editing a comment, only when adding one.
 
 \`td comment view\` flags image attachments with a \`Hint\` line pointing at \`td attachment view\`. In \`--json\` mode the hint is written to stderr so stdout stays parseable — watch the tool output, not just the JSON body.
 


### PR DESCRIPTION
Brings `td comment add` to parity with the MCP, which shipped this in Doist/todoist-mcp#580 for Doist/todoist-mcp#509.

**Stacked on #477** — based on that branch for SDK 14.0.1, which carries the `uidsToNotify` serialisation fix. Retarget to `main` once #477 merges.

## The problem

Comments posted with `td` notify nobody. `comment add` never sent `uidsToNotify`, so a teammate named in a comment found out only if they happened to open the task.

That also breaks the *next* comment, which is the part people notice and can't reproduce. Todoist's clients pick the recipients themselves and send them with each comment; the API notifies exactly who it is handed and derives nobody on its own. On a first comment the clients notify the assignee, the assigner and the creator; on a reply they notify the previous comment's participants, so threads keep flowing without everyone being re-tagged. A comment posted with an empty list therefore silences the comment that follows it — including one a human later writes in the app.

## What this does

`comment add` gains `--notify`, accepting names, emails, `id:xxx` or `"me"`, comma-separated in the same style as `--labels`. `--no-notify` posts in silence, matching the existing `--no-labels` negation.

Omitting `--notify` mirrors the clients: assignee, assigner and creator on a task's first comment, or the previous comment's participants on a reply, always excluding the author. The rules live in `src/lib/comment-recipients.ts`, ported from the MCP's equivalent.

Two things worth calling out in review:

- **Naming yourself is honoured**, not filtered out. Self-exclusion is only right when the recipients were *inferred* rather than asked for. I had this filtering unconditionally at first and caught it in live testing — `--notify me` silently did nothing.
- **The thread walk keeps only the newest comment** rather than using `paginate()`, which accumulates every result. Comments come back oldest-first with no reverse option, so reaching the last page is unavoidable; holding the whole history is not. Review flagged exactly this on the MCP version.

`resolveNotifyIds` is pure over an already-fetched collaborator list, so the `--notify` path fetches collaborators once and reuses them to render the names back — my own tests caught a double fetch here.

`@mentions` in the comment text are deliberately **not** parsed; the user names people with `--notify`. `SKILL_CONTENT` documents this so agents don't assume the text alone notifies.

Notification on *edit* is out of scope — `UpdateCommentArgs` is `{ content }` only.

## Surfacing

Who was notified is now visible in three places: the confirmation line after adding, a `Notified:` line in `comment view` (resolved only when there are recipients, so the common case costs no extra request), and `postedUid` / `uidsToNotify` in plain `--json` rather than only under `--full`.

## Verification

`npm run type-check`, `npm run check`, `npm run build`, `npm run check:skill-sync` and all 1815 tests pass (suite run three times to rule out flakiness).

Live against the real API on a throwaway task in a shared project, since deleted:

| case | result |
| --- | --- |
| `--dry-run` with `--notify` | previews the raw string unresolved, no API call |
| defaults, first comment on a solo task | no recipients |
| `--notify "Ada Lovelace"` | `Notified: Ada L.` |
| `--notify "me,ada@example.com"` | deduped to one |
| `--notify Ghost,Phantom` | one `ASSIGNEE_NOT_FOUND` naming both |
| reply, defaults | previous comment's participants, author excluded |
| `--no-notify` | silent, no recipient field sent |
| `comment view` / `--json` | recipients shown |

The paths involving a **second person** — a reply inheriting someone else's participants, and a first comment on a task assigned to someone else — are covered by unit tests rather than live calls, since verifying them for real means sending test notifications to an actual colleague.

🤖 Generated with [Claude Code](https://claude.com/claude-code)