### PR TITLE
fix: pin the changelog preset to a version semantic-release can render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@semantic-release/changelog": "7.0.0",
         "@semantic-release/git": "11.0.1",
         "@types/node": "25.9.5",
-        "conventional-changelog-conventionalcommits": "10.4.0",
+        "conventional-changelog-conventionalcommits": "9.3.1",
         "lefthook": "2.1.10",
         "oxfmt": "0.64.0",
         "oxlint": "1.79.0",
@@ -134,16 +134,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@conventional-changelog/template": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.4.0.tgz",
-      "integrity": "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@doist/cli-core": {
@@ -4110,16 +4100,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
-      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.4.0"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@semantic-release/changelog": "7.0.0",
     "@semantic-release/git": "11.0.1",
     "@types/node": "25.9.5",
-    "conventional-changelog-conventionalcommits": "10.4.0",
+    "conventional-changelog-conventionalcommits": "9.3.1",
     "lefthook": "2.1.10",
     "oxfmt": "0.64.0",
     "oxlint": "1.79.0",

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,11 @@
             "matchPackageNames": ["oxlint", "oxfmt"],
             "groupName": "ox toolchain",
             "description": "Group oxlint and oxfmt updates into a single PR"
+        },
+        {
+            "matchPackageNames": ["conventional-changelog-conventionalcommits"],
+            "allowedVersions": "<10",
+            "description": "10.x requires conventional-changelog-writer@9; semantic-release still pins writer 8, so the preset throws at generateNotes"
         }
     ]
 }


### PR DESCRIPTION
The 3.3.2 release failed, so the transport fix from #492 is merged but unpublished. This unblocks it.

## What happened

[The release job](https://github.com/Doist/todoist-cli/actions/runs/32838543779/job/97772746192) died at `generateNotes`:

```
Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer (conventional-changelog@8 or newer).
Your changelog tooling loaded an older writer which cannot render this preset."
```

`conventional-changelog-conventionalcommits@10.4.0` added a hard guard requiring `conventional-changelog-writer@9`. `semantic-release@25.0.9` resolves `@semantic-release/release-notes-generator@14.1.1`, which pins `conventional-changelog-writer@^8.0.0` — and so does its latest release, so there is no version of semantic-release that satisfies the 10.x preset today.

Renovate moved us from 10.3.0 to 10.4.0 in #490 yesterday. 10.3.0 carried no such guard, which is exactly why 3.3.1 released and 3.3.2 did not. Nothing in #492 is involved — its lockfile changes do not touch the changelog tooling.

## The fix

Pin the preset to `9.3.1` — the line the preset's own error message points at ("use an older major version of the preset"), and the version both `@doist/todoist-sdk` and `@doist/comms-sdk` already release from. A Renovate rule keeps 10.x out until semantic-release moves to writer 9.

## Verification

Rendered the actual 3.3.2 notes through `@semantic-release/release-notes-generator` against the installed writer:

```
preset 10.4.0 + writer 8.4.0 → FAILED — Missing helper: …
preset 10.3.0 + writer 8.4.0 → OK
preset  9.3.1 + writer 8.4.0 → OK
  ## [3.3.2](https://github.com/Doist/todoist-cli/compare/v3.3.1...v3.3.2) (2026-08-25)
```

`npx semantic-release --dry-run` then completes with no failed steps. `npm test` (1878) and `npm run check` still pass.

Chose 9.3.1 over reverting to 10.3.0 because the whole 10.x line has declared it needs writer 9 — going back to 10.3.0 just waits for the next patch bump to break the release again.

## After merge

The release aborted before tagging or publishing — npm is still on 3.3.1 and there is no `v3.3.2` tag — so merging this re-runs the job and publishes 3.3.2 cleanly, including the transport fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
