### PR TITLE
fix: update Todoist SDK to 15.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@doist/cli-core": "1.4.0",
-        "@doist/todoist-sdk": "15.0.1",
+        "@doist/todoist-sdk": "15.0.2",
         "@napi-rs/keyring": "1.3.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "6.0.0",
@@ -200,9 +200,9 @@
       "license": "MIT"
     },
     "node_modules/@doist/todoist-sdk": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-15.0.1.tgz",
-      "integrity": "sha512-jLHQwBeV8THDQgRqYCIzgTm5d5JYOjkrvBc1+lN9NnULX1PEL8rfe+qQpoNvSoNFGjxFKJUUUIjauYY8jngxwA==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-15.0.2.tgz",
+      "integrity": "sha512-mM9OO6X5SuZ8JUkuM0FNZh9nn3/MBOgkTEXm0Y4hIqJnxSHGK1Q2upFxvDcjFJ5KlCAMdDKegtY99MrkNAMZfA==",
       "license": "MIT",
       "dependencies": {
         "@doist/sdk-kmp": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@doist/cli-core": "1.4.0",
-    "@doist/todoist-sdk": "15.0.1",
+    "@doist/todoist-sdk": "15.0.2",
     "@napi-rs/keyring": "1.3.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "6.0.0",


### PR DESCRIPTION
## Summary

- update `@doist/todoist-sdk` from 15.0.1 to 15.0.2
- pick up compatible Todoist user response normalization and WebSocket URL support

See https://github.com/Doist/todoist-sdk-typescript/pull/676