### PR TITLE
chore(filter): drop the stale queryUsesDates entry and its leftover cache

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -173,8 +173,10 @@ New subcommand? Copy a sibling in the target group, wire it in that group's
   `parsePriority`, `PRIORITY_CHOICES` (`"p1"`–`"p4"`; internally p1→4, p4→1)
 - **`task-sort.ts`** — the CLI half of task ordering: `TASK_SORT_FIELDS`
   (the `--sort` vocabulary), `taskSortFromViewOptions`, `buildProjectOrder`,
-  `queryUsesDates`, and a `sortTasks` wrapper. The comparators live in the
-  SDK; the API returns storage order, so every list view sorts locally.
+  and a `sortTasks` wrapper. The comparators live in the SDK; the API returns
+  storage order, so every list view sorts locally. Whether a filter query is
+  date-driven is the SDK's `isDateDrivenQuery`, which needs the account
+  language from `getAccountLanguage` (`lib/api/core.ts`).
 - **`pagination.ts`** — `paginate()`, `LIMITS` (tasks: 300, projects: 50, …)
 - **`completion.ts`** — `parseCompLine`, `getCompletions`,
   `withCaseInsensitiveChoices`, `withUnvalidatedChoices` (Commander tree-walker)

--- a/src/commands/filter/filter.test.ts
+++ b/src/commands/filter/filter.test.ts
@@ -1325,7 +1325,7 @@ describe('filter show sorting', () => {
         ])
     })
 
-    it('does not look up the timezone when nothing is sorted', async () => {
+    it('does not look up the timezone or the language when nothing is sorted', async () => {
         const program = createProgram()
         captureConsole()
 
@@ -1341,6 +1341,7 @@ describe('filter show sorting', () => {
         ])
 
         expect(mockAccountTimezone).not.toHaveBeenCalled()
+        expect(mockAccountLanguage).not.toHaveBeenCalled()
     })
 
     it('skips the project fetch when nothing is sorted', async () => {

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -351,7 +351,6 @@ export async function getCurrentUserId(): Promise<string> {
 export function clearCurrentUserCache(): void {
     currentUserIdCache = null
     accountTimezoneCache = null
-    accountLanguageCache = null
     accountUserPromise = null
 }
 
@@ -401,24 +400,22 @@ export async function getAccountTimezone(): Promise<string | undefined> {
     return accountTimezoneCache ?? undefined
 }
 
-let accountLanguageCache: string | null = null
-
 /**
  * The language the Todoist account writes filter queries in. The API parses a
  * saved filter in it when the request carries no `lang`, and the date keywords
  * that decide a filter's default ordering are localized, so classifying a
  * query needs it. Undefined on a failed lookup, which reads the query as
- * English. Caches for the life of the process.
+ * English.
+ *
+ * No cache of its own: `getAccountUser` already holds the record this reads.
  */
 export async function getAccountLanguage(): Promise<string | undefined> {
-    if (accountLanguageCache) return accountLanguageCache
     try {
         const user = await getAccountUser()
-        accountLanguageCache = user.lang || null
+        return user.lang || undefined
     } catch {
-        accountLanguageCache = null
+        return undefined
     }
-    return accountLanguageCache ?? undefined
 }
 
 function localTimezone(): string | null {


### PR DESCRIPTION
Three follow-ups doistbot raised on #513, none of them user-facing.

- **The stale doc entry:** the `src/lib/` catalog in CODEBASE.md still listed `queryUsesDates` under `task-sort.ts`, which #513 deleted. That catalog is the thing AGENTS.md points people at so they don't reimplement helpers, so pointing at a function that no longer exists is the one kind of error it can't afford. It now names `isDateDrivenQuery` and says where the account language comes from.
- **The redundant cache:** `accountLanguageCache` guarded a lookup that `getAccountUser` already memoizes for the life of the process. It never saved a request, and its truthiness check meant an account with an empty `lang` was never cached anyway.
- **The untested guard:** the tests only covered the sorting path, so `sorting ? getAccountLanguage() : …` could have regressed to an unconditional lookup without failing anything. Made that unconditional locally and the extended test fails; put the guard back and it passes.