### PR TITLE
fix: update Todoist SDK to 15.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@doist/cli-core": "1.4.0",
-        "@doist/todoist-sdk": "15.0.0",
+        "@doist/todoist-sdk": "15.0.1",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "6.0.0",
@@ -200,9 +200,9 @@
       "license": "MIT"
     },
     "node_modules/@doist/todoist-sdk": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-15.0.0.tgz",
-      "integrity": "sha512-GN1WNG/smkjyo8f6HfAfM5cdR1TuBFheN87by/03SM6cBAIs6L71nlf6EM9srskAn4gM0kpCggEkgCADSoiOAg==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-15.0.1.tgz",
+      "integrity": "sha512-jLHQwBeV8THDQgRqYCIzgTm5d5JYOjkrvBc1+lN9NnULX1PEL8rfe+qQpoNvSoNFGjxFKJUUUIjauYY8jngxwA==",
       "license": "MIT",
       "dependencies": {
         "@doist/sdk-kmp": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@doist/cli-core": "1.4.0",
-    "@doist/todoist-sdk": "15.0.0",
+    "@doist/todoist-sdk": "15.0.1",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "6.0.0",

--- a/src/lib/api/reminders.ts
+++ b/src/lib/api/reminders.ts
@@ -3,6 +3,7 @@ import {
     type LocationReminder,
     type LocationTrigger,
     type Reminder as SdkReminder,
+    type SyncReminder,
 } from '@doist/todoist-sdk'
 import { getApi, pickDefined } from './core.js'
 
@@ -24,7 +25,7 @@ export interface Reminder {
     isDeleted: boolean
 }
 
-function toReminder(r: SdkReminder): Reminder {
+function toReminder(r: SyncReminder): Reminder {
     return {
         id: r.id,
         itemId: r.itemId,


### PR DESCRIPTION
## Summary

- update `@doist/todoist-sdk` to 15.0.1
- use the SDK's Sync-specific reminder type for Sync responses
- keep REST reminder responses typed with the REST reminder type

This consumes Doist/todoist-sdk-typescript#676.
