### PR TITLE
feat!: build and parse Todoist URLs with the SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@doist/cli-core": "1.2.0",
-        "@doist/todoist-sdk": "14.2.0",
+        "@doist/todoist-sdk": "15.0.0",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "6.0.0",
@@ -193,12 +193,19 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/@doist/sdk-kmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@doist/sdk-kmp/-/sdk-kmp-0.2.3.tgz",
+      "integrity": "sha512-6V1vuu80nEhIOKDQ117kPICZJpTgYbsdIL1AiGQbAPVFkNJYLZAWG5JXqmNrVBzAwq7LF+f/47C/NZX4pzNjdw==",
+      "license": "MIT"
+    },
     "node_modules/@doist/todoist-sdk": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-14.2.0.tgz",
-      "integrity": "sha512-v1KwLfCtk1zcm11/wDXdcvQSSmbdMcRv6KRL+ketMzm6Q6/s5r+5vh0kljQORBFdAY01yOMAWBfIB6D+Ec6vAA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-15.0.0.tgz",
+      "integrity": "sha512-GN1WNG/smkjyo8f6HfAfM5cdR1TuBFheN87by/03SM6cBAIs6L71nlf6EM9srskAn4gM0kpCggEkgCADSoiOAg==",
       "license": "MIT",
       "dependencies": {
+        "@doist/sdk-kmp": "0.2.3",
         "camelcase": "6.3.0",
         "emoji-regex": "10.6.0",
         "ts-custom-error": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@doist/cli-core": "1.2.0",
-    "@doist/todoist-sdk": "14.2.0",
+    "@doist/todoist-sdk": "15.0.0",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "6.0.0",

--- a/src/lib/refs.test.ts
+++ b/src/lib/refs.test.ts
@@ -106,6 +106,18 @@ describe('parseTodoistUrl', () => {
         expect(result).toEqual({ entityType: 'filter', id: 'filter1' })
     })
 
+    it('returns null for link types the CLI has no command for', () => {
+        // The SDK recognises these, but there is no `td section` or `td workspace`.
+        expect(parseTodoistUrl('https://app.todoist.com/app/section/to-do-sec1')).toBeNull()
+        expect(parseTodoistUrl('https://app.todoist.com/app/12345')).toBeNull()
+    })
+
+    it('returns null for workspace-scoped links', () => {
+        // Parsed as a filter without this guard, which would report
+        // "Filter not found." instead of an unrecognised URL.
+        expect(parseTodoistUrl('https://app.todoist.com/app/12345/filter/work-filter1')).toBeNull()
+    })
+
     it('returns null for non-Todoist URLs', () => {
         expect(parseTodoistUrl('https://google.com')).toBeNull()
     })

--- a/src/lib/refs.ts
+++ b/src/lib/refs.ts
@@ -1,4 +1,9 @@
-import { type AppWithUserCount, TodoistApi, TodoistRequestError } from '@doist/todoist-sdk'
+import {
+    type AppWithUserCount,
+    parseTodoistUrl as parseSdkTodoistUrl,
+    TodoistApi,
+    TodoistRequestError,
+} from '@doist/todoist-sdk'
 import type { Project, Task } from './api/core.js'
 import {
     fetchWorkspaceFolders,
@@ -18,20 +23,21 @@ export interface ParsedTodoistUrl {
     id: string
 }
 
-const TODOIST_URL_PATTERN = new RegExp(
-    `^https?://app\\.todoist\\.com/app/(${URL_ENTITY_TYPES.join('|')})/([^?#]+)`,
-)
+function isUrlEntityType(value: string): value is UrlEntityType {
+    return (URL_ENTITY_TYPES as readonly string[]).includes(value)
+}
 
 export function parseTodoistUrl(url: string): ParsedTodoistUrl | null {
-    const match = url.match(TODOIST_URL_PATTERN)
-    if (!match) return null
+    const parsed = parseSdkTodoistUrl(url)
+    if (!parsed) return null
 
-    const entityType = match[1] as UrlEntityType
-    const slugAndId = match[2]
-    const lastHyphenIndex = slugAndId.lastIndexOf('-')
-    const id = lastHyphenIndex === -1 ? slugAndId : slugAndId.slice(lastHyphenIndex + 1)
+    // The SDK recognises more kinds of link than the CLI has commands for.
+    if (!isUrlEntityType(parsed.type)) return null
 
-    return { entityType, id }
+    // Workspace-scoped links (such as a workspace filter) have no CLI command.
+    if (parsed.workspaceId) return null
+
+    return { entityType: parsed.type, id: parsed.id }
 }
 
 const VIEW_TYPES = ['today', 'upcoming'] as const

--- a/src/lib/urls.test.ts
+++ b/src/lib/urls.test.ts
@@ -57,7 +57,7 @@ describe('URL builders', () => {
     describe('projectCommentUrl', () => {
         it('generates correct web app URL for project comment', () => {
             expect(projectCommentUrl('project-1', 'comment-2')).toBe(
-                'https://app.todoist.com/app/project/project-1/comments#comment-comment-2',
+                'https://app.todoist.com/app/project/project-1#comment-comment-2',
             )
         })
     })

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,29 +1,41 @@
+import {
+    getFilterUrl,
+    getLabelUrl,
+    getProjectCommentUrl,
+    getProjectUrl,
+    getSectionUrl,
+    getTaskCommentUrl,
+    getTaskUrl,
+} from '@doist/todoist-sdk'
+
+/**
+ * Todoist web links.
+ *
+ * These delegate to the SDK, which is the shared source of the URL rules, so
+ * links stay in step with the other Todoist clients. Only links the SDK has no
+ * builder for are assembled here.
+ */
+
 const BASE_URL = 'https://app.todoist.com/app'
 
-type EntityPath = 'task' | 'project' | 'label' | 'filter' | 'section'
-
-function entityUrl(path: EntityPath, id: string): string {
-    return `${BASE_URL}/${path}/${id}`
-}
-
 export function taskUrl(taskId: string): string {
-    return entityUrl('task', taskId)
+    return getTaskUrl(taskId)
 }
 
 export function projectUrl(projectId: string): string {
-    return entityUrl('project', projectId)
+    return getProjectUrl(projectId)
 }
 
 export function labelUrl(labelId: string): string {
-    return entityUrl('label', labelId)
+    return getLabelUrl(labelId)
 }
 
 export function filterUrl(filterId: string): string {
-    return entityUrl('filter', filterId)
+    return getFilterUrl(filterId)
 }
 
 export function sectionUrl(sectionId: string): string {
-    return entityUrl('section', sectionId)
+    return getSectionUrl(sectionId)
 }
 
 export function appInstallUrl(distributionToken: string): string {
@@ -31,9 +43,9 @@ export function appInstallUrl(distributionToken: string): string {
 }
 
 export function commentUrl(taskId: string, commentId: string): string {
-    return `${entityUrl('task', taskId)}#comment-${commentId}`
+    return getTaskCommentUrl(taskId, commentId)
 }
 
 export function projectCommentUrl(projectId: string, commentId: string): string {
-    return `${entityUrl('project', projectId)}/comments#comment-${commentId}`
+    return getProjectCommentUrl(projectId, commentId)
 }


### PR DESCRIPTION
## What

Takes `@doist/todoist-sdk` 15.0.0 and moves the CLI's Todoist URL handling onto it. The SDK is now the shared source of the URL rules (backed by `@doist/sdk-kmp`), so the CLI should not be assembling and matching links itself.

## Building

`lib/urls.ts` keeps every signature and hands each builder to the SDK. Two of these are links the SDK only gained in v15 — `getLabelUrl` and `getFilterUrl` — so the CLI no longer needs its own `entityUrl` at all.

`appInstallUrl` stays local; the SDK has no builder for install links.

## Parsing

`parseTodoistUrl` in `lib/refs.ts` delegates the entity part to the SDK, which extracts IDs properly instead of splitting the slug on its last hyphen. View links (`today`, `upcoming`) have no SDK equivalent and are still matched here.

The SDK recognises more kinds of link than the CLI has commands for, so two guards keep the existing behaviour:

- anything outside `task`, `project`, `label` and `filter` is still treated as unsupported;
- workspace-scoped links, such as a workspace filter, are still rejected. Without this the SDK parses them as filters and `td view <workspace filter URL>` would answer "Filter not found." instead of "Not a recognized Todoist URL".

## Breaking

`projectCommentUrl` now returns `/app/project/{id}#comment-{id}` rather than `/app/project/{id}/comments#comment-{id}`, to match the shared rules. Every other builder produces byte-identical output — checked against the previous implementation before the swap.

## Verification

1878 tests pass, `type-check`, `check` and `build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)