### PR TITLE
feat(filter): read a filter query in the account language

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@doist/cli-core": "1.4.0",
-        "@doist/todoist-sdk": "15.1.0",
+        "@doist/todoist-sdk": "15.2.0",
         "@napi-rs/keyring": "2.0.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "6.0.0",
@@ -228,9 +228,9 @@
       "license": "MIT"
     },
     "node_modules/@doist/todoist-sdk": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-15.1.0.tgz",
-      "integrity": "sha512-qKtCpzCyf5e/2u6Xqz1c7dukzOInPsA6nz46eka7N5til9Lnl1KnmSo8882D86zHC7nqmUd89eqtHQzBE+L6vg==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-15.2.0.tgz",
+      "integrity": "sha512-DqEiAE9K+xukh8gl0nYrS+fg1Pub7fSF1B2MNY7pjsYS4dLitTwFcEo4eLWLX3Jv0yz9s22JAhYsfyjL59835g==",
       "license": "MIT",
       "dependencies": {
         "@doist/sdk-kmp": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@doist/cli-core": "1.4.0",
-    "@doist/todoist-sdk": "15.1.0",
+    "@doist/todoist-sdk": "15.2.0",
     "@napi-rs/keyring": "2.0.0",
     "@pnpm/tabtab": "0.5.4",
     "chalk": "6.0.0",

--- a/src/commands/filter/filter.test.ts
+++ b/src/commands/filter/filter.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('../../lib/api/core.js', () => ({
     getApi: vi.fn(),
     getAccountTimezone: vi.fn(async () => 'US/Pacific'),
+    getAccountLanguage: vi.fn(async () => 'en'),
 }))
 
 vi.mock('../../lib/api/workspaces.js', () => ({
@@ -18,7 +19,7 @@ vi.mock('../../lib/api/filters.js', () => ({
 }))
 
 import type { ViewOptions as SavedViewOptions } from '@doist/todoist-sdk'
-import { getAccountTimezone } from '../../lib/api/core.js'
+import { getAccountLanguage, getAccountTimezone } from '../../lib/api/core.js'
 import { addFilter, deleteFilter, fetchFilters, updateFilter } from '../../lib/api/filters.js'
 import { setupApiMock } from '../../test-support/api-mock.js'
 import { fixtures, makeFilter } from '../../test-support/fixtures.js'
@@ -28,6 +29,7 @@ import { splitFilterQueries } from './view.js'
 
 const mockFetchFilters = vi.mocked(fetchFilters)
 const mockAccountTimezone = vi.mocked(getAccountTimezone)
+const mockAccountLanguage = vi.mocked(getAccountLanguage)
 const mockAddFilter = vi.mocked(addFilter)
 const mockUpdateFilter = vi.mocked(updateFilter)
 const mockDeleteFilter = vi.mocked(deleteFilter)
@@ -1275,6 +1277,52 @@ describe('filter show sorting', () => {
         await program.parseAsync(['node', 'td', 'filter', 'show', 'Work', '--json'])
 
         expect(mockAccountTimezone).toHaveBeenCalled()
+    })
+
+    /** Sets up a two-task filter where date-first and priority-first disagree. */
+    async function orderUnderQuery(query: string, lang: string): Promise<string[]> {
+        mockAccountLanguage.mockResolvedValue(lang)
+        mockFetchFilters.mockResolvedValue([makeFilter({ id: 'filter-1', name: 'Q', query })])
+        mockApi.getTasksByFilter.mockResolvedValue({
+            // p1 due Jan 9 and p3 due Jan 1: priority puts the first one on
+            // top, date puts the second.
+            results: [fixtures.tasks.withDue, fixtures.tasks.overdue],
+            nextCursor: null,
+        })
+        mockApi.getViewOptions.mockResolvedValue([makeViewOptions({})])
+
+        const program = createProgram()
+        const consoleSpy = captureConsole()
+        await program.parseAsync(['node', 'td', 'filter', 'show', 'Q', '--json'])
+
+        const parsed = JSON.parse(consoleSpy.mock.calls[0][0])
+        return parsed.results.map((task: { id: string }) => task.id)
+    }
+
+    it('leads with the date for a Spanish query the English keywords missed', async () => {
+        // Doist/todoist-sdk-typescript#669: the old table matched no English
+        // keyword in "hoy | vencidas", so this fell to priority and the p1 led.
+        expect(await orderUnderQuery('hoy | vencidas', 'es')).toEqual([
+            fixtures.tasks.overdue.id,
+            fixtures.tasks.withDue.id,
+        ])
+    })
+
+    // "sin fecha" is a keyword under es and an unknown phrase under en, and an
+    // unknown phrase reads as a bare date. The pair below only comes out in
+    // different orders if `lang` reaches the classifier.
+    it('sends the account language, so a localized keyword is not read as a date', async () => {
+        expect(await orderUnderQuery('sin fecha', 'es')).toEqual([
+            fixtures.tasks.withDue.id,
+            fixtures.tasks.overdue.id,
+        ])
+    })
+
+    it('reads the same query as a bare date under the wrong language', async () => {
+        expect(await orderUnderQuery('sin fecha', 'en')).toEqual([
+            fixtures.tasks.overdue.id,
+            fixtures.tasks.withDue.id,
+        ])
     })
 
     it('does not look up the timezone when nothing is sorted', async () => {

--- a/src/commands/filter/view.ts
+++ b/src/commands/filter/view.ts
@@ -1,12 +1,19 @@
 import { outputIds, resolveOutputMode } from '@doist/cli-core'
 import {
     findViewOptions,
+    isDateDrivenQuery,
     isWorkspaceProject,
     type TodoistApi,
     type ViewOptions as SavedViewOptions,
 } from '@doist/todoist-sdk'
 import chalk from 'chalk'
-import { getAccountTimezone, getApi, type Project, type Task } from '../../lib/api/core.js'
+import {
+    getAccountLanguage,
+    getAccountTimezone,
+    getApi,
+    type Project,
+    type Task,
+} from '../../lib/api/core.js'
 import { fetchWorkspaces } from '../../lib/api/workspaces.js'
 import { CollaboratorCache, formatAssignee } from '../../lib/collaborators.js'
 import { CliError } from '../../lib/errors.js'
@@ -30,7 +37,6 @@ import {
     formatTaskSort,
     parseTaskSortDirection,
     parseTaskSortField,
-    queryUsesDates,
     sortNeedsCollaborators,
     sortNeedsProjects,
     sortTasks,
@@ -282,13 +288,14 @@ export async function showFilter(nameOrId: string, options: FilterViewOptions): 
     const isPretty = outputMode === 'human'
 
     // Rendering needs the projects and collaborators for every task; sorting
-    // needs them, plus the account timezone, only for some fields. Fetch when
-    // either side asks, never when there is nothing to order or draw.
+    // needs them, plus the account timezone and language, only for some fields.
+    // Fetch when either side asks, never when there is nothing to order or draw.
     const needsProjects = tasks.length > 0 && (isPretty || sortNeedsProjects(sort.field))
     const sorting = tasks.length > 0 && sort.field !== 'none'
-    const [projectMap, timezone] = await Promise.all([
+    const [projectMap, timezone, lang] = await Promise.all([
         needsProjects ? fetchProjects(api) : Promise.resolve(new Map<string, Project>()),
         sorting ? getAccountTimezone() : Promise.resolve(undefined),
+        sorting ? getAccountLanguage() : Promise.resolve(undefined),
     ])
     const collaboratorCache = new CollaboratorCache()
     if (tasks.length > 0 && (isPretty || sortNeedsCollaborators(sort.field))) {
@@ -305,7 +312,7 @@ export async function showFilter(nameOrId: string, options: FilterViewOptions): 
             results: sortTasks(section.results, sort, {
                 ...projectOrder,
                 timezone,
-                dateDriven: queryUsesDates(section.query),
+                dateDriven: isDateDrivenQuery(section.query, { lang }),
                 assigneeName: (task) =>
                     task.responsibleUid
                         ? (collaboratorCache.getUserName({

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -351,6 +351,33 @@ export async function getCurrentUserId(): Promise<string> {
 export function clearCurrentUserCache(): void {
     currentUserIdCache = null
     accountTimezoneCache = null
+    accountLanguageCache = null
+    accountUserPromise = null
+}
+
+/** What `getUser` actually returns, which is wider than the exported `User`. */
+type AccountUser = Awaited<ReturnType<TodoistApi['getUser']>>
+
+let accountUserPromise: Promise<AccountUser> | null = null
+
+/**
+ * One `getUser` per process, shared by the callers that only want a field off
+ * it. A command that needs both the timezone and the language would otherwise
+ * pay two round trips for the same record. A failed lookup clears the memo so
+ * the next caller can try again.
+ */
+function getAccountUser(): Promise<AccountUser> {
+    const cached = accountUserPromise
+    if (cached) return cached
+
+    const lookup = getApi()
+        .then((api) => api.getUser())
+        .catch((error: unknown) => {
+            if (accountUserPromise === lookup) accountUserPromise = null
+            throw error
+        })
+    accountUserPromise = lookup
+    return lookup
 }
 
 let accountTimezoneCache: string | null = null
@@ -366,13 +393,32 @@ let accountTimezoneCache: string | null = null
 export async function getAccountTimezone(): Promise<string | undefined> {
     if (accountTimezoneCache) return accountTimezoneCache
     try {
-        const api = await getApi()
-        const user = await api.getUser()
+        const user = await getAccountUser()
         accountTimezoneCache = user.tzInfo?.timezone || localTimezone()
     } catch {
         accountTimezoneCache = localTimezone()
     }
     return accountTimezoneCache ?? undefined
+}
+
+let accountLanguageCache: string | null = null
+
+/**
+ * The language the Todoist account writes filter queries in. The API parses a
+ * saved filter in it when the request carries no `lang`, and the date keywords
+ * that decide a filter's default ordering are localized, so classifying a
+ * query needs it. Undefined on a failed lookup, which reads the query as
+ * English. Caches for the life of the process.
+ */
+export async function getAccountLanguage(): Promise<string | undefined> {
+    if (accountLanguageCache) return accountLanguageCache
+    try {
+        const user = await getAccountUser()
+        accountLanguageCache = user.lang || null
+    } catch {
+        accountLanguageCache = null
+    }
+    return accountLanguageCache ?? undefined
 }
 
 function localTimezone(): string | null {

--- a/src/lib/task-sort.test.ts
+++ b/src/lib/task-sort.test.ts
@@ -8,7 +8,6 @@ import {
     formatTaskSort,
     parseTaskSortDirection,
     parseTaskSortField,
-    queryUsesDates,
     sortTasks,
     taskSortFromViewOptions,
 } from './task-sort.js'
@@ -253,42 +252,6 @@ describe('taskSortFromViewOptions', () => {
         expect(taskSortFromViewOptions(makeViewOptions({ sortedBy: 'DUE_DATE' })).direction).toBe(
             'asc',
         )
-    })
-})
-
-describe('queryUsesDates', () => {
-    it.each([
-        'today',
-        'due before: next week',
-        'overdue | today',
-        '@work & 7 days',
-        'no date',
-        'deadline: today',
-    ])('treats %s as date-driven', (query) => {
-        expect(queryUsesDates(query)).toBe(true)
-    })
-
-    it.each(['##work & p4 & !subtask', '@waiting', '#Marketing & p1', 'search: invoice'])(
-        'treats %s as priority-driven',
-        (query) => {
-            expect(queryUsesDates(query)).toBe(false)
-        },
-    )
-
-    it('ignores date words inside project and label names', () => {
-        expect(queryUsesDates('#May Launch')).toBe(false)
-        expect(queryUsesDates('@monday-meeting & p1')).toBe(false)
-        // A name runs to the operator, so "date" here belongs to the project.
-        expect(queryUsesDates('#due date')).toBe(false)
-        expect(queryUsesDates('#due date & p1')).toBe(false)
-        expect(queryUsesDates('#due date & today')).toBe(true)
-    })
-
-    it('ignores date words inside a search term', () => {
-        expect(queryUsesDates('search: due diligence')).toBe(false)
-        expect(queryUsesDates('search: today notes & p1')).toBe(false)
-        // The search operand ends at the operator, so a real date query still counts.
-        expect(queryUsesDates('search: invoice & today')).toBe(true)
     })
 })
 

--- a/src/lib/task-sort.ts
+++ b/src/lib/task-sort.ts
@@ -8,9 +8,9 @@ import { CliError } from './errors.js'
  *
  * The comparators themselves live in the SDK (`sortTasks`), which is where
  * every Todoist client can share them. What stays here is the vocabulary the
- * `--sort` flag speaks, the mapping from a saved view to that vocabulary, the
- * sidebar layout the SDK wants as a lookup, and the guess at whether a filter
- * query is date-driven, which the SDK asks the caller to decide.
+ * `--sort` flag speaks, the mapping from a saved view to that vocabulary, and
+ * the sidebar layout the SDK wants as a lookup. Whether a query is date-driven
+ * is the SDK's answer too, via `isDateDrivenQuery`.
  *
  * @see https://www.todoist.com/help/articles/default-sorting-order-for-todoist-tasks-mqmgerY7
  */
@@ -303,46 +303,4 @@ export function sortTasks(tasks: Task[], sort: TaskSort, context: TaskOrderConte
             timezone: context.timezone,
         } satisfies TaskSortContext,
     )
-}
-
-/**
- * Tokens that make a filter query date-driven, which switches the default
- * ordering from priority-first to date-first.
- *
- * Known limitation: these are the English keywords. The backend parses a saved
- * query in the account's language when the request carries no `lang`, so a
- * filter written as "hoy" or "heute" reads as priority-first here. Classifying
- * properly means the query parser, which is Filterist's job rather than a
- * regex's, so the fix belongs in the SDK. Until then the cost is one of two
- * default hierarchies, not a wrong result set.
- */
-const DATE_QUERY_PATTERN = new RegExp(
-    [
-        String.raw`\b(?:today|tomorrow|yesterday|overdue|due|dated?|datetime|deadlines?|recurring)\b`,
-        String.raw`\b(?:mon|tue|wed|thu|fri|sat|sun)\b`,
-        String.raw`\b(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b`,
-        String.raw`\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\b`,
-        String.raw`\b(?:before|after)\s*:`,
-        String.raw`\b\d+\s*(?:days?|hours?|weeks?|months?)\b`,
-        String.raw`\b(?:next|last)\s+(?:week|month|year|\d+)`,
-    ].join('|'),
-    'i',
-)
-
-/**
- * Names and free-text searches can contain date words ("#May launch",
- * "#due date", "search: due diligence"), so those operands are dropped before
- * the query is inspected. Todoist ends a name at an operator rather than at a
- * space, so these run to the next one and take the whole name with them.
- */
-function stripNamedRefs(query: string): string {
-    return query
-        .replace(/"[^"]*"/g, ' ')
-        .replace(/'[^']*'/g, ' ')
-        .replace(/\bsearch\s*:[^&|(),]*/gi, ' ')
-        .replace(/[#@/]{1,2}[^&|(),]*/g, ' ')
-}
-
-export function queryUsesDates(query: string): boolean {
-    return DATE_QUERY_PATTERN.test(stripNamedRefs(query))
 }


### PR DESCRIPTION
Todoist reads a saved filter in whatever language your account is set to. `td filter view` matched English keywords, so a Spanish account with `hoy | vencidas` got priority-first where Todoist gives date-first.

- **What replaced the regex:** `isDateDrivenQuery` from the SDK, which shares its vocabulary with the web, Android and iOS lexers. The pattern and the helper that stripped project and label names ahead of it are both gone.
- **Where the language comes from:** `getUser`, which the timezone lookup already calls. The two share one request now, so this adds no round trip.
- **Requires:** `@doist/todoist-sdk` 15.2.0.
- **The test to look at:** `sin fecha`, a keyword under `es` and an unknown phrase under `en`, so each language gives it a different hierarchy. Delete `{ lang }` from the call and that test fails on its own.
- **Checked in the real CLI:** ran `td filter view` against my own account on an English query, still date-first.

Raised in Doist/todoist-sdk-typescript#669.