### PR TITLE
fix(text): slice and index name strings by code point, not code unit

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -180,6 +180,11 @@ New subcommand? Copy a sibling in the target group, wire it in that group's
 - **`pagination.ts`** — `paginate()`, `LIMITS` (tasks: 300, projects: 50, …)
 - **`completion.ts`** — `parseCompLine`, `getCompletions`,
   `withCaseInsensitiveChoices`, `withUnvalidatedChoices` (Commander tree-walker)
+- **`text.ts`** — `firstCodePoint`, `truncateForDisplay`. Code-point-safe
+  indexing and truncation. Reach for these rather than `name[0]` or
+  `text.slice(0, n)` on anything user-supplied: those cut by UTF-16 code unit
+  and split an emoji into a lone surrogate, which has no UTF-8 form and is
+  rejected by anything requiring well-formed text.
 - **`spinner.ts`** — `startEarlySpinner`, `LoadingSpinner` class
   (yocto-spinner wrapper)
 - **`markdown.ts`** — `preloadMarkdown`, markdown → terminal renderer

--- a/src/commands/activity.test.ts
+++ b/src/commands/activity.test.ts
@@ -59,6 +59,43 @@ describe('activity command', () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Buy groceries'))
     })
 
+    it('does not split an emoji when truncating long activity content', async () => {
+        // The call-site guard for `truncateContent`. The default limit is 100 and
+        // the cut lands at 97, so this content puts a palm tree exactly across
+        // that boundary, which is where a code-unit slice used to bisect it.
+        const straddling = `${'x'.repeat(96)}\u{1F334} and more text past the limit`
+        const program = createProgram()
+
+        mockApi.getActivityLogs.mockResolvedValue({
+            results: [
+                {
+                    id: 'event-1',
+                    objectType: 'task',
+                    objectId: 'task-1',
+                    eventType: 'added',
+                    eventDate: new Date('2025-01-10T14:30:00Z'),
+                    parentProjectId: 'proj-1',
+                    parentItemId: null,
+                    initiatorId: 'user-1',
+                    extraData: { content: straddling },
+                },
+            ],
+            nextCursor: null,
+        })
+        mockApi.getProjects.mockResolvedValue({
+            results: [{ id: 'proj-1', name: 'Shopping' }],
+            nextCursor: null,
+        })
+
+        await program.parseAsync(['node', 'td', 'activity'])
+
+        const printed = consoleSpy.mock.calls.flat().join('\n')
+        expect(printed.isWellFormed()).toBe(true)
+        // It truncated (so the guard is exercised) and kept the emoji whole.
+        expect(printed).toContain('...')
+        expect(printed).toContain('\u{1F334}')
+    })
+
     it('shows "No activity found" when empty', async () => {
         const program = createProgram()
 

--- a/src/commands/activity.ts
+++ b/src/commands/activity.ts
@@ -14,6 +14,7 @@ import type { Pagination } from '../lib/options.js'
 import { formatPaginatedJson, formatPaginatedNdjson } from '../lib/output.js'
 import { paginate } from '../lib/pagination.js'
 import { extractId, isIdRef, resolveProjectId } from '../lib/refs.js'
+import { truncateForDisplay } from '../lib/text.js'
 
 interface ActivityOptions extends Pagination {
     since?: string
@@ -93,10 +94,10 @@ function getEventContent(event: ActivityEvent): string {
 
 function truncateContent(content: string, maxLength = 100): string {
     const firstLine = content.split('\n')[0]
-    if (firstLine.length <= maxLength) {
-        return firstLine
-    }
-    return `${firstLine.slice(0, maxLength - 3)}...`
+    // Unlike the comment previews, the ellipsis counts toward `maxLength` here,
+    // so the helper's budget is three short of it. The outer check stays in code
+    // units: it only decides WHETHER to cut, never where, so it cannot split a pair.
+    return firstLine.length <= maxLength ? firstLine : truncateForDisplay(firstLine, maxLength - 3)
 }
 
 function formatActivityRow(

--- a/src/commands/comment/add.ts
+++ b/src/commands/comment/add.ts
@@ -13,6 +13,7 @@ import { openLocalFileAsBlob } from '../../lib/local-file.js'
 import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveProjectRef, resolveTaskRef } from '../../lib/refs.js'
 import { readStdin } from '../../lib/stdin.js'
+import { truncateForDisplay } from '../../lib/text.js'
 
 interface AddOptions {
     content?: string
@@ -59,7 +60,7 @@ export async function addComment(ref: string, options: AddOptions): Promise<void
         printDryRun('add comment', {
             Target: ref,
             'Target type': options.project ? 'project' : 'task',
-            Content: content.length > 80 ? `${content.slice(0, 80)}...` : content,
+            Content: truncateForDisplay(content, 80),
             File: options.file,
             // Printed unresolved: the dry-run deliberately runs before getApi(),
             // so no lookup has happened at this point.

--- a/src/commands/comment/delete.ts
+++ b/src/commands/comment/delete.ts
@@ -2,6 +2,7 @@ import { getApi } from '../../lib/api/core.js'
 import { isQuiet } from '../../lib/global-args.js'
 import { printDryRun } from '../../lib/output.js'
 import { lenientIdRef } from '../../lib/refs.js'
+import { truncateForDisplay } from '../../lib/text.js'
 
 export async function deleteComment(
     commentId: string,
@@ -11,8 +12,7 @@ export async function deleteComment(
 
     const api = await getApi()
     const comment = await api.getComment(id)
-    const preview =
-        comment.content.length > 50 ? `${comment.content.slice(0, 50)}...` : comment.content
+    const preview = truncateForDisplay(comment.content, 50)
 
     if (options.dryRun) {
         printDryRun('delete comment', { Comment: preview })

--- a/src/commands/comment/update.ts
+++ b/src/commands/comment/update.ts
@@ -2,6 +2,7 @@ import { getApi } from '../../lib/api/core.js'
 import { isQuiet } from '../../lib/global-args.js'
 import { formatJson, printDryRun } from '../../lib/output.js'
 import { lenientIdRef } from '../../lib/refs.js'
+import { truncateForDisplay } from '../../lib/text.js'
 
 export async function updateComment(
     commentId: string,
@@ -10,8 +11,7 @@ export async function updateComment(
     const id = lenientIdRef(commentId, 'comment')
 
     if (options.dryRun) {
-        const preview =
-            options.content.length > 80 ? `${options.content.slice(0, 80)}...` : options.content
+        const preview = truncateForDisplay(options.content, 80)
         printDryRun('update comment', { ID: id, Content: preview })
         return
     }
@@ -25,8 +25,7 @@ export async function updateComment(
     }
 
     const comment = await api.getComment(id)
-    const oldPreview =
-        comment.content.length > 50 ? `${comment.content.slice(0, 50)}...` : comment.content
+    const oldPreview = truncateForDisplay(comment.content, 50)
     await api.updateComment(id, { content: options.content })
     if (!isQuiet()) console.log(`Updated comment: ${oldPreview} (id:${id})`)
 }

--- a/src/lib/collaborators.test.ts
+++ b/src/lib/collaborators.test.ts
@@ -10,8 +10,6 @@ import { describe, expect, it } from 'vitest'
 
 import { formatUserShortName } from './collaborators.js'
 
-const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/
-
 describe('formatUserShortName', () => {
     it.each([
         ['Omar | 🌴', 'Omar 🌴.'],
@@ -22,9 +20,9 @@ describe('formatUserShortName', () => {
         expect(formatUserShortName(input)).toBe(expected)
     })
 
-    it('never returns a lone surrogate', () => {
+    it('always returns well-formed output', () => {
         for (const name of ['Omar | 🌴', 'Ada Lovelace', 'Rui', 'Yuki 🎌 Tanaka', 'A 👨‍👩‍👧']) {
-            expect(LONE_SURROGATE.test(formatUserShortName(name))).toBe(false)
+            expect(formatUserShortName(name).isWellFormed()).toBe(true)
         }
     })
 

--- a/src/lib/collaborators.test.ts
+++ b/src/lib/collaborators.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Unit tests for `formatUserShortName`.
+ *
+ * The emoji case is the regression: abbreviating by UTF-16 code unit took the
+ * first half of 🌴 and returned `"Omar \ud83c."`, a lone surrogate that has no
+ * UTF-8 form and is rejected by anything requiring well-formed text. The other
+ * three names are the control and must be byte-identical to the old behaviour.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { formatUserShortName } from './collaborators.js'
+
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/
+
+describe('formatUserShortName', () => {
+    it.each([
+        ['Omar | 🌴', 'Omar 🌴.'],
+        ['Ada Lovelace', 'Ada L.'],
+        ['Rui', 'Rui'],
+        ['Yuki 🎌 Tanaka', 'Yuki T.'],
+    ])('abbreviates %j to %j', (input, expected) => {
+        expect(formatUserShortName(input)).toBe(expected)
+    })
+
+    it('never returns a lone surrogate', () => {
+        for (const name of ['Omar | 🌴', 'Ada Lovelace', 'Rui', 'Yuki 🎌 Tanaka', 'A 👨‍👩‍👧']) {
+            expect(LONE_SURROGATE.test(formatUserShortName(name))).toBe(false)
+        }
+    })
+
+    it('collapses surrounding and repeated whitespace as before', () => {
+        expect(formatUserShortName('  Ada   Lovelace  ')).toBe('Ada L.')
+    })
+})

--- a/src/lib/collaborators.ts
+++ b/src/lib/collaborators.ts
@@ -2,6 +2,7 @@ import { isWorkspaceProject, type TodoistApi } from '@doist/todoist-sdk'
 import { getCurrentUserId, type Project, type Task } from './api/core.js'
 import { CliError } from './errors.js'
 import { extractId, isIdRef } from './refs.js'
+import { firstCodePoint } from './text.js'
 
 export interface CollaboratorInfo {
     id: string
@@ -132,7 +133,9 @@ export function formatUserShortName(fullName: string): string {
         return parts[0]
     }
     const firstName = parts[0]
-    const lastInitial = parts[parts.length - 1][0]
+    // By code point, not `[0]`: indexing by code unit takes half of an astral
+    // character, so a last name starting with an emoji yields a lone surrogate.
+    const lastInitial = firstCodePoint(parts[parts.length - 1])
     return `${firstName} ${lastInitial}.`
 }
 

--- a/src/lib/text.test.ts
+++ b/src/lib/text.test.ts
@@ -9,9 +9,6 @@ import { describe, expect, it } from 'vitest'
 
 import { firstCodePoint, truncateForDisplay } from './text.js'
 
-/** A high surrogate with no low surrogate after it, or the reverse. */
-const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/
-
 describe('firstCodePoint', () => {
     it('keeps an astral character whole', () => {
         expect(firstCodePoint('🌴')).toBe('🌴')
@@ -47,13 +44,14 @@ describe('truncateForDisplay', () => {
         // where `slice(0, 80)` used to bisect it.
         const straddling = `${'x'.repeat(79)}🌴 tail`
         const out = truncateForDisplay(straddling, 80)
-        expect(LONE_SURROGATE.test(out)).toBe(false)
+        expect(out.isWellFormed()).toBe(true)
         expect(out).toBe(`${'x'.repeat(79)}🌴...`)
 
-        // MUST STAY SILENT: the same content with the emoji clear of the
-        // boundary is unaffected either way.
+        // MUST STAY SILENT: 76 code points fit under the limit, so this must
+        // come back byte-identical. Asserting only "no lone surrogate" would
+        // pass even if the input had been mangled into a different valid string.
         const clear = `${'x'.repeat(70)}🌴 tail`
-        expect(LONE_SURROGATE.test(truncateForDisplay(clear, 80))).toBe(false)
+        expect(truncateForDisplay(clear, 80)).toBe(clear)
     })
 
     it('counts in the same unit it cuts, so the check cannot disagree with the slice', () => {
@@ -62,6 +60,6 @@ describe('truncateForDisplay', () => {
         const emoji = '🌴'.repeat(40)
         expect(truncateForDisplay(emoji, 40)).toBe(emoji)
         expect(truncateForDisplay(emoji, 10)).toBe(`${'🌴'.repeat(10)}...`)
-        expect(LONE_SURROGATE.test(truncateForDisplay(emoji, 10))).toBe(false)
+        expect(truncateForDisplay(emoji, 10).isWellFormed()).toBe(true)
     })
 })

--- a/src/lib/text.test.ts
+++ b/src/lib/text.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for the code-point-safe string helpers.
+ *
+ * Every case carries its control: an input that MUST change and an input that
+ * MUST NOT, so a helper that quietly did nothing (or mangled ordinary text)
+ * cannot pass.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { firstCodePoint, truncateForDisplay } from './text.js'
+
+/** A high surrogate with no low surrogate after it, or the reverse. */
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/
+
+describe('firstCodePoint', () => {
+    it('keeps an astral character whole', () => {
+        expect(firstCodePoint('🌴')).toBe('🌴')
+        expect(firstCodePoint('🌴 tail')).toBe('🌴')
+    })
+
+    it('returns the same character as [0] for ordinary text', () => {
+        // The control: for BMP text the two agree, so the fix only moves the broken case.
+        for (const s of ['Lovelace', 'ada', 'Álvarez', 'здраво', '123']) {
+            expect(firstCodePoint(s)).toBe(s[0])
+        }
+    })
+
+    it('returns an empty string for empty input rather than undefined', () => {
+        expect(firstCodePoint('')).toBe('')
+    })
+})
+
+describe('truncateForDisplay', () => {
+    it('leaves a string that already fits completely untouched', () => {
+        expect(truncateForDisplay('short', 80)).toBe('short')
+        expect(truncateForDisplay('🌴🌴🌴', 80)).toBe('🌴🌴🌴')
+        const exact = 'x'.repeat(80)
+        expect(truncateForDisplay(exact, 80)).toBe(exact)
+    })
+
+    it('truncates with an ellipsis past the limit', () => {
+        expect(truncateForDisplay('x'.repeat(81), 80)).toBe(`${'x'.repeat(80)}...`)
+    })
+
+    it('never cuts an astral character in half', () => {
+        // MUST FIRE: the emoji straddles the 80th code unit, which is exactly
+        // where `slice(0, 80)` used to bisect it.
+        const straddling = `${'x'.repeat(79)}🌴 tail`
+        const out = truncateForDisplay(straddling, 80)
+        expect(LONE_SURROGATE.test(out)).toBe(false)
+        expect(out).toBe(`${'x'.repeat(79)}🌴...`)
+
+        // MUST STAY SILENT: the same content with the emoji clear of the
+        // boundary is unaffected either way.
+        const clear = `${'x'.repeat(70)}🌴 tail`
+        expect(LONE_SURROGATE.test(truncateForDisplay(clear, 80))).toBe(false)
+    })
+
+    it('counts in the same unit it cuts, so the check cannot disagree with the slice', () => {
+        // 40 emoji are 40 code points but 80 code units. Counting units would
+        // call this "not too long" at 80 and then a 50-unit cut would bisect it.
+        const emoji = '🌴'.repeat(40)
+        expect(truncateForDisplay(emoji, 40)).toBe(emoji)
+        expect(truncateForDisplay(emoji, 10)).toBe(`${'🌴'.repeat(10)}...`)
+        expect(LONE_SURROGATE.test(truncateForDisplay(emoji, 10))).toBe(false)
+    })
+})

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -24,7 +24,10 @@
 
 /** The first code point of `text`, or `''` when empty. Never half a surrogate pair. */
 export function firstCodePoint(text: string): string {
-    return Array.from(text)[0] ?? ''
+    // String iteration steps by code point, so this reads one character rather
+    // than materialising every code point in the string to discard all but one.
+    for (const character of text) return character
+    return ''
 }
 
 /**
@@ -36,6 +39,10 @@ export function firstCodePoint(text: string): string {
  * string containing an emoji.
  */
 export function truncateForDisplay(text: string, maxCodePoints: number): string {
+    // A string's UTF-16 length is never below its code-point count, so anything
+    // fitting by code unit certainly fits by code point. This keeps the common
+    // already-fits path an O(1) check rather than an allocation.
+    if (text.length <= maxCodePoints) return text
     const points = Array.from(text)
     if (points.length <= maxCodePoints) return text
     return `${points.slice(0, maxCodePoints).join('')}...`

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -1,0 +1,42 @@
+/**
+ * Code-point-safe string helpers.
+ *
+ * JavaScript indexes and slices strings by UTF-16 code UNIT, so `name[0]` and
+ * `text.slice(0, n)` can cut an astral character (any emoji) in half and leave
+ * an orphaned surrogate behind.
+ *
+ * That is worse than a mangled glyph. A lone surrogate is not a Unicode scalar
+ * value and has no UTF-8 representation at all, so anything requiring
+ * well-formed text rejects it: `Omar | 🌴` abbreviated by code unit became
+ * `"Omar \ud83c."`, which Postgres `jsonb` refuses with `invalid input syntax
+ * for type json`. A consumer storing `--json` output stopped persisting for
+ * over a day because of one display name.
+ *
+ * `Array.from` iterates by code POINT, which keeps a surrogate pair together.
+ * These wrap that so the intent is visible at the call site rather than looking
+ * like a needless allocation.
+ *
+ * Code points, not grapheme clusters: a ZWJ sequence like 👨‍👩‍👧 is several code
+ * points and can still be split between them. That produces an odd-looking but
+ * VALID string, so it is a cosmetic limit rather than the correctness bug these
+ * fix. Reach for `Intl.Segmenter` if that ever matters.
+ */
+
+/** The first code point of `text`, or `''` when empty. Never half a surrogate pair. */
+export function firstCodePoint(text: string): string {
+    return Array.from(text)[0] ?? ''
+}
+
+/**
+ * `text` shortened to `maxCodePoints` with a trailing ellipsis, or unchanged
+ * when it already fits.
+ *
+ * Counts and cuts in the same unit deliberately. Testing `text.length` (code
+ * units) and then slicing by code point would disagree with itself on any
+ * string containing an emoji.
+ */
+export function truncateForDisplay(text: string, maxCodePoints: number): string {
+    const points = Array.from(text)
+    if (points.length <= maxCodePoints) return text
+    return `${points.slice(0, maxCodePoints).join('')}...`
+}


### PR DESCRIPTION
Closes #506.

## What was wrong

`formatUserShortName` took the last-name initial with `parts[parts.length - 1][0]`. Indexing a JS string that way returns one UTF-16 code unit rather than one code point, so a last part beginning with an astral character gets split in half. `Omar | 🌴` returned `"Omar \ud83c."`, carrying an orphaned high surrogate.

That string is valid in JS and survives `--json`, so it reaches consumers looking fine. It is not valid anywhere that requires well-formed Unicode: a lone surrogate is not a Unicode scalar value and has no UTF-8 representation at all. Postgres `jsonb` rejects it outright, which is how it surfaced. A service storing `td completed list --full` output stopped persisting for over a day because one workspace member has a palm tree in their display name.

## The sweep

Six sites share the defect, all now routed through a new `src/lib/text.ts`:

| site | what it cut |
| --- | --- |
| `lib/collaborators.ts` | `parts[last][0]`, the reported bug |
| `commands/comment/add.ts` | `content.slice(0, 80)` |
| `commands/comment/update.ts` (x2) | `slice(0, 80)` and `slice(0, 50)` |
| `commands/comment/delete.ts` | `slice(0, 50)` |
| `commands/activity.ts` | `firstLine.slice(0, maxLength - 3)` |

An earlier revision of this description claimed every other `slice(0, n)` in the tree was array indexing or ASCII. That was wrong. It came from a sweep matching the literal bounds `80` and `50`, which cannot see a computed one, and `activity.ts` was missed as a result. Thanks to @doistbot for catching it.

The sweep was redone matching computed bounds and excluding array indexing. Two further candidates came up and both are genuinely clear: the second `truncateContent` in `comment/helpers.ts` slices an array of lines rather than a string, and `completion.ts` cuts at `indexOf('=')`, which is never inside a surrogate pair. `completed/list.ts` and `reminder/helpers.ts` both slice ASCII dates.

Two deliberate details. `truncateForDisplay` counts and cuts in the same unit, because the old code tested `.length` in code units and changing only the slice would leave the two disagreeing on any string with an emoji. And in `activity.ts` the ellipsis counts toward `maxLength`, unlike the comment previews, so the helper gets a budget three short of it while the outer check stays in code units, since it decides only whether to cut and never where.

Code points, not grapheme clusters. A ZWJ sequence can still be split between its code points, but that produces an odd-looking **valid** string rather than an invalid one, so it is a cosmetic limit rather than this bug. Noted in the module comment for whoever needs `Intl.Segmenter`.

## Test plan

The risk is a helper that quietly does nothing, which looks identical to a working one. Every case has a control, and each guard was verified to fail against the original code rather than merely passing.

1. `npm test`
2. - [ ] Green: 73 files, 1905 tests.
3. `npx vitest run src/lib/collaborators.test.ts`
4. - [ ] The four names from #506: `Omar | 🌴` becomes `Omar 🌴.`, while `Ada L.`, `Rui` and `Yuki T.` stay byte-identical. Those three are the control, since the regression worth worrying about is ordinary names changing.
5. `npx vitest run src/lib/text.test.ts`
6. - [ ] An emoji straddling the cut survives whole, and the same content with the emoji clear of the boundary comes back `toBe(clear)`, not merely well-formed.
7. - [ ] 40 emoji (40 code points, 80 code units) are not truncated at a limit of 40.
8. `npx vitest run src/commands/activity.test.ts`
9. - [ ] The call-site guard: a real `td activity` run whose content puts an emoji across the 97th code point prints well-formed output. The helper being correct is not evidence the call site is, so this drives the command rather than the helper.
10. Mutation check.
11. - [ ] Reverting `activity.ts` to the code-unit slice, `firstCodePoint` to `text[0]`, or `truncateForDisplay` to the code-unit slice each turns the suite red.

`npm run check`, `type-check` and `build` are clean. The one `no-irregular-whitespace` warning is pre-existing in `src/commands/user/aliases.ts`, untouched here.

Follow-up filed as #508: the abbreviation also assumes `First Last`, so a display name carrying a status marker yields an initial from the status. Separate defect, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
