### PR TITLE
fix: use the fetch the SDK pairs with its dispatcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@doist/cli-core": "1.2.0",
-        "@doist/todoist-sdk": "14.1.0",
+        "@doist/todoist-sdk": "14.2.0",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "6.0.0",
@@ -204,16 +204,15 @@
       }
     },
     "node_modules/@doist/todoist-sdk": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-14.1.0.tgz",
-      "integrity": "sha512-4hNZe6Hx4/oLYQbFokWMMaQd3Q6pXnUpbVq64PmYby4l466wxLarvTqB9g7J+TNdt5f8qfYWHjXOhaBucHblgA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-14.2.0.tgz",
+      "integrity": "sha512-v1KwLfCtk1zcm11/wDXdcvQSSmbdMcRv6KRL+ketMzm6Q6/s5r+5vh0kljQORBFdAY01yOMAWBfIB6D+Ec6vAA==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "6.3.0",
         "emoji-regex": "10.6.0",
-        "form-data": "4.0.6",
         "ts-custom-error": "^3.2.0",
-        "undici": "7.24.8",
+        "undici": "^7.29.0",
         "uuid": "11.1.1",
         "zod": "4.3.6"
       },
@@ -3573,12 +3572,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/await-to-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-3.0.0.tgz",
@@ -3767,19 +3760,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -4085,18 +4065,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -4390,15 +4358,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4433,20 +4392,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/duplexer2": {
@@ -4674,57 +4619,12 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -4903,22 +4803,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/form-data-encoder": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
@@ -4968,15 +4852,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/function-timeout": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
@@ -5009,43 +4884,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -5083,18 +4921,6 @@
         "stream-combiner2": "~1.1.1",
         "through2": "~2.0.0",
         "traverse": "0.6.8"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/got": {
@@ -5162,45 +4988,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/highlight.js": {
@@ -6434,15 +6221,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -6490,27 +6268,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -10718,9 +10475,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@doist/cli-core": "1.2.0",
-    "@doist/todoist-sdk": "14.1.0",
+    "@doist/todoist-sdk": "14.2.0",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "6.0.0",

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -150,19 +150,36 @@ export function initializeLogger(): void {
     const log = getLogger()
     log.initialize()
 
-    // When verbose, patch globalThis.fetch so SDK-internal HTTP calls are also logged.
-    // This is the only way to get HTTP-level visibility for @doist/todoist-sdk
-    // since it uses fetch() internally and doesn't expose hooks.
+    // When verbose, patch globalThis.fetch so HTTP calls made through it are
+    // logged. This covers everything that reaches the runtime's own fetch:
+    // the help centre client, and anything inside our dependencies that calls
+    // fetch directly. Todoist API traffic does not go through the global fetch
+    // — see `withHttpLogging`, which the transport layer applies itself.
     if (log.isEnabled()) {
         patchGlobalFetch()
     }
 }
 
+/** Whether HTTP logging should be applied to a fetch implementation. */
+export function isHttpLoggingEnabled(): boolean {
+    return getLogger().isEnabled()
+}
+
 /** Save original fetch and replace with logging wrapper. */
 function patchGlobalFetch(): void {
-    const originalFetch = globalThis.fetch
+    globalThis.fetch = withHttpLogging(globalThis.fetch)
+}
 
-    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+/**
+ * Wraps a fetch implementation with request and response logging.
+ *
+ * Used both to patch `globalThis.fetch` and, in the transport layer, to wrap
+ * the fetch the SDK pairs with its dispatcher. That one is undici's own fetch
+ * rather than the runtime's, so it never passes through the global patch and
+ * would otherwise be invisible to `--verbose`.
+ */
+export function withHttpLogging(originalFetch: typeof fetch): typeof fetch {
+    return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
         const log = getLogger()
         const urlStr =
             typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url

--- a/src/lib/migrate-auth.ts
+++ b/src/lib/migrate-auth.ts
@@ -45,7 +45,9 @@ interface MigrateOptions {
 const USER_ENDPOINT = 'https://api.todoist.com/api/v1/user'
 
 export async function migrateLegacyAuth(opts: MigrateOptions = {}): Promise<MigrateAuthResult> {
-    const fetchImpl = opts.fetchImpl ?? fetch
+    // Left undefined when the caller supplies nothing, so `fetchTodoist`
+    // resolves the SDK's transport rather than the bare global fetch.
+    const fetchImpl = opts.fetchImpl
 
     // Cache the config across the cli-core callbacks: a successful migration
     // hits `hasMigrated`, `loadLegacyPlaintextToken`, `identifyAccount`, and
@@ -108,7 +110,7 @@ interface TodoistUser {
     email: string
 }
 
-async function fetchUser(token: string, fetchImpl: typeof fetch): Promise<TodoistUser> {
+async function fetchUser(token: string, fetchImpl?: typeof fetch): Promise<TodoistUser> {
     const response = await fetchTodoist(
         USER_ENDPOINT,
         { headers: { Authorization: `Bearer ${token}` } },

--- a/src/lib/usage-tracking.test.ts
+++ b/src/lib/usage-tracking.test.ts
@@ -1,4 +1,4 @@
-import { getDefaultDispatcher } from '@doist/todoist-sdk'
+import { getDefaultTransport } from '@doist/todoist-sdk'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
     buildUsageTrackingHeaders,
@@ -13,11 +13,11 @@ vi.mock('@doist/todoist-sdk', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@doist/todoist-sdk')>()
     return {
         ...actual,
-        getDefaultDispatcher: vi.fn(() => Promise.resolve(undefined)),
+        getDefaultTransport: vi.fn(() => Promise.resolve(undefined)),
     }
 })
 
-const getDefaultDispatcherMock = vi.mocked(getDefaultDispatcher)
+const getDefaultTransportMock = vi.mocked(getDefaultTransport)
 
 describe('usage tracking', () => {
     it('normalizes commander command paths into header-friendly values', () => {
@@ -149,39 +149,61 @@ describe('usage tracking', () => {
     })
 
     describe('proxy dispatcher injection', () => {
-        const fakeDispatcher = { kind: 'env-http-proxy-agent' } as unknown as NonNullable<
-            Awaited<ReturnType<typeof getDefaultDispatcher>>
-        >
+        type Transport = NonNullable<Awaited<ReturnType<typeof getDefaultTransport>>>
+        const fakeDispatcher = {
+            kind: 'env-http-proxy-agent',
+        } as unknown as Transport['dispatcher']
 
         afterEach(() => {
             vi.restoreAllMocks()
-            getDefaultDispatcherMock.mockReset()
-            getDefaultDispatcherMock.mockResolvedValue(undefined)
+            getDefaultTransportMock.mockReset()
+            getDefaultTransportMock.mockResolvedValue(undefined)
         })
 
-        function spyOnNativeFetch(): () => RequestInit | undefined {
+        /**
+         * Stands in for the SDK's transport: a fetch of our own, paired with a
+         * dispatcher, exactly as undici's own fetch is paired in production.
+         */
+        function stubPairedTransport(): {
+            getCaptured: () => RequestInit | undefined
+            pairedFetch: ReturnType<typeof vi.fn>
+        } {
             let captured: RequestInit | undefined
-            vi.spyOn(globalThis, 'fetch').mockImplementation((async (
-                _url: RequestInfo | URL,
-                options?: RequestInit,
-            ) => {
+            const pairedFetch = vi.fn(async (_url: RequestInfo | URL, options?: RequestInit) => {
                 captured = options
                 return new Response('{}', {
                     status: 200,
                     headers: { 'content-type': 'application/json' },
                 })
-            }) as typeof fetch)
-            return () => captured
+            })
+            getDefaultTransportMock.mockResolvedValue({
+                dispatcher: fakeDispatcher,
+                fetch: pairedFetch as unknown as Transport['fetch'],
+            })
+            return { getCaptured: () => captured, pairedFetch }
         }
 
-        it('attaches the env proxy dispatcher when createTrackedFetch uses native fetch', async () => {
-            getDefaultDispatcherMock.mockResolvedValue(fakeDispatcher)
-            const getCaptured = spyOnNativeFetch()
+        /**
+         * Left without an implementation on purpose. If the transport pairing
+         * ever regresses to the global fetch, this makes a real network call
+         * and the test fails loudly instead of passing against a stub.
+         */
+        function spyOnGlobalFetch() {
+            return vi.spyOn(globalThis, 'fetch')
+        }
+
+        it('sends createTrackedFetch requests through the fetch paired with the dispatcher', async () => {
+            const globalFetchSpy = spyOnGlobalFetch()
+            const { getCaptured, pairedFetch } = stubPairedTransport()
 
             const trackedFetch = createTrackedFetch()
             await trackedFetch('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
 
-            expect(getDefaultDispatcherMock).toHaveBeenCalled()
+            expect(getDefaultTransportMock).toHaveBeenCalled()
+            expect(pairedFetch).toHaveBeenCalled()
+            // The dispatcher decompresses the body itself, so it must never be
+            // handed to a fetch it was not paired with.
+            expect(globalFetchSpy).not.toHaveBeenCalled()
             // dispatcher is a Node fetch extension not present in RequestInit types
             expect((getCaptured() as unknown as { dispatcher?: unknown }).dispatcher).toBe(
                 fakeDispatcher,
@@ -200,20 +222,22 @@ describe('usage tracking', () => {
 
             await trackedFetch('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
 
-            expect(getDefaultDispatcherMock).not.toHaveBeenCalled()
+            expect(getDefaultTransportMock).not.toHaveBeenCalled()
             expect(captured).toBeTruthy()
             expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBeUndefined()
         })
 
-        it('attaches the env proxy dispatcher when fetchTodoist uses native fetch', async () => {
-            getDefaultDispatcherMock.mockResolvedValue(fakeDispatcher)
-            const getCaptured = spyOnNativeFetch()
+        it('sends fetchTodoist requests through the fetch paired with the dispatcher', async () => {
+            const globalFetchSpy = spyOnGlobalFetch()
+            const { getCaptured, pairedFetch } = stubPairedTransport()
 
             await fetchTodoist('https://api.todoist.com/api/v1/user', {
                 headers: { Authorization: 'Bearer token' },
             })
 
-            expect(getDefaultDispatcherMock).toHaveBeenCalled()
+            expect(getDefaultTransportMock).toHaveBeenCalled()
+            expect(pairedFetch).toHaveBeenCalled()
+            expect(globalFetchSpy).not.toHaveBeenCalled()
             expect((getCaptured() as unknown as { dispatcher?: unknown }).dispatcher).toBe(
                 fakeDispatcher,
             )
@@ -235,8 +259,71 @@ describe('usage tracking', () => {
                 fetchImpl,
             )
 
-            expect(getDefaultDispatcherMock).not.toHaveBeenCalled()
+            expect(getDefaultTransportMock).not.toHaveBeenCalled()
             expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBeUndefined()
+        })
+
+        it('uses the global fetch when the transport has no fetch of its own', async () => {
+            // Bun reports Node but ships a partial undici: the SDK returns a
+            // dispatcher with no paired fetch, and the global fetch is then the
+            // correct partner because Bun decompresses natively.
+            let captured: RequestInit | undefined
+            const globalFetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((async (
+                _url: RequestInfo | URL,
+                options?: RequestInit,
+            ) => {
+                captured = options
+                return new Response('{}', {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                })
+            }) as typeof fetch)
+            getDefaultTransportMock.mockResolvedValue({
+                dispatcher: fakeDispatcher,
+                fetch: undefined,
+            })
+
+            await createTrackedFetch()('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
+
+            expect(globalFetchSpy).toHaveBeenCalled()
+            expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBe(
+                fakeDispatcher,
+            )
+        })
+
+        it('uses the global fetch and no dispatcher outside Node', async () => {
+            let captured: RequestInit | undefined
+            const globalFetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((async (
+                _url: RequestInfo | URL,
+                options?: RequestInit,
+            ) => {
+                captured = options
+                return new Response('{}', {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                })
+            }) as typeof fetch)
+            getDefaultTransportMock.mockResolvedValue(undefined)
+
+            await createTrackedFetch()('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
+
+            expect(globalFetchSpy).toHaveBeenCalled()
+            expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBeUndefined()
+        })
+
+        it('leaves a dispatcher the caller chose in place', async () => {
+            const ownDispatcher = { kind: 'caller-supplied' }
+            const { getCaptured, pairedFetch } = stubPairedTransport()
+
+            await fetchTodoist('https://api.todoist.com/api/v1/user', {
+                // dispatcher is a Node fetch extension not present in RequestInit types
+                dispatcher: ownDispatcher,
+            } as RequestInit)
+
+            expect(pairedFetch).toHaveBeenCalled()
+            expect((getCaptured() as unknown as { dispatcher?: unknown }).dispatcher).toBe(
+                ownDispatcher,
+            )
         })
     })
 

--- a/src/lib/usage-tracking.test.ts
+++ b/src/lib/usage-tracking.test.ts
@@ -192,6 +192,25 @@ describe('usage tracking', () => {
             return vi.spyOn(globalThis, 'fetch')
         }
 
+        /** Global fetch stubbed to capture the request options it is given. */
+        function stubGlobalFetch(): {
+            getCaptured: () => RequestInit | undefined
+            spy: ReturnType<typeof spyOnGlobalFetch>
+        } {
+            let captured: RequestInit | undefined
+            const spy = vi.spyOn(globalThis, 'fetch').mockImplementation((async (
+                _url: RequestInfo | URL,
+                options?: RequestInit,
+            ) => {
+                captured = options
+                return new Response('{}', {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                })
+            }) as typeof fetch)
+            return { getCaptured: () => captured, spy }
+        }
+
         it('sends createTrackedFetch requests through the fetch paired with the dispatcher', async () => {
             const globalFetchSpy = spyOnGlobalFetch()
             const { getCaptured, pairedFetch } = stubPairedTransport()
@@ -267,17 +286,7 @@ describe('usage tracking', () => {
             // Bun reports Node but ships a partial undici: the SDK returns a
             // dispatcher with no paired fetch, and the global fetch is then the
             // correct partner because Bun decompresses natively.
-            let captured: RequestInit | undefined
-            const globalFetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((async (
-                _url: RequestInfo | URL,
-                options?: RequestInit,
-            ) => {
-                captured = options
-                return new Response('{}', {
-                    status: 200,
-                    headers: { 'content-type': 'application/json' },
-                })
-            }) as typeof fetch)
+            const { getCaptured, spy } = stubGlobalFetch()
             getDefaultTransportMock.mockResolvedValue({
                 dispatcher: fakeDispatcher,
                 fetch: undefined,
@@ -285,30 +294,22 @@ describe('usage tracking', () => {
 
             await createTrackedFetch()('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
 
-            expect(globalFetchSpy).toHaveBeenCalled()
-            expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBe(
+            expect(spy).toHaveBeenCalled()
+            expect((getCaptured() as unknown as { dispatcher?: unknown }).dispatcher).toBe(
                 fakeDispatcher,
             )
         })
 
         it('uses the global fetch and no dispatcher outside Node', async () => {
-            let captured: RequestInit | undefined
-            const globalFetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((async (
-                _url: RequestInfo | URL,
-                options?: RequestInit,
-            ) => {
-                captured = options
-                return new Response('{}', {
-                    status: 200,
-                    headers: { 'content-type': 'application/json' },
-                })
-            }) as typeof fetch)
+            const { getCaptured, spy } = stubGlobalFetch()
             getDefaultTransportMock.mockResolvedValue(undefined)
 
             await createTrackedFetch()('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
 
-            expect(globalFetchSpy).toHaveBeenCalled()
-            expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBeUndefined()
+            expect(spy).toHaveBeenCalled()
+            expect(
+                (getCaptured() as unknown as { dispatcher?: unknown }).dispatcher,
+            ).toBeUndefined()
         })
 
         it('leaves a dispatcher the caller chose in place', async () => {

--- a/src/lib/usage-tracking.transport.test.ts
+++ b/src/lib/usage-tracking.transport.test.ts
@@ -1,0 +1,129 @@
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { brotliCompressSync, deflateSync, gzipSync } from 'node:zlib'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { createTrackedFetch, fetchTodoist } from './usage-tracking.js'
+
+// Deliberately no `vi.mock('@doist/todoist-sdk')` in this file, unlike its
+// sibling `usage-tracking.test.ts`. This exercises the REAL transport — the
+// SDK's proxy agent, its decompress interceptor and undici's own fetch —
+// against a real local server.
+//
+// It exists because every other test in the CLI stubs fetch, which means none
+// of them can see a mismatch between the dispatcher and the fetch it is used
+// with. That mismatch corrupts every compressed response on Node 26 while
+// leaving a stubbed suite entirely green.
+
+const PAYLOAD = {
+    results: Array.from({ length: 200 }, (_, index) => ({
+        id: `task-${index}`,
+        content: `Task number ${index} with enough text to push the body past a single chunk`,
+    })),
+}
+
+const ENCODERS = {
+    gzip: gzipSync,
+    deflate: deflateSync,
+    br: brotliCompressSync,
+} as const
+
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x01, 0x02, 0x03])
+
+let server: Server
+let baseUrl: string
+let lastRequestHeaders: Record<string, string | string[] | undefined> = {}
+
+beforeAll(async () => {
+    // `EnvHttpProxyAgent` reads the proxy environment at construction and the
+    // SDK caches the transport for the life of the process, so this has to
+    // happen before the first request in this file.
+    for (const name of [
+        'HTTP_PROXY',
+        'HTTPS_PROXY',
+        'ALL_PROXY',
+        'http_proxy',
+        'https_proxy',
+        'all_proxy',
+    ]) {
+        vi.stubEnv(name, undefined)
+    }
+
+    server = createServer((request, response) => {
+        lastRequestHeaders = request.headers
+
+        const url = new URL(request.url ?? '/', 'http://localhost')
+
+        if (url.pathname === '/binary') {
+            const body = gzipSync(PNG_BYTES)
+            response.writeHead(200, {
+                'content-type': 'image/png',
+                'content-encoding': 'gzip',
+                'content-length': String(body.length),
+            })
+            response.end(body)
+            return
+        }
+
+        const encoding = url.searchParams.get('encoding') as keyof typeof ENCODERS | null
+        const raw = Buffer.from(JSON.stringify(PAYLOAD))
+        const body = encoding ? ENCODERS[encoding](raw) : raw
+        response.writeHead(200, {
+            'content-type': 'application/json',
+            ...(encoding ? { 'content-encoding': encoding } : {}),
+            'content-length': String(body.length),
+        })
+        response.end(body)
+    })
+
+    await new Promise<void>((resolve) => {
+        server.listen(0, '127.0.0.1', resolve)
+    })
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+})
+
+afterAll(async () => {
+    server.closeAllConnections()
+    await new Promise<void>((resolve) => {
+        server.close(() => resolve())
+    })
+})
+
+describe('usage tracking over the real transport', () => {
+    it.each(Object.keys(ENCODERS))('decodes a %s-encoded response body', async (encoding) => {
+        const response = await createTrackedFetch()(`${baseUrl}/json?encoding=${encoding}`, {
+            method: 'GET',
+        })
+
+        expect(response.status).toBe(200)
+        // A dispatcher paired with the wrong fetch decompresses the body twice
+        // and this rejects with `TypeError: terminated`.
+        expect(await response.json()).toEqual(PAYLOAD)
+    })
+
+    it('decodes a compressed response through fetchTodoist', async () => {
+        // The OAuth token exchange and the postinstall user fetch take this
+        // path rather than going through TodoistApi.
+        const response = await fetchTodoist(`${baseUrl}/json?encoding=gzip`)
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual(PAYLOAD)
+    })
+
+    it('reads a compressed binary body back byte for byte', async () => {
+        const response = await createTrackedFetch()(`${baseUrl}/binary`, { method: 'GET' })
+        // `arrayBuffer` is optional on the SDK's custom fetch response type,
+        // but the CLI always supplies it — this is what `viewAttachment` uses.
+        if (!response.arrayBuffer) throw new Error('expected an arrayBuffer reader')
+        const bytes = Buffer.from(await response.arrayBuffer())
+
+        expect(bytes.equals(PNG_BYTES)).toBe(true)
+    })
+
+    it('still sends the usage tracking headers', async () => {
+        await createTrackedFetch()(`${baseUrl}/json`, { method: 'GET' })
+
+        expect(lastRequestHeaders['user-agent']).toMatch(/^todoist-cli\//)
+        expect(lastRequestHeaders['request-id']).toBeTruthy()
+        expect(lastRequestHeaders['session-id']).toBeTruthy()
+    })
+})

--- a/src/lib/usage-tracking.transport.test.ts
+++ b/src/lib/usage-tracking.transport.test.ts
@@ -2,6 +2,7 @@ import { createServer, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { brotliCompressSync, deflateSync, gzipSync } from 'node:zlib'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { initializeLogger, resetLogger } from './logger.js'
 import { createTrackedFetch, fetchTodoist } from './usage-tracking.js'
 
 // Deliberately no `vi.mock('@doist/todoist-sdk')` in this file, unlike its
@@ -82,6 +83,9 @@ beforeAll(async () => {
 })
 
 afterAll(async () => {
+    // `restoreMocks` does not undo `vi.stubEnv`, so without this the worker
+    // keeps the cleared proxy variables for every test file that follows.
+    vi.unstubAllEnvs()
     server.closeAllConnections()
     await new Promise<void>((resolve) => {
         server.close(() => resolve())
@@ -125,5 +129,42 @@ describe('usage tracking over the real transport', () => {
         expect(lastRequestHeaders['user-agent']).toMatch(/^todoist-cli\//)
         expect(lastRequestHeaders['request-id']).toBeTruthy()
         expect(lastRequestHeaders['session-id']).toBeTruthy()
+    })
+
+    it('still logs API traffic when verbose is on', async () => {
+        // The regression this guards: API requests go through the fetch paired
+        // with the dispatcher, never `globalThis.fetch`, so the global patch in
+        // `initializeLogger` cannot see them. Drop the `withHttpLogging` wrap in
+        // `resolveRequestFetch` and `td --verbose` goes silent for every call.
+        const originalGlobalFetch = globalThis.fetch
+        const written: string[] = []
+        const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((
+            chunk: string | Uint8Array,
+        ) => {
+            written.push(String(chunk))
+            return true
+        }) as typeof process.stderr.write)
+
+        try {
+            vi.stubEnv('TD_VERBOSE', '1')
+            resetLogger()
+            initializeLogger()
+            // Undo the global patch, so a log line can only have come from the
+            // wrapper applied to the paired fetch.
+            globalThis.fetch = originalGlobalFetch
+
+            const response = await createTrackedFetch()(`${baseUrl}/json?encoding=gzip`, {
+                method: 'GET',
+            })
+
+            expect(await response.json()).toEqual(PAYLOAD)
+            expect(written.join('')).toMatch(/fetch GET \/json/)
+            expect(written.join('')).toMatch(/=> 200/)
+        } finally {
+            globalThis.fetch = originalGlobalFetch
+            stderrSpy.mockRestore()
+            vi.stubEnv('TD_VERBOSE', '')
+            resetLogger()
+        }
     })
 })

--- a/src/lib/usage-tracking.ts
+++ b/src/lib/usage-tracking.ts
@@ -1,10 +1,7 @@
 import { randomUUID } from 'node:crypto'
-import {
-    type CustomFetch,
-    type CustomFetchResponse,
-    getDefaultDispatcher,
-} from '@doist/todoist-sdk'
+import { type CustomFetch, type CustomFetchResponse, getDefaultTransport } from '@doist/todoist-sdk'
 import packageJson from '../../package.json' with { type: 'json' }
+import { isHttpLoggingEnabled, withHttpLogging } from './logger.js'
 
 const CLI_NAME = 'todoist-cli'
 const CLI_VERSION = packageJson.version
@@ -76,21 +73,51 @@ function mergeTodoistHeaders(
     return Object.fromEntries(mergedHeaders.entries())
 }
 
-async function attachDispatcherIfNative(
-    fetchImpl: typeof fetch,
+/**
+ * Picks the fetch for one request, attaching the SDK's proxy dispatcher when
+ * we own the request path. Mutates `options` to add the dispatcher, so the
+ * fetch and the dispatcher can only ever be chosen together.
+ *
+ * A caller that supplies its own fetch — test stubs, injected clients — keeps
+ * it untouched and gets no dispatcher: a dispatcher means nothing to a stub,
+ * and attaching one to a fetch it was not paired with is the failure this
+ * function exists to prevent. Passing `globalThis.fetch` explicitly counts as
+ * asking for the default path, so callers that captured the global binding
+ * before calling us keep proxy support.
+ *
+ * The dispatcher and its fetch come from `getDefaultTransport()` as a single
+ * value and must not be mixed with anything else. The dispatcher decompresses
+ * the response body itself, so a fetch from a different undici build decodes
+ * it a second time and the request fails mid-stream with `terminated`.
+ */
+async function resolveRequestFetch(
+    fetchImpl: typeof fetch | undefined,
     options: RequestInit,
-): Promise<void> {
-    // Test stubs pass their own `fetchImpl`; they don't need (or understand)
-    // the dispatcher option. Only the real native fetch path needs it for
-    // HTTP_PROXY / HTTPS_PROXY / NO_PROXY support.
-    if (fetchImpl !== globalThis.fetch) return
+): Promise<typeof fetch> {
+    if (fetchImpl !== undefined && fetchImpl !== globalThis.fetch) return fetchImpl
+
+    const transport = await getDefaultTransport()
+    // No transport outside Node (browser, edge): the global fetch is on its own.
+    if (transport === undefined) return globalThis.fetch
+
     // Don't clobber a dispatcher the caller already chose.
-    if ('dispatcher' in options) return
-    const dispatcher = await getDefaultDispatcher()
-    if (dispatcher !== undefined) {
+    if (!('dispatcher' in options)) {
         // @ts-expect-error - dispatcher is a valid option for Node's fetch but not in the TS types
-        options.dispatcher = dispatcher
+        options.dispatcher = transport.dispatcher
     }
+
+    // `fetch: undefined` means the global fetch is the correct partner for
+    // this dispatcher (Bun, which decompresses natively). It has already been
+    // wrapped for logging by `initializeLogger` if verbose is on.
+    if (transport.fetch === undefined) return globalThis.fetch
+
+    // undici's fetch and the global fetch are the same call at runtime but
+    // carry different (undici vs DOM) types.
+    const pairedFetch = transport.fetch as unknown as typeof fetch
+
+    // The global patch in `initializeLogger` cannot see this fetch, so apply
+    // the same wrapper here or `--verbose` goes quiet for all API traffic.
+    return isHttpLoggingEnabled() ? withHttpLogging(pairedFetch) : pairedFetch
 }
 
 function toCustomFetchResponse(response: Response): CustomFetchResponse {
@@ -105,7 +132,7 @@ function toCustomFetchResponse(response: Response): CustomFetchResponse {
     }
 }
 
-export function createTrackedFetch(baseFetch: typeof fetch = globalThis.fetch): CustomFetch {
+export function createTrackedFetch(baseFetch?: typeof fetch): CustomFetch {
     return async (url, options = {}) => {
         const { timeout: timeoutMs, headers, signal, ...rest } = options
 
@@ -120,9 +147,9 @@ export function createTrackedFetch(baseFetch: typeof fetch = globalThis.fetch): 
             signal: abortSignal,
             headers: mergeTodoistHeaders(headers),
         }
-        await attachDispatcherIfNative(baseFetch, fetchOptions)
+        const requestFetch = await resolveRequestFetch(baseFetch, fetchOptions)
 
-        const response = await baseFetch(url, fetchOptions)
+        const response = await requestFetch(url, fetchOptions)
         return toCustomFetchResponse(response)
     }
 }
@@ -130,7 +157,7 @@ export function createTrackedFetch(baseFetch: typeof fetch = globalThis.fetch): 
 export async function fetchTodoist(
     url: string | URL,
     options: RequestInit = {},
-    fetchImpl: typeof fetch = globalThis.fetch,
+    fetchImpl?: typeof fetch,
     commandPath?: string,
 ): Promise<Response> {
     const { headers, ...rest } = options
@@ -138,8 +165,8 @@ export async function fetchTodoist(
         ...rest,
         headers: mergeTodoistHeaders(headers, commandPath),
     }
-    await attachDispatcherIfNative(fetchImpl, fetchOptions)
-    return fetchImpl(url, fetchOptions)
+    const requestFetch = await resolveRequestFetch(fetchImpl, fetchOptions)
+    return requestFetch(url, fetchOptions)
 }
 
 export function resetUsageTrackingForTests(): void {


### PR DESCRIPTION
Fixes a break that would otherwise land the moment the CLI picks up the new SDK. Depends on Doist/todoist-sdk-typescript#674, now merged and released as `@doist/todoist-sdk@14.2.0`, which this PR bumps to.

## The problem

The SDK builds a dispatcher for `HTTP_PROXY`/`HTTPS_PROXY` support and composes undici's `decompress` interceptor onto it. That dispatcher is only usable with the `fetch` it was paired with, because it decodes the response body itself — a `fetch` from a different undici build decodes it a second time.

`attachDispatcherIfNative` took the dispatcher from `getDefaultDispatcher()` and attached it to `globalThis.fetch`, which is backed by whatever undici ships inside the running Node release. That works today. From undici 7.29 onwards it does not: Node 26's built-in fetch reads `controller.rawHeaders`, still sees `content-encoding: gzip` on a body the interceptor already decompressed, and every API call fails with `TypeError: terminated` / `Error: incorrect header check`.

So the next SDK bump would have broken the CLI on Node 26 — a repeat of #318 — and nothing here would have caught it. Every test in the repo stubs fetch, so no test has ever seen a real compressed response.

## What changed

- `resolveRequestFetch` replaces `attachDispatcherIfNative`. It takes both halves from `getDefaultTransport()` and returns the fetch while attaching the dispatcher, so the two can only be chosen together. `createTrackedFetch` and `fetchTodoist` now default their fetch parameter to `undefined` rather than `globalThis.fetch`, which turns the old `fetchImpl !== globalThis.fetch` identity check into the question it was always standing in for: did the caller supply their own fetch? Explicit stubs still get no dispatcher.
- This fixes all three affected paths at once: the whole `TodoistApi` surface, the OAuth token exchange in `auth-provider.ts`, and the postinstall user fetch in `migrate-auth.ts`.
- `migrate-auth.ts` no longer pre-captures the global `fetch` binding. It worked by coincidence — the captured value was `=== globalThis.fetch` — and relying on that coincidence is what made the original bug subtle.
- **Verbose logging needed rescuing.** `patchGlobalFetch` only wraps `globalThis.fetch`, which API traffic no longer passes through, so `td --verbose` would have gone silent for every API request. The wrapper is now `withHttpLogging`, applied both to the global patch and to the paired fetch. The stale comment claiming the global patch is "the only way to get HTTP-level visibility for @doist/todoist-sdk" is updated.

## The test that would have caught this

`src/lib/usage-tracking.transport.test.ts` is the first CLI test to make a real HTTP request: a local `node:http` server serving gzip, deflate and brotli bodies over the real transport, with no SDK mock. It covers `createTrackedFetch`, `fetchTodoist`, a compressed binary body (the `viewAttachment` path) and the tracking headers.

Verified it has teeth — reverting `resolveRequestFetch` to `globalThis.fetch` and running on Node 26 gives:

```
× decodes a gzip-encoded response body
× decodes a deflate-encoded response body
× decodes a br-encoded response body
× decodes a compressed response through fetchTodoist
× reads a compressed binary body back byte for byte
TypeError: terminated
Caused by: Error: incorrect header check
```

The existing dispatcher tests are rewritten to assert the pairing rather than just the attachment, including that the global fetch is *not* called. New cases cover the Bun path (dispatcher with no paired fetch), the non-Node path, and a caller-supplied dispatcher being left alone.

## Review follow-ups

- **Verbose logging was untested** (P2) — fair, and it was the one behaviour this PR calls out as needing rescue. Covered now over the real paired transport, with the global patch undone so a log line can only come from the `withHttpLogging` wrap. Verified it fails when the wrap is dropped. First logger coverage in the repo.
- **Proxy env stubs leaking** (P3) — fixed with `vi.unstubAllEnvs()` in `afterAll`; `restoreMocks` does not undo `vi.stubEnv`.
- **Duplicated global-fetch stubbing** (P3) — folded into one `stubGlobalFetch()` helper.
- **Caching the wrapped paired fetch** (P3) — not doing it. One closure allocation per HTTP request is nothing against a network round trip, and a module-level or `WeakMap` cache would hold logger state across tests, where `resetLogger()` between cases is what keeps them honest. The cost is real but it buys a hazard rather than avoiding one.

## Verification

`npm test` (1878 tests), `npm run type-check` and `npm run check` all green on Node 24.18.0 and Node 26.4.0, against the **published** `@doist/todoist-sdk@14.2.0` — so with undici 7.29.0 actually resolved in the tree, which is the condition that breaks the old code.

Also checked end to end against the published package on both Node versions, with no mocks: a gzipped GET through `createTrackedFetch` succeeds, and the upload path (`fs.openAsBlob` → `customFetch` → paired undici fetch) sends real multipart framing with the file bytes and the tracking headers intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
