### PR TITLE
feat(activity)!: remove markdown output mode

### DIFF
--- a/src/commands/activity.test.ts
+++ b/src/commands/activity.test.ts
@@ -225,58 +225,11 @@ describe('activity command', () => {
         expect(lines).toHaveLength(2)
     })
 
-    it('outputs markdown with --markdown flag', async () => {
-        const program = createProgram()
-
-        mockApi.getActivityLogs.mockResolvedValue({
-            results: [
-                {
-                    id: 'event-1',
-                    objectType: 'task',
-                    objectId: 'task-1',
-                    eventType: 'completed',
-                    eventDate: new Date('2025-01-10T14:30:00Z'),
-                    parentProjectId: 'proj-1',
-                    parentItemId: null,
-                    initiatorId: null,
-                    extraData: { content: 'Buy groceries' },
-                },
-            ],
-            nextCursor: null,
-        })
-        mockApi.getProjects.mockResolvedValue({
-            results: [{ id: 'proj-1', name: 'Shopping' }],
-            nextCursor: null,
-        })
-
-        await program.parseAsync(['node', 'td', 'activity', '--markdown'])
-
-        const output = consoleSpy.mock.calls[0][0]
-        expect(output).toContain('# Activity Log')
-        expect(output).toContain('## 2025-01-10')
-        expect(output).toMatch(
-            /^- \d{2}:\d{2} - completed task: Buy groceries \(project: Shopping\)$/m,
-        )
-    })
-
-    it('outputs markdown header when no activity and --markdown is used', async () => {
-        const program = createProgram()
-
-        mockApi.getActivityLogs.mockResolvedValue({
-            results: [],
-            nextCursor: null,
-        })
-
-        await program.parseAsync(['node', 'td', 'activity', '--markdown'])
-
-        expect(consoleSpy).toHaveBeenCalledWith('# Activity Log')
-    })
-
     it('rejects conflicting output format flags', async () => {
         const program = createProgram()
 
         await expect(
-            program.parseAsync(['node', 'td', 'activity', '--markdown', '--json']),
+            program.parseAsync(['node', 'td', 'activity', '--json', '--ndjson']),
         ).rejects.toThrow('mutually exclusive')
     })
 
@@ -347,19 +300,5 @@ describe('activity command', () => {
         const textOutput = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
         expect(textOutput).toContain('--cursor')
         expect(textOutput).not.toContain('--all')
-
-        consoleSpy.mockClear()
-        mockApi.getActivityLogs.mockResolvedValue({
-            results: [mockEvent],
-            nextCursor: 'cursor-abc',
-        })
-        mockApi.getProjects.mockResolvedValue(mockProjects)
-
-        const program2 = createProgram()
-        await program2.parseAsync(['node', 'td', 'activity', '--markdown'])
-
-        const mdOutput = consoleSpy.mock.calls[0][0]
-        expect(mdOutput).toContain('--cursor')
-        expect(mdOutput).not.toContain('--all')
     })
 })

--- a/src/commands/activity.ts
+++ b/src/commands/activity.ts
@@ -22,7 +22,6 @@ interface ActivityOptions extends Pagination {
     event?: string
     project?: string
     by?: string
-    markdown?: boolean
     json?: boolean
     ndjson?: boolean
     full?: boolean
@@ -125,76 +124,6 @@ function formatActivityRow(
     return `${line1}\n${line2}`
 }
 
-function normalizeInlineText(text: string): string {
-    return text.replace(/\s+/g, ' ').trim()
-}
-
-function formatMarkdownDay(date: Date): string {
-    const year = date.getFullYear()
-    const month = String(date.getMonth() + 1).padStart(2, '0')
-    const day = String(date.getDate()).padStart(2, '0')
-    return `${year}-${month}-${day}`
-}
-
-function formatMarkdownTime(date: Date): string {
-    const hours = String(date.getHours()).padStart(2, '0')
-    const minutes = String(date.getMinutes()).padStart(2, '0')
-    return `${hours}:${minutes}`
-}
-
-function formatActivityMarkdown(
-    events: ActivityEvent[],
-    projects: Map<string, Project>,
-    userNames: Map<string, string>,
-    nextCursor?: string | null,
-): string {
-    const sortedEvents = [...events].sort(
-        (a, b) => new Date(b.eventDate).getTime() - new Date(a.eventDate).getTime(),
-    )
-
-    const lines: string[] = ['# Activity Log']
-    let currentDay: string | null = null
-
-    for (const event of sortedEvents) {
-        const day = formatMarkdownDay(event.eventDate)
-        if (day !== currentDay) {
-            lines.push('', `## ${day}`, '')
-            currentDay = day
-        }
-
-        const objectType = OBJECT_TYPE_LABELS[event.objectType] || event.objectType
-        const content = normalizeInlineText(getEventContent(event))
-        const parts = [
-            `- ${formatMarkdownTime(event.eventDate)} - ${event.eventType} ${objectType}: ${content}`,
-        ]
-
-        if (event.parentProjectId) {
-            const projectName = projects.get(event.parentProjectId)?.name
-            if (projectName) {
-                parts.push(`(project: ${normalizeInlineText(projectName)})`)
-            }
-        }
-
-        if (event.initiatorId && userNames.size > 0) {
-            const fullName = userNames.get(event.initiatorId)
-            if (fullName) {
-                parts.push(`(by: ${normalizeInlineText(formatUserShortName(fullName))})`)
-            }
-        }
-
-        lines.push(parts.join(' '))
-    }
-
-    if (nextCursor) {
-        lines.push(
-            '',
-            '> Note: More items exist. Use --cursor to paginate, or narrow results with --since/--until.',
-        )
-    }
-
-    return lines.join('\n')
-}
-
 export function registerActivityCommand(program: Command): void {
     program
         .command('activity')
@@ -217,18 +146,15 @@ export function registerActivityCommand(program: Command): void {
         .option('--by <user>', 'Filter by initiator (use "me" for yourself)')
         .option('--limit <n>', `Limit results (default: ${ACTIVITY_LIMIT})`)
         .option('--cursor <cursor>', CURSOR_DESCRIPTION)
-        .option('--markdown', 'Output as raw Markdown')
         .option('--json', 'Output as JSON')
         .option('--ndjson', 'Output as newline-delimited JSON')
         .option('--full', 'Include all fields in JSON output')
         .action(async (options: ActivityOptions) => {
-            const selectedOutputFormats = [options.markdown, options.json, options.ndjson].filter(
-                Boolean,
-            ).length
+            const selectedOutputFormats = [options.json, options.ndjson].filter(Boolean).length
             if (selectedOutputFormats > 1) {
                 throw new CliError(
                     'CONFLICTING_OPTIONS',
-                    'Options --markdown, --json, and --ndjson are mutually exclusive.',
+                    'Options --json and --ndjson are mutually exclusive.',
                 )
             }
 
@@ -287,17 +213,6 @@ export function registerActivityCommand(program: Command): void {
             }
 
             if (events.length === 0) {
-                if (options.markdown) {
-                    const lines = ['# Activity Log']
-                    if (nextCursor) {
-                        lines.push(
-                            '',
-                            '> Note: More items exist. Use --cursor to paginate, or narrow results with --since/--until.',
-                        )
-                    }
-                    console.log(lines.join('\n'))
-                    return
-                }
                 console.log('No activity found.')
                 if (nextCursor) {
                     console.log(
@@ -336,11 +251,6 @@ export function registerActivityCommand(program: Command): void {
                     if (!response.hasMore || !response.nextCursor) break
                     cursor = response.nextCursor
                 }
-            }
-
-            if (options.markdown) {
-                console.log(formatActivityMarkdown(events, projects, userNames, nextCursor))
-                return
             }
 
             console.log(chalk.bold(`Activity (${events.length})`))


### PR DESCRIPTION
`td activity --markdown` is the only command-specific Markdown output mode in the CLI. It was introduced as an LLM-friendly export, but JSON and NDJSON now provide clearer structured output for agents and automation. Keeping this one-off mode requires a dedicated formatter and special conflict handling without establishing a consistent CLI-wide pattern.

## Summary

- remove the `--markdown` option from `td activity`
- remove the dedicated activity Markdown formatter
- keep human, JSON, and NDJSON output unchanged
- preserve mutual-exclusion validation for `--json` and `--ndjson`

## Alternatives

Use the default terminal-oriented output for interactive use:

```sh
td activity
```

Use structured output for agents, scripts, or conversion into another format:

```sh
td activity --json
td activity --ndjson
```

This is a breaking change because `td activity --markdown` is no longer accepted.
