### PR TITLE
feat(extensions): add the extension manager library

### DIFF
--- a/src/lib/extensions/discover.test.ts
+++ b/src/lib/extensions/discover.test.ts
@@ -1,0 +1,168 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { writeFakeGitRepo, writeFixtureExtension } from '../../test-support/extension-fixture.js'
+import { discoverExtensions, parseRemote } from './discover.js'
+import { writeState } from './state.js'
+
+const OFFICIAL = { host: 'github.com', owner: 'Doist' }
+
+describe('parseRemote', () => {
+    it.each([
+        ['https://github.com/Doist/td-goals.git', 'github.com', 'Doist', 'td-goals'],
+        ['https://git.example.com/Doist/td-goals', 'git.example.com', 'Doist', 'td-goals'],
+        ['git@github.com:example/td-standup.git', 'github.com', 'example', 'td-standup'],
+    ])('parses %s', (url, host, owner, repo) => {
+        expect(parseRemote(url)).toEqual({ host, owner, repo })
+    })
+
+    it('returns undefined for something that is not a remote', () => {
+        expect(parseRemote('not-a-remote')).toBeUndefined()
+    })
+})
+
+describe('discoverExtensions', () => {
+    let root: string
+    let extensionsDir: string
+    let stateDir: string
+
+    const discover = () =>
+        discoverExtensions({ extensionsDir, stateDir, binName: 'td', officialSource: OFFICIAL })
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-discover-'))
+        extensionsDir = join(root, 'extensions')
+        stateDir = join(root, 'state')
+        await mkdir(extensionsDir, { recursive: true })
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('returns nothing when the extensions directory does not exist', async () => {
+        const missing = discoverExtensions({
+            extensionsDir: join(root, 'nope'),
+            stateDir,
+            binName: 'td',
+            officialSource: OFFICIAL,
+        })
+        await expect(missing).resolves.toEqual([])
+    })
+
+    it('ignores directories that do not carry the binary-name prefix', async () => {
+        await mkdir(join(extensionsDir, 'unrelated'), { recursive: true })
+        await mkdir(join(extensionsDir, 'td-'), { recursive: true })
+        await writeFixtureExtension(extensionsDir, 'goals')
+
+        const found = await discover()
+        expect(found.map((extension) => extension.name)).toEqual(['goals'])
+    })
+
+    it('reads a binary install from its manifest and marks a first-party source', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: {
+                owner: 'Doist',
+                name: 'td-goals',
+                host: 'github.com',
+                tag: 'v0.3.0',
+                pinned: false,
+                asset: 'td-goals_v0.3.0_linux-x64',
+                installedAt: '2026-09-07T10:12:00Z',
+                description: 'Track quarterly goals',
+            },
+        })
+
+        const [extension] = await discover()
+        expect(extension).toMatchObject({
+            name: 'goals',
+            dirName: 'td-goals',
+            kind: 'binary',
+            source: 'Doist/td-goals',
+            official: true,
+            description: 'Track quarterly goals',
+        })
+    })
+
+    it('reads a git install from its remote, and withholds the marker from another host', async () => {
+        const dir = await writeFixtureExtension(extensionsDir, 'x')
+        await writeFakeGitRepo(dir, 'https://git.example.com/Doist/td-x')
+
+        const [extension] = await discover()
+        expect(extension).toMatchObject({
+            kind: 'git',
+            host: 'git.example.com',
+            owner: 'Doist',
+            source: 'Doist/td-x',
+            official: false,
+        })
+    })
+
+    it('marks a git install from the official host and owner', async () => {
+        const dir = await writeFixtureExtension(extensionsDir, 'x')
+        await writeFakeGitRepo(dir, 'https://github.com/Doist/td-x.git')
+
+        const [extension] = await discover()
+        expect(extension.official).toBe(true)
+    })
+
+    it('follows a local install to its target and never marks it official', async () => {
+        const workspace = join(root, 'code')
+        await mkdir(workspace, { recursive: true })
+        const target = await writeFixtureExtension(workspace, 'scratch')
+        await writeFakeGitRepo(target, 'https://github.com/Doist/td-scratch.git')
+        await symlink(target, join(extensionsDir, 'td-scratch'), 'dir')
+
+        const [extension] = await discover()
+        expect(extension).toMatchObject({ name: 'scratch', kind: 'local', official: false })
+        expect(extension.dir).toBe(target)
+        expect(extension.executablePath).toBe(join(target, 'td-scratch'))
+    })
+
+    it('follows a Windows-style path file for a local install', async () => {
+        const workspace = join(root, 'code')
+        await mkdir(workspace, { recursive: true })
+        const target = await writeFixtureExtension(workspace, 'scratch')
+        await writeFile(join(extensionsDir, 'td-scratch'), target, 'utf8')
+
+        const [extension] = await discover()
+        expect(extension).toMatchObject({ kind: 'local', dir: target })
+    })
+
+    it('prefers the authored manifest over the one written at install time', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            authoredManifest: { description: 'from the author', requires: { td: '>=9.0.0' } },
+            installedManifest: {
+                owner: 'Doist',
+                name: 'td-goals',
+                host: 'github.com',
+                tag: 'v1',
+                pinned: false,
+                asset: 'a',
+                installedAt: 'now',
+                description: 'from install time',
+            },
+        })
+
+        const [extension] = await discover()
+        expect(extension.description).toBe('from the author')
+        expect(extension.requires).toEqual({ td: '>=9.0.0' })
+    })
+
+    it('reports a pin recorded in the state directory', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals')
+        await writeState(stateDir, 'td-goals', { pinned: 'v1.2.3' })
+
+        const [extension] = await discover()
+        expect(extension.pinned).toBe(true)
+    })
+
+    it('sorts by command name', async () => {
+        await writeFixtureExtension(extensionsDir, 'zulu')
+        await writeFixtureExtension(extensionsDir, 'alpha')
+
+        const found = await discover()
+        expect(found.map((extension) => extension.name)).toEqual(['alpha', 'zulu'])
+    })
+})

--- a/src/lib/extensions/discover.ts
+++ b/src/lib/extensions/discover.ts
@@ -1,0 +1,192 @@
+/**
+ * Finding what is installed.
+ *
+ * Discovery is one `readdir` of the extensions directory plus, for each entry
+ * found, a couple of small file reads. It runs on every invocation of the host
+ * CLI — including the overwhelmingly common case of no extensions at all,
+ * where it costs a single failed directory read — so nothing here may spawn a
+ * process or touch the network.
+ */
+
+import { lstat, readdir, readFile, realpath, stat } from 'node:fs/promises'
+import { isAbsolute, join, resolve } from 'node:path'
+import { readAuthoredManifest, readInstalledManifest } from './manifest.js'
+import { toCommandName } from './source.js'
+import { readState } from './state.js'
+import type { Extension, ExtensionKind } from './types.js'
+
+export type DiscoverOptions = {
+    extensionsDir: string
+    stateDir: string
+    binName: string
+    officialSource: { host: string; owner: string }
+}
+
+async function exists(path: string): Promise<boolean> {
+    try {
+        await stat(path)
+        return true
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Pull `remote.origin.url` out of `.git/config` rather than shelling out to
+ * git, so that listing extensions stays free of subprocesses.
+ */
+async function readGitRemote(dir: string): Promise<string | undefined> {
+    let config: string
+    try {
+        config = await readFile(join(dir, '.git', 'config'), 'utf8')
+    } catch {
+        return undefined
+    }
+    const section = config.match(/\[remote "origin"\]([\s\S]*?)(?=\n\[|$)/)
+    if (!section) return undefined
+    return section[1].match(/^\s*url\s*=\s*(.+)$/m)?.[1].trim()
+}
+
+/** Owner and host of a git remote, for the first-party check and for `list`. */
+export function parseRemote(
+    url: string,
+): { host: string; owner: string; repo: string } | undefined {
+    const scpLike = url.match(/^(?:[^@]+@)?([^:/]+):(.+?)\/([^/]+?)(?:\.git)?$/)
+    if (scpLike && !url.includes('://')) {
+        return { host: scpLike[1], owner: scpLike[2], repo: scpLike[3] }
+    }
+    try {
+        const parsed = new URL(url)
+        const segments = parsed.pathname.split('/').filter(Boolean)
+        if (segments.length < 2) return undefined
+        const repo = segments[segments.length - 1].replace(/\.git$/, '')
+        return { host: parsed.host, owner: segments[segments.length - 2], repo }
+    } catch {
+        return undefined
+    }
+}
+
+/**
+ * Resolve the directory a local install points at. On POSIX the entry is a
+ * symlink; on Windows it is a plain file holding the target path, because
+ * creating a symlink there needs elevated rights.
+ */
+async function resolveLocalTarget(entryPath: string, isLink: boolean): Promise<string | undefined> {
+    if (isLink) {
+        try {
+            return await realpath(entryPath)
+        } catch {
+            return undefined
+        }
+    }
+    try {
+        const target = (await readFile(entryPath, 'utf8')).trim()
+        if (!target) return undefined
+        return isAbsolute(target) ? target : resolve(target)
+    } catch {
+        return undefined
+    }
+}
+
+async function inferKind(entryPath: string, isDirectory: boolean): Promise<ExtensionKind> {
+    if (!isDirectory) return 'local'
+    if (await exists(join(entryPath, '.git'))) return 'git'
+    return 'binary'
+}
+
+/**
+ * The executable an extension is dispatched through: `<dir>/<dirName>`, with
+ * the `.exe` variant preferred on Windows when it is the one that exists.
+ */
+async function findExecutable(dir: string, dirName: string): Promise<string> {
+    const base = join(dir, dirName)
+    if (process.platform === 'win32') {
+        for (const candidate of [`${base}.exe`, `${base}.cmd`]) {
+            if (await exists(candidate)) return candidate
+        }
+    }
+    return base
+}
+
+async function describe(entry: string, options: DiscoverOptions): Promise<Extension | undefined> {
+    const { extensionsDir, stateDir, binName, officialSource } = options
+    const entryPath = join(extensionsDir, entry)
+
+    let stats: Awaited<ReturnType<typeof stat>>
+    let isLink = false
+    try {
+        const linkStats = await stat(entryPath).catch(() => undefined)
+        if (!linkStats) return undefined
+        stats = linkStats
+        // `stat` follows links, so ask separately whether the entry itself is one.
+        isLink = (await lstat(entryPath)).isSymbolicLink()
+    } catch {
+        return undefined
+    }
+
+    const kind = await inferKind(entryPath, stats.isDirectory() && !isLink)
+    const dir =
+        kind === 'local' ? ((await resolveLocalTarget(entryPath, isLink)) ?? entryPath) : entryPath
+
+    const [authored, installed, state] = await Promise.all([
+        readAuthoredManifest(dir, binName),
+        kind === 'binary' ? readInstalledManifest(dir, binName) : Promise.resolve(undefined),
+        readState(stateDir, entry),
+    ])
+
+    let host: string | undefined
+    let owner: string | undefined
+    let source: string | undefined
+
+    if (kind === 'binary' && installed) {
+        host = installed.host
+        owner = installed.owner
+        source = `${installed.owner}/${installed.name}`
+    } else if (kind === 'git') {
+        const remote = await readGitRemote(dir)
+        const parsed = remote ? parseRemote(remote) : undefined
+        host = parsed?.host
+        owner = parsed?.owner
+        source = parsed ? `${parsed.owner}/${parsed.repo}` : remote
+    } else if (kind === 'local') {
+        source = dir
+    }
+
+    const official =
+        kind !== 'local' && host === officialSource.host && owner === officialSource.owner
+
+    return {
+        name: toCommandName(binName, entry),
+        dirName: entry,
+        kind,
+        dir,
+        entryPath,
+        executablePath: await findExecutable(dir, entry),
+        source,
+        host,
+        owner,
+        pinned: Boolean(state.pinned ?? installed?.pinned),
+        official,
+        description: authored?.description ?? installed?.description,
+        requires: authored?.requires ?? installed?.requires,
+        manifest: installed,
+    }
+}
+
+/** Every extension installed for this CLI, sorted by command name. */
+export async function discoverExtensions(options: DiscoverOptions): Promise<Extension[]> {
+    let entries: string[]
+    try {
+        entries = await readdir(options.extensionsDir)
+    } catch {
+        return []
+    }
+
+    const prefix = `${options.binName}-`
+    const candidates = entries.filter((entry) => entry.startsWith(prefix) && entry !== prefix)
+    const described = await Promise.all(candidates.map((entry) => describe(entry, options)))
+
+    return described
+        .filter((extension): extension is Extension => extension !== undefined)
+        .sort((a, b) => a.name.localeCompare(b.name))
+}

--- a/src/lib/extensions/dispatch.test.ts
+++ b/src/lib/extensions/dispatch.test.ts
@@ -1,0 +1,178 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { writeFixtureExtension } from '../../test-support/extension-fixture.js'
+import { buildExtensionEnv, buildSpawnPlan, dispatchExtension } from './dispatch.js'
+import type { Extension } from './types.js'
+
+function asExtension(dir: string, name: string): Extension {
+    return {
+        name,
+        dirName: `td-${name}`,
+        kind: 'git',
+        dir,
+        entryPath: dir,
+        executablePath: join(dir, `td-${name}`),
+        pinned: false,
+        official: false,
+    }
+}
+
+describe('buildSpawnPlan', () => {
+    let root: string
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-spawn-'))
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('runs a node-shebang script with the host’s own node', async () => {
+        const dir = await writeFixtureExtension(root, 'goals')
+        const plan = await buildSpawnPlan(join(dir, 'td-goals'), ['list'])
+
+        expect(plan.command).toBe(process.execPath)
+        expect(plan.args).toEqual([join(dir, 'td-goals'), 'list'])
+    })
+
+    it('runs any other executable directly on POSIX', async () => {
+        const dir = await writeFixtureExtension(root, 'shell', { interpreter: 'sh' })
+        const plan = await buildSpawnPlan(join(dir, 'td-shell'), ['a', 'b'])
+
+        expect(plan.command).toBe(join(dir, 'td-shell'))
+        expect(plan.args).toEqual(['a', 'b'])
+    })
+
+    it('refuses an executable that has not been built or made executable', async () => {
+        const dir = await writeFixtureExtension(root, 'compiled', { notExecutable: true })
+
+        await expect(buildSpawnPlan(join(dir, 'td-compiled'), [])).rejects.toMatchObject({
+            code: 'EXTENSION_NOT_EXECUTABLE',
+        })
+    })
+
+    it('refuses when the executable is missing entirely', async () => {
+        await expect(buildSpawnPlan(join(root, 'td-ghost', 'td-ghost'), [])).rejects.toMatchObject({
+            code: 'EXTENSION_NOT_EXECUTABLE',
+        })
+    })
+})
+
+describe('buildExtensionEnv', () => {
+    const extension = asExtension('/ext/td-goals', 'goals')
+
+    const build = (overrides: Partial<Parameters<typeof buildExtensionEnv>[0]> = {}) =>
+        buildExtensionEnv({
+            envPrefix: 'TD',
+            version: '5.3.1',
+            configDir: '/config/todoist-cli',
+            hostPath: '/usr/lib/td/dist/index.js',
+            extension,
+            ...overrides,
+        })
+
+    it('sets the documented contract', () => {
+        const env = build()
+
+        expect(env.TD_EXTENSION).toBe('1')
+        expect(env.TD_EXTENSION_NAME).toBe('goals')
+        expect(env.TD_EXTENSION_DIR).toBe('/ext/td-goals')
+        expect(env.TD_PATH).toBe('/usr/lib/td/dist/index.js')
+        expect(env.TD_NODE).toBe(process.execPath)
+        expect(env.TD_VERSION).toBe('5.3.1')
+        expect(env.TD_CONFIG_DIR).toBe('/config/todoist-cli')
+    })
+
+    it('never puts an API token in the child environment', () => {
+        const env = build()
+        expect(env.TD_TOKEN).toBeUndefined()
+        expect(env.TD_API_TOKEN).toBeUndefined()
+    })
+
+    it('forwards --user only when one was given before the command token', () => {
+        expect(build().TD_USER).toBeUndefined()
+        expect(build({ user: 'alice@example.com' }).TD_USER).toBe('alice@example.com')
+    })
+
+    it('marks accessible mode so nested calls inherit it', () => {
+        expect(build().TD_ACCESSIBLE).toBeUndefined()
+        expect(build({ accessible: true }).TD_ACCESSIBLE).toBe('1')
+    })
+
+    it('uses a different prefix for a different host CLI', () => {
+        const env = buildExtensionEnv({
+            envPrefix: 'TDC',
+            version: '1.0.0',
+            configDir: '/config/comms-cli',
+            hostPath: '/usr/lib/tdc/index.js',
+            extension,
+        })
+        expect(env.TDC_EXTENSION).toBe('1')
+        expect(env.TD_EXTENSION).toBe(process.env.TD_EXTENSION)
+    })
+})
+
+describe('dispatchExtension', () => {
+    let root: string
+    let reportPath: string
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-dispatch-'))
+        reportPath = join(root, 'report.json')
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    async function run(args: string[], envOverrides: Record<string, string> = {}) {
+        const dir = await writeFixtureExtension(root, 'goals')
+        const extension = asExtension(dir, 'goals')
+        const env = buildExtensionEnv({
+            envPrefix: 'TD',
+            version: '5.3.1',
+            configDir: '/config',
+            hostPath: '/host/index.js',
+            extension,
+            extra: { XX_REPORT: reportPath, ...envOverrides },
+        })
+        const code = await dispatchExtension(extension, args, env)
+        return { code, extension }
+    }
+
+    async function report(): Promise<{ args: string[]; env: Record<string, string> }> {
+        return JSON.parse(await readFile(reportPath, 'utf8'))
+    }
+
+    it('passes every argument through untouched, flags included', async () => {
+        await run(['add', '--json', '-x', '--user', 'someone', '--', 'raw'])
+
+        expect((await report()).args).toEqual([
+            'add',
+            '--json',
+            '-x',
+            '--user',
+            'someone',
+            '--',
+            'raw',
+        ])
+    })
+
+    it('hands the environment contract to the child process', async () => {
+        await run([])
+
+        const { env } = await report()
+        expect(env.TD_EXTENSION).toBe('1')
+        expect(env.TD_EXTENSION_NAME).toBe('goals')
+        expect(env.TD_VERSION).toBe('5.3.1')
+    })
+
+    it('returns the exit code the extension chose', async () => {
+        await expect(run(['--exit-code', '0'])).resolves.toMatchObject({ code: 0 })
+        await expect(run(['--exit-code', '3'])).resolves.toMatchObject({ code: 3 })
+        await expect(run(['--exit-code', '42'])).resolves.toMatchObject({ code: 42 })
+    })
+})

--- a/src/lib/extensions/dispatch.ts
+++ b/src/lib/extensions/dispatch.ts
@@ -1,0 +1,178 @@
+/**
+ * Running an extension.
+ *
+ * The contract is the process boundary: arguments are passed through exactly
+ * as the user typed them, the three standard streams are the host's own, and
+ * the host exits with whatever the extension exited with. Nothing is parsed,
+ * rewritten or added on either side.
+ */
+
+import { spawn } from 'node:child_process'
+import { open, stat } from 'node:fs/promises'
+import { constants } from 'node:os'
+import { CliError } from '@doist/cli-core'
+import type { DispatchOptions, Extension } from './types.js'
+
+export type SpawnPlan = { command: string; args: string[] }
+
+/** First line of a file, when it is a shebang. */
+async function readShebang(path: string): Promise<string | undefined> {
+    let handle: Awaited<ReturnType<typeof open>>
+    try {
+        handle = await open(path, 'r')
+    } catch {
+        return undefined
+    }
+    try {
+        const buffer = Buffer.alloc(256)
+        const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0)
+        const head = buffer.subarray(0, bytesRead).toString('utf8')
+        if (!head.startsWith('#!')) return undefined
+        return head.split('\n', 1)[0].trim()
+    } finally {
+        await handle.close()
+    }
+}
+
+async function isExecutable(path: string): Promise<boolean> {
+    try {
+        const stats = await stat(path)
+        if (!stats.isFile()) return false
+        // Windows has no executable bit; existence is the only signal there.
+        return process.platform === 'win32' ? true : (stats.mode & 0o111) !== 0
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Decide how to launch an extension's executable.
+ *
+ * Node scripts are launched with the host's own Node rather than through the
+ * shebang, which makes them work on Windows and pins them to the Node version
+ * the host already requires. Everything else runs directly on POSIX, and
+ * through `sh` on Windows, where shebangs mean nothing.
+ */
+export async function buildSpawnPlan(executablePath: string, args: string[]): Promise<SpawnPlan> {
+    const onWindows = process.platform === 'win32'
+
+    if (!(await isExecutable(executablePath))) {
+        throw new CliError(
+            'EXTENSION_NOT_EXECUTABLE',
+            `The executable for this extension is missing or not executable: ${executablePath}`,
+            {
+                hints: [
+                    'Compiled extensions need building after a source install.',
+                    'Script extensions need an executable bit: chmod +x the file.',
+                ],
+            },
+        )
+    }
+
+    if (onWindows && /\.(exe|cmd|bat)$/i.test(executablePath)) {
+        return { command: executablePath, args }
+    }
+
+    const shebang = await readShebang(executablePath)
+    if (shebang && /\bnode\b/.test(shebang)) {
+        return { command: process.execPath, args: [executablePath, ...args] }
+    }
+
+    if (onWindows) {
+        // Matches how `gh` runs script extensions on Windows: Git for Windows
+        // provides the interpreter, and without it a shebang script cannot run.
+        return {
+            command: 'sh',
+            args: ['-c', '"$0" "$@"', executablePath, ...args],
+        }
+    }
+
+    return { command: executablePath, args }
+}
+
+export type ExtensionEnvOptions = {
+    envPrefix: string
+    version: string
+    configDir: string
+    hostPath: string
+    extension: Extension
+    user?: string
+    accessible?: boolean
+    extra?: Record<string, string | undefined>
+}
+
+/**
+ * The variables an extension can rely on. The API token is deliberately not
+ * among them: an extension that needs it runs `<bin> auth token view`, which
+ * keeps the secret out of the environment of every process it starts.
+ */
+export function buildExtensionEnv(options: ExtensionEnvOptions): NodeJS.ProcessEnv {
+    const { envPrefix: prefix, extension } = options
+    const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        [`${prefix}_EXTENSION`]: '1',
+        [`${prefix}_EXTENSION_NAME`]: extension.name,
+        [`${prefix}_EXTENSION_DIR`]: extension.dir,
+        [`${prefix}_PATH`]: options.hostPath,
+        [`${prefix}_NODE`]: process.execPath,
+        [`${prefix}_VERSION`]: options.version,
+        [`${prefix}_CONFIG_DIR`]: options.configDir,
+    }
+
+    if (options.user) env[`${prefix}_USER`] = options.user
+    if (options.accessible) env[`${prefix}_ACCESSIBLE`] = '1'
+
+    for (const [key, value] of Object.entries(options.extra ?? {})) {
+        if (value === undefined) delete env[key]
+        else env[key] = value
+    }
+
+    return env
+}
+
+/** Exit code convention for a child killed by a signal, as the shell reports it. */
+function exitCodeForSignal(signal: NodeJS.Signals): number {
+    const number = (constants.signals as Record<string, number | undefined>)[signal]
+    return number === undefined ? 1 : 128 + number
+}
+
+/** Run an extension to completion and return the code the host should exit with. */
+export async function dispatchExtension(
+    extension: Extension,
+    args: string[],
+    env: NodeJS.ProcessEnv,
+    _options: DispatchOptions = {},
+): Promise<number> {
+    const plan = await buildSpawnPlan(extension.executablePath, args)
+
+    return new Promise((resolve, reject) => {
+        const child = spawn(plan.command, plan.args, {
+            cwd: process.cwd(),
+            env,
+            stdio: 'inherit',
+        })
+
+        child.on('error', (error: NodeJS.ErrnoException) => {
+            if (error.code === 'ENOENT' && plan.command === 'sh') {
+                reject(
+                    new CliError(
+                        'EXTENSION_NEEDS_SHELL',
+                        `Running "${extension.name}" needs a POSIX shell, which was not found.`,
+                        { hints: ['Install Git for Windows, which provides sh.exe.'] },
+                    ),
+                )
+                return
+            }
+            reject(
+                new CliError(
+                    'EXTENSION_NOT_EXECUTABLE',
+                    `Could not run "${extension.name}": ${error.message}`,
+                ),
+            )
+        })
+
+        child.on('close', (code, signal) => {
+            resolve(signal ? exitCodeForSignal(signal) : (code ?? 0))
+        })
+    })
+}

--- a/src/lib/extensions/git.ts
+++ b/src/lib/extensions/git.ts
@@ -1,0 +1,104 @@
+/**
+ * The git operations the extension system needs. Every one of them shells out
+ * to the user's own git, so clones inherit whatever credential helper and SSH
+ * configuration they already have.
+ */
+
+import { CliError } from '@doist/cli-core'
+import { outputHints, run, type RunResult } from './run.js'
+
+function requireGit(result: RunResult): void {
+    if (result.missing) {
+        throw new CliError('EXTENSION_INSTALL_FAILED', 'git was not found on PATH.', {
+            hints: ['Install git, or install this extension from a release binary instead.'],
+        })
+    }
+}
+
+export async function clone(url: string, destination: string): Promise<void> {
+    const result = await run('git', ['clone', '--quiet', url, destination])
+    requireGit(result)
+    if (result.code !== 0) {
+        throw new CliError('EXTENSION_NOT_INSTALLABLE', `Could not clone ${url}.`, {
+            hints: outputHints(result),
+        })
+    }
+}
+
+export async function checkout(dir: string, ref: string): Promise<void> {
+    const result = await run('git', ['checkout', '--quiet', ref], { cwd: dir })
+    requireGit(result)
+    if (result.code !== 0) {
+        throw new CliError('EXTENSION_NOT_INSTALLABLE', `Could not check out "${ref}".`, {
+            hints: outputHints(result),
+        })
+    }
+}
+
+/** Full commit SHA of HEAD, or undefined when the directory is not a clone. */
+export async function headSha(dir: string): Promise<string | undefined> {
+    const result = await run('git', ['rev-parse', 'HEAD'], { cwd: dir })
+    if (result.code !== 0) return undefined
+    return result.stdout.trim() || undefined
+}
+
+/** True when the working tree has changes the user would not want deleted. */
+export async function isDirty(dir: string): Promise<boolean> {
+    const result = await run('git', ['status', '--porcelain'], { cwd: dir })
+    if (result.code !== 0) return false
+    return result.stdout.trim().length > 0
+}
+
+export type PullResult = { changed: boolean; from?: string; to?: string; error?: string }
+
+/** Fast-forward the clone. Never rewrites local work; `resetToRemote` does that. */
+export async function pull(dir: string): Promise<PullResult> {
+    const from = await headSha(dir)
+    const result = await run('git', ['pull', '--quiet', '--ff-only'], { cwd: dir })
+    requireGit(result)
+    if (result.code !== 0) {
+        return { changed: false, from, error: outputHints(result).join(' ') }
+    }
+    const to = await headSha(dir)
+    return { changed: from !== to, from, to }
+}
+
+/** Discard local commits and working-tree changes in favour of the remote. */
+export async function resetToRemote(dir: string): Promise<PullResult> {
+    const from = await headSha(dir)
+    const fetched = await run('git', ['fetch', '--quiet', 'origin'], { cwd: dir })
+    requireGit(fetched)
+    if (fetched.code !== 0) {
+        return { changed: false, from, error: outputHints(fetched).join(' ') }
+    }
+    const reset = await run('git', ['reset', '--quiet', '--hard', 'origin/HEAD'], { cwd: dir })
+    if (reset.code !== 0) {
+        return { changed: false, from, error: outputHints(reset).join(' ') }
+    }
+    const to = await headSha(dir)
+    return { changed: from !== to, from, to }
+}
+
+/** Commit the remote's default branch points at, without fetching it. */
+export async function remoteHeadSha(dir: string): Promise<string | undefined> {
+    const result = await run('git', ['ls-remote', 'origin', 'HEAD'], { cwd: dir })
+    if (result.code !== 0) return undefined
+    return result.stdout.trim().split(/\s+/)[0] || undefined
+}
+
+/** Resolve a ref to the SHA it names, used when pinning a clone. */
+export async function resolveRef(dir: string, ref: string): Promise<string | undefined> {
+    const result = await run('git', ['rev-parse', ref], { cwd: dir })
+    if (result.code !== 0) return undefined
+    return result.stdout.trim() || undefined
+}
+
+/** Files that changed between two commits, used to decide if deps need reinstalling. */
+export async function changedFiles(dir: string, from: string, to: string): Promise<string[]> {
+    const result = await run('git', ['diff', '--name-only', `${from}..${to}`], { cwd: dir })
+    if (result.code !== 0) return []
+    return result.stdout
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+}

--- a/src/lib/extensions/github.ts
+++ b/src/lib/extensions/github.ts
@@ -1,0 +1,191 @@
+/**
+ * The slice of the GitHub API the extension system uses: look up a release,
+ * download an asset, and read a file out of the repository.
+ *
+ * `GH_TOKEN` / `GITHUB_TOKEN` are honoured when set, so extensions in private
+ * repositories install without any extra configuration.
+ */
+
+import { createHash } from 'node:crypto'
+import { CliError } from '@doist/cli-core'
+
+export type ReleaseAsset = {
+    name: string
+    /** API URL that serves the bytes when asked for `application/octet-stream`. */
+    url: string
+    size: number
+}
+
+export type Release = {
+    tag: string
+    assets: ReleaseAsset[]
+}
+
+export type GitHubClient = {
+    fetchRelease(owner: string, repo: string, tag?: string): Promise<Release | undefined>
+    downloadAsset(asset: ReleaseAsset): Promise<Buffer>
+    fetchAssetText(asset: ReleaseAsset): Promise<string>
+    fetchRepoFile(
+        owner: string,
+        repo: string,
+        path: string,
+        ref?: string,
+    ): Promise<string | undefined>
+}
+
+const API_ROOT = 'https://api.github.com'
+
+function authHeaders(): Record<string, string> {
+    const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN
+    return token ? { authorization: `Bearer ${token}` } : {}
+}
+
+function failed(response: Response, what: string): CliError {
+    const hints =
+        response.status === 403 || response.status === 429
+            ? ['GitHub may be rate limiting you. Set GH_TOKEN to raise the limit.']
+            : response.status === 401
+              ? ['Check that GH_TOKEN or GITHUB_TOKEN is valid.']
+              : []
+    return new CliError(
+        'EXTENSION_NOT_INSTALLABLE',
+        `GitHub returned ${response.status} for ${what}.`,
+        { hints },
+    )
+}
+
+export function createGitHubClient(fetchImpl: typeof fetch = fetch): GitHubClient {
+    async function request(url: string, accept: string): Promise<Response> {
+        return fetchImpl(url, {
+            headers: {
+                accept,
+                'user-agent': 'doist-cli-extensions',
+                'x-github-api-version': '2022-11-28',
+                ...authHeaders(),
+            },
+        })
+    }
+
+    return {
+        async fetchRelease(owner, repo, tag) {
+            const path = tag ? `releases/tags/${encodeURIComponent(tag)}` : 'releases/latest'
+            const url = `${API_ROOT}/repos/${owner}/${repo}/${path}`
+            const response = await request(url, 'application/vnd.github+json')
+
+            if (response.status === 404) return undefined
+            if (!response.ok) throw failed(response, `${owner}/${repo} ${path}`)
+
+            const body = (await response.json()) as {
+                tag_name?: string
+                assets?: { name?: string; url?: string; size?: number }[]
+            }
+            return {
+                tag: body.tag_name ?? tag ?? '',
+                assets: (body.assets ?? [])
+                    .filter(
+                        (asset): asset is { name: string; url: string; size: number } =>
+                            typeof asset.name === 'string' && typeof asset.url === 'string',
+                    )
+                    .map((asset) => ({ name: asset.name, url: asset.url, size: asset.size ?? 0 })),
+            }
+        },
+
+        async downloadAsset(asset) {
+            const response = await request(asset.url, 'application/octet-stream')
+            if (!response.ok) throw failed(response, `asset ${asset.name}`)
+            return Buffer.from(await response.arrayBuffer())
+        },
+
+        async fetchAssetText(asset) {
+            const response = await request(asset.url, 'application/octet-stream')
+            if (!response.ok) throw failed(response, `asset ${asset.name}`)
+            return response.text()
+        },
+
+        async fetchRepoFile(owner, repo, path, ref) {
+            const query = ref ? `?ref=${encodeURIComponent(ref)}` : ''
+            const url = `${API_ROOT}/repos/${owner}/${repo}/contents/${path}${query}`
+            const response = await request(url, 'application/vnd.github.raw')
+            if (response.status === 404) return undefined
+            if (!response.ok) throw failed(response, `${owner}/${repo} ${path}`)
+            return response.text()
+        },
+    }
+}
+
+/**
+ * Asset name endings that identify a build for this machine. Node's own
+ * `platform`-`arch` spelling is used, since an extension author working in
+ * Node already has those values to hand.
+ */
+export function assetSuffixes(
+    platform: NodeJS.Platform = process.platform,
+    arch: string = process.arch,
+): string[] {
+    const base = `${platform}-${arch}`
+    return platform === 'win32' ? [`${base}.exe`, base] : [base]
+}
+
+export function pickAsset(assets: ReleaseAsset[], suffixes: string[]): ReleaseAsset | undefined {
+    for (const suffix of suffixes) {
+        const match = assets.find((asset) => asset.name.endsWith(suffix))
+        if (match) return match
+    }
+    return undefined
+}
+
+/**
+ * The checksum a release publishes for one asset, from either a shared
+ * `checksums.txt` or a per-asset `<asset>.sha256`. Returns undefined when the
+ * release publishes neither, which is not an error — only a mismatch is.
+ */
+export async function findExpectedChecksum(
+    client: GitHubClient,
+    release: Release,
+    assetName: string,
+): Promise<string | undefined> {
+    const perAsset = release.assets.find((asset) => asset.name === `${assetName}.sha256`)
+    if (perAsset) {
+        const text = await client.fetchAssetText(perAsset)
+        return text.trim().split(/\s+/)[0]?.toLowerCase()
+    }
+
+    const combined = release.assets.find(
+        (asset) => asset.name === 'checksums.txt' || asset.name.endsWith('_checksums.txt'),
+    )
+    if (!combined) return undefined
+
+    const text = await client.fetchAssetText(combined)
+    for (const line of text.split('\n')) {
+        const [hash, ...rest] = line.trim().split(/\s+/)
+        const name = rest.join(' ').replace(/^\*/, '')
+        if (name === assetName) return hash.toLowerCase()
+    }
+    return undefined
+}
+
+export function sha256(data: Buffer): string {
+    return createHash('sha256').update(data).digest('hex')
+}
+
+export function verifyChecksum(
+    data: Buffer,
+    expected: string | undefined,
+    assetName: string,
+): void {
+    if (!expected) return
+    const actual = sha256(data)
+    if (actual !== expected) {
+        throw new CliError(
+            'EXTENSION_CHECKSUM_MISMATCH',
+            `The downloaded asset ${assetName} does not match the published checksum.`,
+            {
+                hints: [
+                    `Expected ${expected}`,
+                    `Got      ${actual}`,
+                    'The download may be corrupt or the release may have been tampered with.',
+                ],
+            },
+        )
+    }
+}

--- a/src/lib/extensions/install.test.ts
+++ b/src/lib/extensions/install.test.ts
@@ -1,0 +1,360 @@
+import { createHash } from 'node:crypto'
+import { lstat, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { writeFixtureExtension } from '../../test-support/extension-fixture.js'
+import { createGitHubClient } from './github.js'
+import { installExtension, type InstallContext } from './install.js'
+import { run } from './run.js'
+import { readState } from './state.js'
+
+const PLATFORM_SUFFIX = `${process.platform}-${process.arch}`
+const ASSET_NAME = `td-goals_v1.0.0_${PLATFORM_SUFFIX}`
+const BINARY = Buffer.from('#!/bin/sh\necho goals\n')
+const CHECKSUM = createHash('sha256').update(BINARY).digest('hex')
+
+type StubOptions = {
+    tag?: string
+    assetName?: string
+    binary?: Buffer
+    checksums?: string | null
+    authoredManifest?: string | null
+    /** Tags that exist; a request for anything else answers 404. */
+    tags?: string[]
+}
+
+function stubGitHub(options: StubOptions = {}) {
+    const tag = options.tag ?? 'v1.0.0'
+    const assetName = options.assetName ?? ASSET_NAME
+    const binary = options.binary ?? BINARY
+    const assets = [
+        { name: assetName, url: `https://api.github.com/assets/bin`, size: binary.length },
+    ]
+    if (options.checksums !== null) {
+        assets.push({ name: 'checksums.txt', url: 'https://api.github.com/assets/sums', size: 64 })
+    }
+
+    const calls: string[] = []
+    const impl = vi.fn(async (input: string | URL | Request) => {
+        const url = String(input)
+        calls.push(url)
+
+        if (url.includes('/releases/latest') || url.includes('/releases/tags/')) {
+            const requested = url.includes('/releases/tags/')
+                ? decodeURIComponent(url.split('/releases/tags/')[1])
+                : tag
+            const known = options.tags ?? [tag]
+            if (!known.includes(requested)) return new Response('{}', { status: 404 })
+            return new Response(JSON.stringify({ tag_name: requested, assets }), { status: 200 })
+        }
+        if (url.endsWith('/assets/bin')) {
+            return new Response(new Uint8Array(binary), { status: 200 })
+        }
+        if (url.endsWith('/assets/sums')) {
+            const body = options.checksums ?? `${CHECKSUM}  ${assetName}\n`
+            return new Response(body, { status: 200 })
+        }
+        if (url.includes('/contents/td-extension.json')) {
+            if (options.authoredManifest === null) return new Response('', { status: 404 })
+            return new Response(
+                options.authoredManifest ??
+                    JSON.stringify({ description: 'Track goals', requires: { td: '>=4.0.0' } }),
+                { status: 200 },
+            )
+        }
+        return new Response('{}', { status: 404 })
+    })
+
+    return { impl: impl as unknown as typeof fetch, calls, spy: impl }
+}
+
+describe('installExtension', () => {
+    let root: string
+    let extensionsDir: string
+    let stateDir: string
+    let warnings: string[]
+    let logs: string[]
+
+    function contextFor(fetchImpl: typeof fetch, reserved: string[] = []): InstallContext {
+        return {
+            binName: 'td',
+            extensionsDir,
+            stateDir,
+            officialSource: { host: 'github.com', owner: 'Doist' },
+            client: createGitHubClient(fetchImpl),
+            reservedNames: () => reserved,
+            log: (message) => logs.push(message),
+            warn: (message) => warnings.push(message),
+            trustWarning: 'Extensions are not reviewed, signed, or endorsed by Todoist.',
+        }
+    }
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-install-'))
+        extensionsDir = join(root, 'extensions')
+        stateDir = join(root, 'state')
+        warnings = []
+        logs = []
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    describe('release binaries', () => {
+        it('downloads the asset for this platform and records a manifest', async () => {
+            const github = stubGitHub()
+            const result = await installExtension('Doist/td-goals', {}, contextFor(github.impl))
+
+            expect(result).toMatchObject({
+                name: 'goals',
+                dirName: 'td-goals',
+                kind: 'binary',
+                source: 'Doist/td-goals',
+                version: 'v1.0.0',
+            })
+
+            const executable = join(extensionsDir, 'td-goals', 'td-goals')
+            expect((await readFile(executable)).equals(BINARY)).toBe(true)
+            expect((await stat(executable)).mode & 0o111).not.toBe(0)
+
+            const manifest = JSON.parse(
+                await readFile(join(extensionsDir, 'td-goals', '.td-manifest.json'), 'utf8'),
+            )
+            expect(manifest).toMatchObject({
+                owner: 'Doist',
+                name: 'td-goals',
+                host: 'github.com',
+                tag: 'v1.0.0',
+                pinned: false,
+                asset: ASSET_NAME,
+                sha256: CHECKSUM,
+            })
+        })
+
+        it("copies the author's description and requires into the manifest", async () => {
+            const github = stubGitHub()
+            await installExtension('Doist/td-goals', {}, contextFor(github.impl))
+
+            const manifest = JSON.parse(
+                await readFile(join(extensionsDir, 'td-goals', '.td-manifest.json'), 'utf8'),
+            )
+            expect(manifest.description).toBe('Track goals')
+            expect(manifest.requires).toEqual({ td: '>=4.0.0' })
+        })
+
+        it('installs without a manifest when the repository ships none', async () => {
+            const github = stubGitHub({ authoredManifest: null })
+            await expect(
+                installExtension('Doist/td-goals', {}, contextFor(github.impl)),
+            ).resolves.toMatchObject({ kind: 'binary' })
+        })
+
+        it('refuses an asset whose checksum does not match, and installs nothing', async () => {
+            const github = stubGitHub({ checksums: `${'0'.repeat(64)}  ${ASSET_NAME}\n` })
+
+            await expect(
+                installExtension('Doist/td-goals', {}, contextFor(github.impl)),
+            ).rejects.toMatchObject({ code: 'EXTENSION_CHECKSUM_MISMATCH' })
+
+            await expect(stat(join(extensionsDir, 'td-goals'))).rejects.toThrow()
+        })
+
+        it('warns, but installs, when the release publishes no checksums', async () => {
+            const github = stubGitHub({ checksums: null })
+            await installExtension('Doist/td-goals', {}, contextFor(github.impl))
+
+            expect(warnings.some((warning) => warning.includes('publishes no checksums'))).toBe(
+                true,
+            )
+        })
+
+        it('resolves --pin against the tagged release rather than the latest one', async () => {
+            const github = stubGitHub({ tag: 'v0.9.0', tags: ['v0.9.0', 'v1.0.0'] })
+            const result = await installExtension(
+                'Doist/td-goals',
+                { pin: 'v0.9.0' },
+                contextFor(github.impl),
+            )
+
+            expect(result.version).toBe('v0.9.0')
+            expect(github.calls.some((url) => url.includes('/releases/tags/v0.9.0'))).toBe(true)
+            expect(github.calls.some((url) => url.includes('/releases/latest'))).toBe(false)
+            await expect(readState(stateDir, 'td-goals')).resolves.toMatchObject({
+                pinned: 'v0.9.0',
+            })
+        })
+
+        it('prints the trust warning before it fetches anything', async () => {
+            const github = stubGitHub()
+            const order: string[] = []
+            const context = contextFor(github.impl)
+            context.warn = (message) => {
+                order.push(`warn: ${message}`)
+                warnings.push(message)
+            }
+            // Fail the first request outright, so the install stops here
+            // rather than falling through to a clone over the network.
+            github.spy.mockImplementation((() => {
+                order.push('fetch')
+                throw new Error('network disabled in this test')
+            }) as never)
+
+            await expect(installExtension('Doist/td-goals', {}, context)).rejects.toThrow()
+
+            expect(order).toEqual(['warn: ' + context.trustWarning, 'fetch'])
+        })
+    })
+
+    describe('name and collision checks', () => {
+        it('refuses a name that a built-in command already owns, before any request', async () => {
+            const github = stubGitHub()
+
+            await expect(
+                installExtension('Doist/td-task', {}, contextFor(github.impl, ['task'])),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NAME_RESERVED' })
+
+            expect(github.calls).toEqual([])
+        })
+
+        it('refuses a repository whose name lacks the binary prefix', async () => {
+            const github = stubGitHub()
+
+            await expect(
+                installExtension('Doist/goals', {}, contextFor(github.impl)),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NAME_INVALID' })
+        })
+
+        it('refuses to replace an installed extension unless forced', async () => {
+            await mkdir(extensionsDir, { recursive: true })
+            await writeFixtureExtension(extensionsDir, 'goals')
+            const github = stubGitHub()
+
+            await expect(
+                installExtension('Doist/td-goals', {}, contextFor(github.impl)),
+            ).rejects.toMatchObject({ code: 'EXTENSION_ALREADY_INSTALLED' })
+
+            await expect(
+                installExtension('Doist/td-goals', { force: true }, contextFor(github.impl)),
+            ).resolves.toMatchObject({ kind: 'binary' })
+        })
+    })
+
+    describe('local installs', () => {
+        it('links the directory instead of copying it', async () => {
+            const workspace = join(root, 'code')
+            await mkdir(workspace, { recursive: true })
+            const target = await writeFixtureExtension(workspace, 'scratch')
+            const github = stubGitHub()
+
+            const result = await installExtension(target, {}, contextFor(github.impl))
+
+            expect(result).toMatchObject({ name: 'scratch', kind: 'local', dir: target })
+            const entry = join(extensionsDir, 'td-scratch')
+            expect((await lstat(entry)).isSymbolicLink()).toBe(true)
+            expect(github.calls).toEqual([])
+        })
+
+        it('warns when the directory has no executable yet, but still links it', async () => {
+            const workspace = join(root, 'code', 'td-unbuilt')
+            await mkdir(workspace, { recursive: true })
+            const github = stubGitHub()
+
+            await installExtension(workspace, {}, contextFor(github.impl))
+
+            expect(warnings.some((warning) => warning.includes('no executable named'))).toBe(true)
+        })
+
+        it('refuses a directory whose name is not <bin>-<name>', async () => {
+            const workspace = join(root, 'code', 'my-tool')
+            await mkdir(workspace, { recursive: true })
+            const github = stubGitHub()
+
+            await expect(
+                installExtension(workspace, {}, contextFor(github.impl)),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NAME_INVALID' })
+        })
+
+        it('refuses a directory that does not exist', async () => {
+            const github = stubGitHub()
+
+            await expect(
+                installExtension(join(root, 'nope', 'td-x'), {}, contextFor(github.impl)),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NOT_INSTALLABLE' })
+        })
+    })
+
+    describe('git clones', () => {
+        let hasGit = false
+
+        beforeEach(async () => {
+            hasGit = (await run('git', ['--version'])).code === 0
+        })
+
+        async function makeRepo(name: string): Promise<string> {
+            const repo = join(root, 'origin', 'Doist', name)
+            await mkdir(repo, { recursive: true })
+            await writeFile(join(repo, name), '#!/bin/sh\necho hi\n', { mode: 0o755 })
+            await run('git', ['init', '--quiet', '--initial-branch=main'], { cwd: repo })
+            await run('git', ['add', '.'], { cwd: repo })
+            await run(
+                'git',
+                [
+                    '-c',
+                    'user.email=t@example.com',
+                    '-c',
+                    'user.name=T',
+                    'commit',
+                    '--quiet',
+                    '-m',
+                    'init',
+                ],
+                { cwd: repo },
+            )
+            return repo
+        }
+
+        it('clones when the repository publishes no matching asset', async () => {
+            if (!hasGit) return
+            const repo = await makeRepo('td-cloned')
+            const github = stubGitHub({ assetName: 'td-cloned_v1_other-arch' })
+
+            const result = await installExtension(`file://${repo}`, {}, contextFor(github.impl))
+
+            expect(result).toMatchObject({ kind: 'git', name: 'cloned' })
+            await expect(stat(join(extensionsDir, 'td-cloned', 'td-cloned'))).resolves.toBeTruthy()
+            await expect(stat(join(extensionsDir, 'td-cloned', '.git'))).resolves.toBeTruthy()
+        })
+
+        it('refuses a repository with no executable at its root, leaving nothing behind', async () => {
+            if (!hasGit) return
+            const repo = join(root, 'origin', 'Doist', 'td-empty')
+            await mkdir(repo, { recursive: true })
+            await writeFile(join(repo, 'README.md'), 'nothing here')
+            await run('git', ['init', '--quiet', '--initial-branch=main'], { cwd: repo })
+            await run('git', ['add', '.'], { cwd: repo })
+            await run(
+                'git',
+                [
+                    '-c',
+                    'user.email=t@example.com',
+                    '-c',
+                    'user.name=T',
+                    'commit',
+                    '--quiet',
+                    '-m',
+                    'init',
+                ],
+                { cwd: repo },
+            )
+            const github = stubGitHub({ assetName: 'td-empty_v1_other-arch' })
+
+            await expect(
+                installExtension(`file://${repo}`, {}, contextFor(github.impl)),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NOT_INSTALLABLE' })
+
+            await expect(stat(join(extensionsDir, 'td-empty'))).rejects.toThrow()
+        })
+    })
+})

--- a/src/lib/extensions/install.ts
+++ b/src/lib/extensions/install.ts
@@ -1,0 +1,343 @@
+/**
+ * Installing an extension.
+ *
+ * Three shapes are supported: a prebuilt release binary, a git clone, and a
+ * symlink to a directory the user is working in. Everything is assembled in a
+ * staging directory inside the extensions directory and moved into place only
+ * once it is complete, so a failed install never leaves a half-written
+ * extension behind and never destroys the one already installed.
+ */
+
+import { chmod, mkdir, readdir, rename, rm, stat, symlink, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { CliError } from '@doist/cli-core'
+import { discoverExtensions } from './discover.js'
+import { checkout, clone, headSha, resolveRef } from './git.js'
+import {
+    assetSuffixes,
+    findExpectedChecksum,
+    type GitHubClient,
+    pickAsset,
+    sha256,
+    verifyChecksum,
+} from './github.js'
+import { writeInstalledManifest } from './manifest.js'
+import { installDependencies } from './npm.js'
+import {
+    authoredManifestFileName,
+    parseSource,
+    toCommandName,
+    validateExtensionName,
+} from './source.js'
+import { writeState } from './state.js'
+import type { AuthoredManifest, Extension, InstallOptions, InstallResult } from './types.js'
+
+export type InstallContext = {
+    binName: string
+    extensionsDir: string
+    stateDir: string
+    officialSource: { host: string; owner: string }
+    client: GitHubClient
+    reservedNames: () => Iterable<string>
+    log: (message: string) => void
+    warn: (message: string) => void
+    trustWarning: string
+}
+
+async function exists(path: string): Promise<boolean> {
+    try {
+        await stat(path)
+        return true
+    } catch {
+        return false
+    }
+}
+
+function expandHome(path: string): string {
+    return path.startsWith('~/') ? join(homedir(), path.slice(2)) : path
+}
+
+/**
+ * Name checks and collision handling, run before anything is downloaded or
+ * cloned so that a doomed install fails without touching the network.
+ */
+async function preflight(
+    dirName: string,
+    context: InstallContext,
+    options: InstallOptions,
+): Promise<Extension | undefined> {
+    validateExtensionName(context.binName, dirName)
+    const name = toCommandName(context.binName, dirName)
+
+    const reserved = new Set(context.reservedNames())
+    if (reserved.has(name)) {
+        throw new CliError(
+            'EXTENSION_NAME_RESERVED',
+            `"${name}" is the name of a built-in ${context.binName} command.`,
+            {
+                hints: [
+                    `An extension cannot take that name. It would only be reachable as \`${context.binName} extension exec ${name}\`.`,
+                ],
+            },
+        )
+    }
+
+    const installed = await discoverExtensions({
+        extensionsDir: context.extensionsDir,
+        stateDir: context.stateDir,
+        binName: context.binName,
+        officialSource: context.officialSource,
+    })
+    const existing = installed.find((extension) => extension.name === name)
+    if (existing && !options.force) {
+        throw new CliError(
+            'EXTENSION_ALREADY_INSTALLED',
+            `"${name}" is already installed${existing.source ? ` from ${existing.source}` : ''}.`,
+            {
+                hints: [
+                    `Run \`${context.binName} extension upgrade ${name}\` to update it.`,
+                    `Run \`${context.binName} extension install … --force\` to replace it.`,
+                ],
+            },
+        )
+    }
+    return existing
+}
+
+async function stagingDir(extensionsDir: string, dirName: string): Promise<string> {
+    await mkdir(extensionsDir, { recursive: true })
+    const path = join(extensionsDir, `.staging-${dirName}-${process.pid}-${Date.now()}`)
+    await rm(path, { recursive: true, force: true })
+    await mkdir(path, { recursive: true })
+    return path
+}
+
+/** Replace whatever is at the destination with the staged directory. */
+async function moveIntoPlace(
+    staged: string,
+    destination: string,
+    existing: Extension | undefined,
+): Promise<void> {
+    if (existing) await rm(existing.entryPath, { recursive: true, force: true })
+    await rm(destination, { recursive: true, force: true })
+    await rename(staged, destination)
+}
+
+export async function installBinary(
+    parsed: { host: string; owner: string; repo: string },
+    release: { tag: string; assets: { name: string; url: string; size: number }[] },
+    asset: { name: string; url: string; size: number },
+    options: InstallOptions,
+    context: InstallContext,
+    existing: Extension | undefined,
+): Promise<InstallResult> {
+    const dirName = parsed.repo
+    const destination = join(context.extensionsDir, dirName)
+    const staged = await stagingDir(context.extensionsDir, dirName)
+
+    try {
+        const [data, expected, authoredRaw] = await Promise.all([
+            context.client.downloadAsset(asset),
+            findExpectedChecksum(context.client, release, asset.name),
+            context.client.fetchRepoFile(
+                parsed.owner,
+                parsed.repo,
+                authoredManifestFileName(context.binName),
+                release.tag,
+            ),
+        ])
+
+        verifyChecksum(data, expected, asset.name)
+        if (!expected) {
+            context.warn(
+                `${parsed.owner}/${parsed.repo} publishes no checksums, so the download could not be verified.`,
+            )
+        }
+
+        const executableName = asset.name.endsWith('.exe') ? `${dirName}.exe` : dirName
+        const executablePath = join(staged, executableName)
+        await writeFile(executablePath, data)
+        await chmod(executablePath, 0o755)
+
+        let authored: AuthoredManifest = {}
+        if (authoredRaw) {
+            try {
+                authored = JSON.parse(authoredRaw) as AuthoredManifest
+            } catch {
+                context.warn(
+                    `Ignoring ${authoredManifestFileName(context.binName)} in ${parsed.owner}/${parsed.repo}: it is not valid JSON.`,
+                )
+            }
+        }
+
+        await writeInstalledManifest(staged, context.binName, {
+            owner: parsed.owner,
+            name: dirName,
+            host: parsed.host,
+            tag: release.tag,
+            pinned: Boolean(options.pin),
+            asset: asset.name,
+            sha256: sha256(data),
+            installedAt: new Date().toISOString(),
+            description: authored.description,
+            requires: authored.requires,
+            completion: authored.completion,
+        })
+
+        await moveIntoPlace(staged, destination, existing)
+        await writeState(context.stateDir, dirName, {
+            pinned: options.pin ? release.tag : undefined,
+        })
+
+        return {
+            name: toCommandName(context.binName, dirName),
+            dirName,
+            kind: 'binary',
+            source: `${parsed.owner}/${parsed.repo}`,
+            version: release.tag,
+            dir: destination,
+        }
+    } finally {
+        await rm(staged, { recursive: true, force: true })
+    }
+}
+
+async function installGit(
+    parsed: { host: string; owner: string; repo: string; url: string },
+    options: InstallOptions,
+    context: InstallContext,
+    existing: Extension | undefined,
+): Promise<InstallResult> {
+    const dirName = parsed.repo
+    const destination = join(context.extensionsDir, dirName)
+    const staged = await stagingDir(context.extensionsDir, dirName)
+    // git refuses to clone into a directory that already has entries.
+    await rm(staged, { recursive: true, force: true })
+
+    let moved = false
+    try {
+        await clone(parsed.url, staged)
+
+        let pinnedSha: string | undefined
+        if (options.pin) {
+            await checkout(staged, options.pin)
+            pinnedSha = await resolveRef(staged, 'HEAD')
+        }
+
+        if (!(await exists(join(staged, dirName)))) {
+            throw new CliError(
+                'EXTENSION_NOT_INSTALLABLE',
+                `${parsed.owner}/${parsed.repo} has no executable named "${dirName}" at its root.`,
+                {
+                    hints: [
+                        `An extension repository must contain a file named ${dirName} that ${context.binName} can run.`,
+                    ],
+                },
+            )
+        }
+
+        await installDependencies(staged)
+
+        const version = (await headSha(staged))?.slice(0, 8)
+        await moveIntoPlace(staged, destination, existing)
+        moved = true
+        await writeState(context.stateDir, dirName, {
+            pinned: options.pin ? (pinnedSha ?? options.pin) : undefined,
+        })
+
+        return {
+            name: toCommandName(context.binName, dirName),
+            dirName,
+            kind: 'git',
+            source: `${parsed.owner}/${parsed.repo}`,
+            version,
+            dir: destination,
+        }
+    } finally {
+        if (!moved) await rm(staged, { recursive: true, force: true })
+    }
+}
+
+async function installLocal(
+    path: string,
+    options: InstallOptions,
+    context: InstallContext,
+): Promise<InstallResult> {
+    const target = resolve(expandHome(path))
+    const dirName = basename(target)
+
+    if (!(await exists(target))) {
+        throw new CliError('EXTENSION_NOT_INSTALLABLE', `${target} does not exist.`)
+    }
+
+    const existing = await preflight(dirName, context, options)
+
+    if (!(await exists(join(target, dirName)))) {
+        context.warn(
+            `${target} has no executable named "${dirName}" yet. Build it before running \`${context.binName} ${toCommandName(context.binName, dirName)}\`.`,
+        )
+    }
+
+    await mkdir(context.extensionsDir, { recursive: true })
+    const destination = join(context.extensionsDir, dirName)
+    if (existing) await rm(existing.entryPath, { recursive: true, force: true })
+    await rm(destination, { recursive: true, force: true })
+
+    if (process.platform === 'win32') {
+        // Symlinks need elevated rights on Windows, so record the target in a
+        // plain file and resolve it at discovery time instead.
+        await writeFile(destination, target, 'utf8')
+    } else {
+        await symlink(target, destination, 'dir')
+    }
+
+    return {
+        name: toCommandName(context.binName, dirName),
+        dirName,
+        kind: 'local',
+        source: target,
+        dir: target,
+    }
+}
+
+/** Install from `owner/repo`, a repository URL, or a local directory. */
+export async function installExtension(
+    source: string,
+    options: InstallOptions,
+    context: InstallContext,
+): Promise<InstallResult> {
+    const parsed = parseSource(source)
+
+    if (parsed.type === 'local') {
+        return installLocal(parsed.path, options, context)
+    }
+
+    const existing = await preflight(parsed.repo, context, options)
+
+    // Printed before anything is downloaded, cloned or executed, so the user
+    // sees it even when a later step runs code from the repository.
+    context.warn(context.trustWarning)
+
+    if (parsed.isGitHub) {
+        const release = await context.client.fetchRelease(parsed.owner, parsed.repo, options.pin)
+        const asset = release ? pickAsset(release.assets, assetSuffixes()) : undefined
+        if (release && asset) {
+            return installBinary(parsed, release, asset, options, context, existing)
+        }
+        if (options.pin && !release) {
+            // No release for that tag: fall through and let git resolve the ref.
+        }
+    }
+
+    return installGit(parsed, options, context, existing)
+}
+
+/** True when the extensions directory holds nothing at all. */
+export async function isEmpty(extensionsDir: string): Promise<boolean> {
+    try {
+        return (await readdir(extensionsDir)).length === 0
+    } catch {
+        return true
+    }
+}

--- a/src/lib/extensions/manager.test.ts
+++ b/src/lib/extensions/manager.test.ts
@@ -1,0 +1,149 @@
+import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { writeFixtureExtension } from '../../test-support/extension-fixture.js'
+import { createExtensionManager, type ExtensionManager } from './manager.js'
+
+describe('createExtensionManager', () => {
+    let root: string
+    let dataDir: string
+    let extensionsDir: string
+    let warnings: string[]
+
+    function makeManager(reserved: string[] = []): ExtensionManager {
+        return createExtensionManager({
+            binName: 'td',
+            envPrefix: 'TD',
+            version: '5.3.1',
+            dataDir,
+            stateDir: join(root, 'state'),
+            configDir: join(root, 'config'),
+            hostPath: '/host/dist/index.js',
+            reservedNames: () => reserved,
+            officialSource: { host: 'github.com', owner: 'Doist' },
+            officialLabel: 'Todoist',
+            warn: (message) => warnings.push(message),
+            log: () => undefined,
+        })
+    }
+
+    /** Send the fixture's report to a file so it does not print during tests. */
+    const quiet = () => ({ XX_REPORT: join(root, 'report.json') })
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-manager-'))
+        dataDir = join(root, 'todoist-cli')
+        extensionsDir = join(dataDir, 'extensions')
+        warnings = []
+        await mkdir(extensionsDir, { recursive: true })
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('puts extensions under <dataDir>/extensions', () => {
+        expect(makeManager().extensionsDir).toBe(extensionsDir)
+    })
+
+    it('reports an empty install, and stops reporting one once something is installed', async () => {
+        const manager = makeManager()
+        await expect(manager.isEmpty()).resolves.toBe(true)
+
+        await writeFixtureExtension(extensionsDir, 'goals')
+        await expect(manager.isEmpty()).resolves.toBe(false)
+    })
+
+    it('builds a trust warning that names the CLI’s owner', () => {
+        expect(makeManager().trustWarning).toContain('endorsed by Todoist')
+    })
+
+    it('resolves a loose selector to an installed extension', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals')
+        const manager = makeManager()
+
+        for (const selector of ['goals', 'td-goals', 'Doist/td-goals']) {
+            await expect(manager.find(selector)).resolves.toMatchObject({ name: 'goals' })
+        }
+    })
+
+    it('throws a not-found error that points at the list command', async () => {
+        await expect(makeManager().require('ghost')).rejects.toMatchObject({
+            code: 'EXTENSION_NOT_FOUND',
+        })
+    })
+
+    it('flags an extension whose name a built-in command owns', async () => {
+        await writeFixtureExtension(extensionsDir, 'task')
+        await writeFixtureExtension(extensionsDir, 'goals')
+
+        const listing = await makeManager(['task']).list()
+
+        expect(listing.find((entry) => entry.name === 'task')?.shadowed).toBe(true)
+        expect(listing.find((entry) => entry.name === 'goals')?.shadowed).toBe(false)
+    })
+
+    it('reports an executable that has not been built', async () => {
+        await writeFixtureExtension(extensionsDir, 'built')
+        await writeFixtureExtension(extensionsDir, 'unbuilt', { notExecutable: true })
+
+        const listing = await makeManager().list()
+
+        expect(listing.find((entry) => entry.name === 'built')?.executable).toBe(true)
+        expect(listing.find((entry) => entry.name === 'unbuilt')?.executable).toBe(false)
+    })
+
+    it('reports the release tag as the version of a binary install', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: {
+                owner: 'Doist',
+                name: 'td-goals',
+                host: 'github.com',
+                tag: 'v0.3.0',
+                pinned: false,
+                asset: 'a',
+                installedAt: 'now',
+            },
+        })
+
+        const [entry] = await makeManager().list()
+        expect(entry).toMatchObject({ version: 'v0.3.0', official: true })
+    })
+
+    it('has no version for a local install', async () => {
+        const workspace = join(root, 'code')
+        await mkdir(workspace, { recursive: true })
+        const target = await writeFixtureExtension(workspace, 'scratch')
+        await symlink(target, join(extensionsDir, 'td-scratch'), 'dir')
+
+        const [entry] = await makeManager().list()
+        expect(entry.version).toBeUndefined()
+    })
+
+    it('runs an extension and returns its exit code', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals')
+
+        await expect(
+            makeManager().dispatch('goals', ['--exit-code', '7'], { env: quiet() }),
+        ).resolves.toBe(7)
+    })
+
+    it('warns, but still runs, when the host is older than the extension requires', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            authoredManifest: { requires: { td: '>=9.0.0' } },
+        })
+
+        await expect(makeManager().dispatch('goals', [], { env: quiet() })).resolves.toBe(0)
+        expect(warnings.some((warning) => warning.includes('expects td >=9.0.0'))).toBe(true)
+    })
+
+    it('says nothing when the host satisfies the required range', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            authoredManifest: { requires: { td: '>=5.0.0' } },
+        })
+
+        await makeManager().dispatch('goals', [], { env: quiet() })
+        expect(warnings).toEqual([])
+    })
+})

--- a/src/lib/extensions/manager.ts
+++ b/src/lib/extensions/manager.ts
@@ -1,0 +1,226 @@
+/**
+ * The extension manager: one object holding every operation the CLI needs,
+ * configured entirely through its options.
+ *
+ * Nothing in this directory knows which CLI it is serving. The binary name,
+ * directories, version, reserved command names and first-party source all
+ * arrive here, which is what allows the whole thing to move to
+ * `@doist/cli-core` and be adopted by another CLI with one call.
+ */
+
+import { stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { CliError } from '@doist/cli-core'
+import { discoverExtensions } from './discover.js'
+import { buildExtensionEnv, dispatchExtension } from './dispatch.js'
+import { headSha } from './git.js'
+import { createGitHubClient } from './github.js'
+import { installExtension, type InstallContext, isEmpty } from './install.js'
+import { removeExtension } from './remove.js'
+import { normalizeSelector } from './source.js'
+import type {
+    DispatchOptions,
+    Extension,
+    ExtensionListing,
+    ExtensionManagerOptions,
+    ExtensionTheme,
+    InstallOptions,
+    InstallResult,
+    RemoveOptions,
+    RemoveResult,
+    UpgradeOptions,
+    UpgradeResult,
+} from './types.js'
+import { mapWithConcurrency, upgradeExtensions } from './upgrade.js'
+import { satisfiesRange } from './version-range.js'
+
+export type ExtensionManager = {
+    readonly binName: string
+    readonly envPrefix: string
+    readonly extensionsDir: string
+    readonly officialLabel: string
+    readonly theme: ExtensionTheme
+    readonly trustWarning: string
+    isAccessible(): boolean
+    /** Everything installed, cheaply: no subprocesses, no network. */
+    discover(): Promise<Extension[]>
+    /** Resolve `goals`, `td-goals` or `owner/td-goals` to an installed extension. */
+    find(selector: string): Promise<Extension | undefined>
+    /** Like `find`, but throws the standard not-found error. */
+    require(selector: string): Promise<Extension>
+    /** Everything installed, with the details that cost extra work to learn. */
+    list(): Promise<ExtensionListing[]>
+    install(source: string, options?: InstallOptions): Promise<InstallResult>
+    upgrade(selectors: string[], options?: UpgradeOptions): Promise<UpgradeResult[]>
+    upgradeAll(options?: UpgradeOptions): Promise<UpgradeResult[]>
+    remove(selector: string, options?: RemoveOptions): Promise<RemoveResult>
+    /** Run an extension and resolve with the exit code the host should use. */
+    dispatch(selector: string, args: string[], options?: DispatchOptions): Promise<number>
+    /** True when no extension is installed, used to decide whether to advertise the feature. */
+    isEmpty(): Promise<boolean>
+}
+
+const IDENTITY: ExtensionTheme = {
+    dim: (text) => text,
+    bold: (text) => text,
+    green: (text) => text,
+    yellow: (text) => text,
+}
+
+export function createExtensionManager(options: ExtensionManagerOptions): ExtensionManager {
+    const {
+        binName,
+        envPrefix,
+        version,
+        dataDir,
+        stateDir,
+        configDir,
+        hostPath,
+        reservedNames,
+        officialSource,
+        officialLabel,
+    } = options
+
+    const extensionsDir = join(dataDir, 'extensions')
+    const theme: ExtensionTheme = { ...IDENTITY, ...options.theme }
+    const log = options.log ?? ((message: string) => console.log(message))
+    const warn = options.warn ?? ((message: string) => console.error(message))
+    const isAccessible = options.isAccessible ?? (() => false)
+    const client = createGitHubClient(options.fetchImpl ?? fetch)
+
+    const trustWarning =
+        `Extensions are not reviewed, signed, or endorsed by ${officialLabel}. ` +
+        `Installing one runs code from its publisher with your permissions and your ${officialLabel} credentials. ` +
+        'Review the source before use.'
+
+    const discoverOptions = { extensionsDir, stateDir, binName, officialSource }
+
+    const installContext: InstallContext = {
+        binName,
+        extensionsDir,
+        stateDir,
+        officialSource,
+        client,
+        reservedNames,
+        log,
+        warn,
+        trustWarning,
+    }
+
+    async function discover(): Promise<Extension[]> {
+        return discoverExtensions(discoverOptions)
+    }
+
+    async function find(selector: string): Promise<Extension | undefined> {
+        const name = normalizeSelector(binName, selector)
+        return (await discover()).find((extension) => extension.name === name)
+    }
+
+    async function requireExtension(selector: string): Promise<Extension> {
+        const extension = await find(selector)
+        if (!extension) {
+            throw new CliError(
+                'EXTENSION_NOT_FOUND',
+                `No extension named "${normalizeSelector(binName, selector)}" is installed.`,
+                { hints: [`Run \`${binName} extension list\` to see what is installed.`] },
+            )
+        }
+        return extension
+    }
+
+    async function isExecutable(path: string): Promise<boolean> {
+        try {
+            const stats = await stat(path)
+            if (!stats.isFile()) return false
+            return process.platform === 'win32' ? true : (stats.mode & 0o111) !== 0
+        } catch {
+            return false
+        }
+    }
+
+    async function describeVersion(extension: Extension): Promise<string | undefined> {
+        if (extension.kind === 'binary') return extension.manifest?.tag
+        if (extension.kind === 'git') return (await headSha(extension.dir))?.slice(0, 8)
+        return undefined
+    }
+
+    async function list(): Promise<ExtensionListing[]> {
+        const extensions = await discover()
+        const reserved = new Set(reservedNames())
+
+        return mapWithConcurrency(extensions, 4, async (extension) => ({
+            ...extension,
+            version: await describeVersion(extension),
+            shadowed: reserved.has(extension.name),
+            executable: await isExecutable(extension.executablePath),
+        }))
+    }
+
+    /**
+     * A `requires` range that the running host does not satisfy is a warning,
+     * never a refusal: upgrading the CLI should not silently break an
+     * extension that still works.
+     */
+    function warnIfIncompatible(extension: Extension): void {
+        const range = extension.requires?.[binName]
+        if (range && !satisfiesRange(version, range)) {
+            warn(
+                `Warning: ${extension.name} expects ${binName} ${range}, but this is ${binName} ${version}.`,
+            )
+        }
+    }
+
+    return {
+        binName,
+        envPrefix,
+        extensionsDir,
+        officialLabel,
+        theme,
+        trustWarning,
+        isAccessible,
+        discover,
+        find,
+        require: requireExtension,
+        list,
+
+        async install(source, installOptions = {}) {
+            return installExtension(source, installOptions, installContext)
+        },
+
+        async upgrade(selectors, upgradeOptions = {}) {
+            const extensions = await Promise.all(selectors.map(requireExtension))
+            return upgradeExtensions(extensions, upgradeOptions, installContext)
+        },
+
+        async upgradeAll(upgradeOptions = {}) {
+            return upgradeExtensions(await discover(), upgradeOptions, installContext)
+        },
+
+        async remove(selector, removeOptions = {}) {
+            const extension = await requireExtension(selector)
+            return removeExtension(extension, removeOptions, { binName, stateDir })
+        },
+
+        async dispatch(selector, args, dispatchOptions = {}) {
+            const extension = await requireExtension(selector)
+            warnIfIncompatible(extension)
+
+            const env = buildExtensionEnv({
+                envPrefix,
+                version,
+                configDir,
+                hostPath,
+                extension,
+                user: dispatchOptions.user,
+                accessible: isAccessible(),
+                extra: dispatchOptions.env,
+            })
+
+            return dispatchExtension(extension, args, env, dispatchOptions)
+        },
+
+        async isEmpty() {
+            return isEmpty(extensionsDir)
+        },
+    }
+}

--- a/src/lib/extensions/manifest.test.ts
+++ b/src/lib/extensions/manifest.test.ts
@@ -1,0 +1,101 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+    findManifestProblems,
+    readAuthoredManifest,
+    readInstalledManifest,
+    writeInstalledManifest,
+} from './manifest.js'
+
+describe('manifests', () => {
+    let dir: string
+
+    beforeEach(async () => {
+        dir = await mkdtemp(join(tmpdir(), 'td-ext-manifest-'))
+    })
+
+    afterEach(async () => {
+        await rm(dir, { recursive: true, force: true })
+    })
+
+    it('reads the dedicated author manifest', async () => {
+        await writeFile(
+            join(dir, 'td-extension.json'),
+            JSON.stringify({ description: 'Goals', requires: { td: '>=4.0.0' }, completion: true }),
+        )
+
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({
+            description: 'Goals',
+            requires: { td: '>=4.0.0' },
+            completion: true,
+        })
+    })
+
+    it('falls back to the host key in package.json for Node extensions', async () => {
+        await writeFile(
+            join(dir, 'package.json'),
+            JSON.stringify({ name: 'td-goals', td: { description: 'From package.json' } }),
+        )
+
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({
+            description: 'From package.json',
+        })
+    })
+
+    it('prefers the dedicated file when both exist', async () => {
+        await writeFile(join(dir, 'td-extension.json'), JSON.stringify({ description: 'Wins' }))
+        await writeFile(join(dir, 'package.json'), JSON.stringify({ td: { description: 'Loses' } }))
+
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({ description: 'Wins' })
+    })
+
+    it('ignores fields of the wrong type instead of failing', async () => {
+        await writeFile(
+            join(dir, 'td-extension.json'),
+            JSON.stringify({ description: 42, requires: { td: 1, tdc: '>=1.0.0' } }),
+        )
+
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({
+            requires: { tdc: '>=1.0.0' },
+        })
+    })
+
+    it('returns nothing when there is no manifest at all', async () => {
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toBeUndefined()
+    })
+
+    it('round-trips the manifest written at install time', async () => {
+        const manifest = {
+            owner: 'Doist',
+            name: 'td-goals',
+            host: 'github.com',
+            tag: 'v1.0.0',
+            pinned: false,
+            asset: 'td-goals_v1.0.0_linux-x64',
+            installedAt: '2026-09-07T10:12:00Z',
+        }
+        await writeInstalledManifest(dir, 'td', manifest)
+
+        await expect(readInstalledManifest(dir, 'td')).resolves.toMatchObject(manifest)
+    })
+
+    it('treats a manifest without an owner or name as absent', async () => {
+        await writeFile(join(dir, '.td-manifest.json'), JSON.stringify({ tag: 'v1' }))
+
+        await expect(readInstalledManifest(dir, 'td')).resolves.toBeUndefined()
+    })
+
+    it('reports unparseable manifests for doctor, and stays quiet about missing ones', async () => {
+        await expect(findManifestProblems(dir, 'td')).resolves.toEqual([])
+
+        await writeFile(join(dir, 'td-extension.json'), '{ not json')
+        await writeFile(join(dir, '.td-manifest.json'), '["an array"]')
+
+        await expect(findManifestProblems(dir, 'td')).resolves.toEqual([
+            'td-extension.json is not valid JSON',
+            '.td-manifest.json is not a JSON object',
+        ])
+    })
+})

--- a/src/lib/extensions/manifest.ts
+++ b/src/lib/extensions/manifest.ts
@@ -1,0 +1,114 @@
+/**
+ * Reading and writing the two manifest files.
+ *
+ * `<bin>-extension.json` is written by the extension author and is optional.
+ * `.<bin>-manifest.json` is written by the CLI for binary installs, which have
+ * no repository on disk to read the authored file from. The CLI-written file is
+ * dot-prefixed so it cannot collide with anything the extension itself ships.
+ */
+
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { authoredManifestFileName, manifestFileName } from './source.js'
+import type { AuthoredManifest, InstalledManifest } from './types.js'
+
+async function readJson(path: string): Promise<unknown | undefined> {
+    let raw: string
+    try {
+        raw = await readFile(path, 'utf8')
+    } catch {
+        return undefined
+    }
+    try {
+        return JSON.parse(raw)
+    } catch {
+        return undefined
+    }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function pickAuthoredFields(value: unknown): AuthoredManifest | undefined {
+    if (!isRecord(value)) return undefined
+    const manifest: AuthoredManifest = {}
+    if (typeof value.description === 'string') manifest.description = value.description
+    if (isRecord(value.requires)) {
+        const requires: Record<string, string> = {}
+        for (const [key, range] of Object.entries(value.requires)) {
+            if (typeof range === 'string') requires[key] = range
+        }
+        if (Object.keys(requires).length > 0) manifest.requires = requires
+    }
+    if (typeof value.completion === 'boolean') manifest.completion = value.completion
+    return manifest
+}
+
+/**
+ * Author metadata for an extension, from `<bin>-extension.json` or, for Node
+ * extensions that would rather not carry a second file, the `<bin>` key of
+ * `package.json`. The dedicated file wins when both exist.
+ */
+export async function readAuthoredManifest(
+    dir: string,
+    binName: string,
+): Promise<AuthoredManifest | undefined> {
+    const dedicated = pickAuthoredFields(
+        await readJson(join(dir, authoredManifestFileName(binName))),
+    )
+    if (dedicated) return dedicated
+
+    const packageJson = await readJson(join(dir, 'package.json'))
+    if (!isRecord(packageJson)) return undefined
+    return pickAuthoredFields(packageJson[binName])
+}
+
+export async function readInstalledManifest(
+    dir: string,
+    binName: string,
+): Promise<InstalledManifest | undefined> {
+    const value = await readJson(join(dir, manifestFileName(binName)))
+    if (!isRecord(value)) return undefined
+    if (typeof value.name !== 'string' || typeof value.owner !== 'string') return undefined
+    return value as InstalledManifest
+}
+
+export async function writeInstalledManifest(
+    dir: string,
+    binName: string,
+    manifest: InstalledManifest,
+): Promise<void> {
+    await writeFile(
+        join(dir, manifestFileName(binName)),
+        `${JSON.stringify(manifest, null, 2)}\n`,
+        {
+            mode: 0o600,
+        },
+    )
+}
+
+/**
+ * Manifest problems worth reporting in `doctor`: a file that exists but does
+ * not parse, or parses to something that is not an object. Missing files are
+ * not a problem — both manifests are optional.
+ */
+export async function findManifestProblems(dir: string, binName: string): Promise<string[]> {
+    const problems: string[] = []
+    for (const fileName of [authoredManifestFileName(binName), manifestFileName(binName)]) {
+        const path = join(dir, fileName)
+        let raw: string
+        try {
+            raw = await readFile(path, 'utf8')
+        } catch {
+            continue
+        }
+        try {
+            const parsed: unknown = JSON.parse(raw)
+            if (!isRecord(parsed)) problems.push(`${fileName} is not a JSON object`)
+        } catch {
+            problems.push(`${fileName} is not valid JSON`)
+        }
+    }
+    return problems
+}

--- a/src/lib/extensions/npm.ts
+++ b/src/lib/extensions/npm.ts
@@ -1,0 +1,60 @@
+/**
+ * Dependency installation for extensions that ship a `package.json`.
+ *
+ * Lifecycle scripts are allowed to run: packages with native dependencies need
+ * them, and by the time this runs the user has already been shown the trust
+ * warning and chosen to install code from this publisher.
+ */
+
+import { stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { CliError } from '@doist/cli-core'
+import { outputHints, run } from './run.js'
+
+async function exists(path: string): Promise<boolean> {
+    try {
+        await stat(path)
+        return true
+    } catch {
+        return false
+    }
+}
+
+export async function hasPackageJson(dir: string): Promise<boolean> {
+    return exists(join(dir, 'package.json'))
+}
+
+const NPM_COMMAND = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+
+/**
+ * Install production dependencies in place. Uses `npm ci` when a lockfile is
+ * present and falls back to `npm install` when it is not.
+ */
+export async function installDependencies(dir: string): Promise<void> {
+    if (!(await hasPackageJson(dir))) return
+
+    const hasLockfile = await exists(join(dir, 'package-lock.json'))
+    const args = hasLockfile ? ['ci', '--omit=dev'] : ['install', '--omit=dev']
+    const result = await run(NPM_COMMAND, args, { cwd: dir })
+
+    if (result.missing) {
+        throw new CliError(
+            'EXTENSION_NPM_MISSING',
+            'This extension has dependencies but npm was not found on PATH.',
+            {
+                hints: [
+                    'Install npm, then run the install again.',
+                    'Extension authors can avoid this by vendoring dependencies or shipping a release binary.',
+                ],
+            },
+        )
+    }
+
+    if (result.code !== 0) {
+        throw new CliError(
+            'EXTENSION_INSTALL_FAILED',
+            "Could not install the extension's dependencies.",
+            { hints: outputHints(result) },
+        )
+    }
+}

--- a/src/lib/extensions/remove.test.ts
+++ b/src/lib/extensions/remove.test.ts
@@ -1,0 +1,144 @@
+import { mkdir, mkdtemp, rm, stat, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { writeFixtureExtension } from '../../test-support/extension-fixture.js'
+import { discoverExtensions } from './discover.js'
+import { removeExtension } from './remove.js'
+import { run } from './run.js'
+import { readState, stateFilePath, writeState } from './state.js'
+
+const OFFICIAL = { host: 'github.com', owner: 'Doist' }
+
+describe('removeExtension', () => {
+    let root: string
+    let extensionsDir: string
+    let stateDir: string
+
+    const context = () => ({ binName: 'td', stateDir })
+    const find = async (name: string) => {
+        const found = await discoverExtensions({
+            extensionsDir,
+            stateDir,
+            binName: 'td',
+            officialSource: OFFICIAL,
+        })
+        const extension = found.find((candidate) => candidate.name === name)
+        if (!extension) throw new Error(`fixture ${name} not discovered`)
+        return extension
+    }
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-remove-'))
+        extensionsDir = join(root, 'extensions')
+        stateDir = join(root, 'state')
+        await mkdir(extensionsDir, { recursive: true })
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('removes a binary install and its state file', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: {
+                owner: 'Doist',
+                name: 'td-goals',
+                host: 'github.com',
+                tag: 'v1',
+                pinned: false,
+                asset: 'a',
+                installedAt: 'now',
+            },
+        })
+        await writeState(stateDir, 'td-goals', { latestRelease: 'v1' })
+
+        const result = await removeExtension(await find('goals'), {}, context())
+
+        expect(result).toMatchObject({ name: 'goals', kind: 'binary', removed: 'directory' })
+        await expect(stat(join(extensionsDir, 'td-goals'))).rejects.toThrow()
+        await expect(stat(stateFilePath(stateDir, 'td-goals'))).rejects.toThrow()
+    })
+
+    it('removes only the link for a local install, never the user’s directory', async () => {
+        const workspace = join(root, 'code')
+        await mkdir(workspace, { recursive: true })
+        const target = await writeFixtureExtension(workspace, 'scratch')
+        await symlink(target, join(extensionsDir, 'td-scratch'), 'dir')
+
+        const result = await removeExtension(await find('scratch'), {}, context())
+
+        expect(result).toMatchObject({ kind: 'local', removed: 'link' })
+        await expect(stat(join(extensionsDir, 'td-scratch'))).rejects.toThrow()
+        await expect(stat(join(target, 'td-scratch'))).resolves.toBeTruthy()
+    })
+
+    describe('git clones', () => {
+        let hasGit = false
+
+        async function makeClone(name: string, dirty: boolean): Promise<void> {
+            const dir = await writeFixtureExtension(extensionsDir, name)
+            await run('git', ['init', '--quiet', '--initial-branch=main'], { cwd: dir })
+            await run('git', ['add', '.'], { cwd: dir })
+            await run(
+                'git',
+                [
+                    '-c',
+                    'user.email=t@example.com',
+                    '-c',
+                    'user.name=T',
+                    'commit',
+                    '--quiet',
+                    '-m',
+                    'init',
+                ],
+                { cwd: dir },
+            )
+            if (dirty) await writeFile(join(dir, 'notes.md'), 'work in progress')
+        }
+
+        beforeEach(async () => {
+            hasGit = (await run('git', ['--version'])).code === 0
+        })
+
+        it('refuses a clone with uncommitted work', async () => {
+            if (!hasGit) return
+            await makeClone('wip', true)
+
+            await expect(removeExtension(await find('wip'), {}, context())).rejects.toMatchObject({
+                code: 'EXTENSION_DIRTY',
+            })
+
+            await expect(stat(join(extensionsDir, 'td-wip'))).resolves.toBeTruthy()
+        })
+
+        it('removes a clone with uncommitted work when forced', async () => {
+            if (!hasGit) return
+            await makeClone('wip', true)
+
+            await expect(
+                removeExtension(await find('wip'), { force: true }, context()),
+            ).resolves.toMatchObject({ removed: 'directory' })
+
+            await expect(stat(join(extensionsDir, 'td-wip'))).rejects.toThrow()
+        })
+
+        it('removes a clean clone without being forced', async () => {
+            if (!hasGit) return
+            await makeClone('clean', false)
+
+            await expect(
+                removeExtension(await find('clean'), {}, context()),
+            ).resolves.toMatchObject({ kind: 'git', removed: 'directory' })
+        })
+    })
+
+    it('leaves no state behind for a reinstall to inherit', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals')
+        await writeState(stateDir, 'td-goals', { pinned: 'v1.0.0' })
+
+        await removeExtension(await find('goals'), {}, context())
+
+        await expect(readState(stateDir, 'td-goals')).resolves.toEqual({})
+    })
+})

--- a/src/lib/extensions/remove.ts
+++ b/src/lib/extensions/remove.ts
@@ -1,0 +1,60 @@
+/**
+ * Removing an extension.
+ *
+ * The rule is that nothing the user wrote is deleted without them saying so:
+ * a local install only loses its link, and a clone with uncommitted work
+ * refuses to go until it is forced.
+ */
+
+import { rm } from 'node:fs/promises'
+import { CliError } from '@doist/cli-core'
+import { isDirty } from './git.js'
+import { removeState } from './state.js'
+import type { Extension, RemoveOptions, RemoveResult } from './types.js'
+
+export type RemoveContext = {
+    binName: string
+    stateDir: string
+}
+
+export async function removeExtension(
+    extension: Extension,
+    options: RemoveOptions,
+    context: RemoveContext,
+): Promise<RemoveResult> {
+    if (extension.kind === 'local') {
+        // Only the link inside the extensions directory. The directory it
+        // points at belongs to the user.
+        await rm(extension.entryPath, { force: true })
+        await removeState(context.stateDir, extension.dirName)
+        return {
+            name: extension.name,
+            kind: extension.kind,
+            removed: 'link',
+            path: extension.entryPath,
+        }
+    }
+
+    if (extension.kind === 'git' && !options.force && (await isDirty(extension.dir))) {
+        throw new CliError(
+            'EXTENSION_DIRTY',
+            `"${extension.name}" has uncommitted changes in ${extension.dir}.`,
+            {
+                hints: [
+                    'Commit or push the changes first, so they are not lost.',
+                    `Run \`${context.binName} extension remove ${extension.name} --force\` to delete them anyway.`,
+                ],
+            },
+        )
+    }
+
+    await rm(extension.entryPath, { recursive: true, force: true })
+    await removeState(context.stateDir, extension.dirName)
+
+    return {
+        name: extension.name,
+        kind: extension.kind,
+        removed: 'directory',
+        path: extension.entryPath,
+    }
+}

--- a/src/lib/extensions/run.ts
+++ b/src/lib/extensions/run.ts
@@ -1,0 +1,68 @@
+/**
+ * A small wrapper around `spawn` for the helper programs the extension system
+ * shells out to (git, npm). It captures output instead of inheriting the
+ * terminal, and it never throws on a non-zero exit — callers decide what a
+ * failure means and which error code to surface.
+ *
+ * Dispatching an extension itself is a different job and lives in `dispatch.ts`.
+ */
+
+import { spawn } from 'node:child_process'
+
+export type RunResult = {
+    code: number
+    stdout: string
+    stderr: string
+    /** True when the program itself could not be found on PATH. */
+    missing: boolean
+}
+
+export type RunOptions = {
+    cwd?: string
+    env?: NodeJS.ProcessEnv
+}
+
+export async function run(
+    command: string,
+    args: string[],
+    options: RunOptions = {},
+): Promise<RunResult> {
+    return new Promise((resolve) => {
+        const child = spawn(command, args, {
+            cwd: options.cwd,
+            env: options.env ?? process.env,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        })
+
+        let stdout = ''
+        let stderr = ''
+        child.stdout?.on('data', (chunk: Buffer) => {
+            stdout += chunk.toString()
+        })
+        child.stderr?.on('data', (chunk: Buffer) => {
+            stderr += chunk.toString()
+        })
+
+        child.on('error', (error: NodeJS.ErrnoException) => {
+            resolve({
+                code: 127,
+                stdout,
+                stderr: stderr || error.message,
+                missing: error.code === 'ENOENT',
+            })
+        })
+
+        child.on('close', (code) => {
+            resolve({ code: code ?? 1, stdout, stderr, missing: false })
+        })
+    })
+}
+
+/** The last few lines of a failed command's output, for use as error hints. */
+export function outputHints(result: RunResult, limit = 4): string[] {
+    return `${result.stderr}\n${result.stdout}`
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .slice(-limit)
+}

--- a/src/lib/extensions/source.test.ts
+++ b/src/lib/extensions/source.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import {
+    authoredManifestFileName,
+    manifestFileName,
+    normalizeSelector,
+    parseSource,
+    toCommandName,
+    toDirName,
+    validateExtensionName,
+} from './source.js'
+
+describe('naming', () => {
+    it('derives directory and command names from the host binary name', () => {
+        expect(toDirName('td', 'goals')).toBe('td-goals')
+        expect(toDirName('td', 'td-goals')).toBe('td-goals')
+        expect(toCommandName('td', 'td-goals')).toBe('goals')
+        expect(toCommandName('tdc', 'tdc-standup')).toBe('standup')
+    })
+
+    it('derives both manifest filenames from the host binary name', () => {
+        expect(authoredManifestFileName('td')).toBe('td-extension.json')
+        expect(manifestFileName('td')).toBe('.td-manifest.json')
+        expect(manifestFileName('tdc')).toBe('.tdc-manifest.json')
+    })
+
+    it('accepts a bare name, a prefixed name or an owner-qualified name', () => {
+        expect(normalizeSelector('td', 'goals')).toBe('goals')
+        expect(normalizeSelector('td', 'td-goals')).toBe('goals')
+        expect(normalizeSelector('td', 'Doist/td-goals')).toBe('goals')
+    })
+
+    it.each(['td-goals', 'td-weekly-review', 'td-g2'])('accepts %s', (name) => {
+        expect(() => validateExtensionName('td', name)).not.toThrow()
+    })
+
+    it.each(['goals', 'td-', 'td-Goals', 'td--x', 'td--x', 'tdgoals'])('rejects %s', (name) => {
+        expect(() => validateExtensionName('td', name)).toThrow(/not a valid extension name/)
+    })
+})
+
+describe('parseSource', () => {
+    it('treats owner/repo as GitHub', () => {
+        expect(parseSource('Doist/td-goals')).toEqual({
+            type: 'git',
+            host: 'github.com',
+            owner: 'Doist',
+            repo: 'td-goals',
+            url: 'https://github.com/Doist/td-goals.git',
+            isGitHub: true,
+        })
+    })
+
+    it('parses a full GitHub URL and strips the .git suffix', () => {
+        const parsed = parseSource('https://github.com/example/td-standup.git')
+        expect(parsed).toMatchObject({
+            type: 'git',
+            host: 'github.com',
+            owner: 'example',
+            repo: 'td-standup',
+            isGitHub: true,
+        })
+    })
+
+    it('marks a non-GitHub host so the API is never used for it', () => {
+        const parsed = parseSource('https://git.example.com/Doist/td-x')
+        expect(parsed).toMatchObject({ host: 'git.example.com', owner: 'Doist', isGitHub: false })
+    })
+
+    it('parses scp-style git remotes', () => {
+        expect(parseSource('git@github.com:Doist/td-goals.git')).toMatchObject({
+            type: 'git',
+            host: 'github.com',
+            owner: 'Doist',
+            repo: 'td-goals',
+            isGitHub: true,
+        })
+    })
+
+    it.each(['.', './td-scratch', '../td-scratch', '/tmp/td-scratch', '~/code/td-scratch'])(
+        'treats %s as a local path',
+        (source) => {
+            expect(parseSource(source)).toEqual({ type: 'local', path: source })
+        },
+    )
+
+    it('refuses input that names neither a repository nor a path', () => {
+        expect(() => parseSource('not a source')).toThrow(/Cannot work out/)
+    })
+})

--- a/src/lib/extensions/source.ts
+++ b/src/lib/extensions/source.ts
@@ -1,0 +1,142 @@
+/**
+ * Naming rules and install-source parsing.
+ *
+ * Every filename convention in the extension system derives from the host's
+ * binary name: `td` gives directories named `td-<name>`, an author manifest of
+ * `td-extension.json` and a CLI-written manifest of `.td-manifest.json`.
+ */
+
+import { isAbsolute } from 'node:path'
+import { CliError } from '@doist/cli-core'
+
+/** Directory (and executable) name for a command name: `goals` → `td-goals`. */
+export function toDirName(binName: string, name: string): string {
+    return name.startsWith(`${binName}-`) ? name : `${binName}-${name}`
+}
+
+/** Command name for a directory name: `td-goals` → `goals`. */
+export function toCommandName(binName: string, dirName: string): string {
+    const prefix = `${binName}-`
+    return dirName.startsWith(prefix) ? dirName.slice(prefix.length) : dirName
+}
+
+/** Name of the manifest the CLI writes for binary installs. */
+export function manifestFileName(binName: string): string {
+    return `.${binName}-manifest.json`
+}
+
+/** Name of the manifest an extension author ships. */
+export function authoredManifestFileName(binName: string): string {
+    return `${binName}-extension.json`
+}
+
+/**
+ * Accepts `goals`, `td-goals` or `Doist/td-goals` and returns the command
+ * name. Used by `remove`, `upgrade` and `exec`, which all take a loose ref.
+ */
+export function normalizeSelector(binName: string, selector: string): string {
+    const withoutOwner = selector.includes('/') ? (selector.split('/').pop() ?? selector) : selector
+    return toCommandName(binName, withoutOwner)
+}
+
+export function validateExtensionName(binName: string, dirName: string): void {
+    const pattern = new RegExp(`^${binName}-[a-z0-9][a-z0-9-]*$`)
+    if (!pattern.test(dirName)) {
+        throw new CliError(
+            'EXTENSION_NAME_INVALID',
+            `"${dirName}" is not a valid extension name.`,
+            {
+                hints: [
+                    `Extension repositories must be named ${binName}-<name>, lowercase, starting with a letter or digit.`,
+                ],
+            },
+        )
+    }
+}
+
+export type ParsedSource =
+    | { type: 'local'; path: string }
+    | { type: 'git'; host: string; owner: string; repo: string; url: string; isGitHub: boolean }
+
+const GITHUB_HOST = 'github.com'
+
+function stripGitSuffix(repo: string): string {
+    return repo.endsWith('.git') ? repo.slice(0, -'.git'.length) : repo
+}
+
+function looksLikeLocalPath(source: string): boolean {
+    if (source === '.' || source === '..') return true
+    if (source.startsWith('./') || source.startsWith('../')) return true
+    if (source.startsWith('~/')) return true
+    if (source.startsWith('.\\') || source.startsWith('..\\')) return true
+    if (isAbsolute(source)) return true
+    // Windows drive-relative paths such as `C:foo` are not worth supporting.
+    return /^[a-zA-Z]:[\\/]/.test(source)
+}
+
+/**
+ * Work out what an install source refers to. A bare `owner/repo` means
+ * GitHub; any other URL is cloned with git and never touches the GitHub API.
+ */
+export function parseSource(source: string): ParsedSource {
+    if (looksLikeLocalPath(source)) {
+        return { type: 'local', path: source }
+    }
+
+    const scpLike = source.match(/^(?:[^@]+@)?([^:/]+):(.+?)\/([^/]+?)(?:\.git)?$/)
+    if (scpLike && !source.includes('://')) {
+        const [, host, owner, repo] = scpLike
+        return {
+            type: 'git',
+            host,
+            owner,
+            repo: stripGitSuffix(repo),
+            url: source,
+            isGitHub: host === GITHUB_HOST,
+        }
+    }
+
+    if (source.includes('://')) {
+        let url: URL
+        try {
+            url = new URL(source)
+        } catch {
+            throw new CliError('EXTENSION_NOT_INSTALLABLE', `"${source}" is not a valid URL.`)
+        }
+        const segments = url.pathname.split('/').filter(Boolean)
+        if (segments.length < 2) {
+            throw new CliError(
+                'EXTENSION_NOT_INSTALLABLE',
+                `"${source}" does not look like a repository URL.`,
+                { hints: ['Expected a URL ending in <owner>/<repo>.'] },
+            )
+        }
+        const repo = stripGitSuffix(segments[segments.length - 1])
+        const owner = segments[segments.length - 2]
+        return {
+            type: 'git',
+            host: url.host,
+            owner,
+            repo,
+            url: source,
+            isGitHub: url.host === GITHUB_HOST,
+        }
+    }
+
+    const shorthand = source.match(/^([^/\s]+)\/([^/\s]+)$/)
+    if (shorthand) {
+        const [, owner, repo] = shorthand
+        return {
+            type: 'git',
+            host: GITHUB_HOST,
+            owner,
+            repo: stripGitSuffix(repo),
+            url: `https://${GITHUB_HOST}/${owner}/${stripGitSuffix(repo)}.git`,
+            isGitHub: true,
+        }
+    }
+
+    throw new CliError('EXTENSION_NOT_INSTALLABLE', `Cannot work out what "${source}" refers to.`, {
+        hints: ['Use <owner>/<repo>, a full repository URL, or a path to a local directory.'],
+    })
+}

--- a/src/lib/extensions/state.ts
+++ b/src/lib/extensions/state.ts
@@ -1,0 +1,45 @@
+/**
+ * Per-extension state that is not part of the extension itself: the pin, and
+ * the bookkeeping a future update notice will need. It lives outside the
+ * extension directory so that deleting the directory by hand is still a clean
+ * uninstall, and so a `git pull` can never clobber it.
+ */
+
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+export type ExtensionState = {
+    /** Git ref or release tag this extension is held at, if pinned. */
+    pinned?: string
+    checkedForUpdateAt?: string
+    latestRelease?: string
+}
+
+export function stateFilePath(stateDir: string, dirName: string): string {
+    return join(stateDir, 'extensions', `${dirName}.json`)
+}
+
+export async function readState(stateDir: string, dirName: string): Promise<ExtensionState> {
+    try {
+        const raw = await readFile(stateFilePath(stateDir, dirName), 'utf8')
+        const parsed: unknown = JSON.parse(raw)
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
+        return parsed as ExtensionState
+    } catch {
+        return {}
+    }
+}
+
+export async function writeState(
+    stateDir: string,
+    dirName: string,
+    state: ExtensionState,
+): Promise<void> {
+    const path = stateFilePath(stateDir, dirName)
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 })
+}
+
+export async function removeState(stateDir: string, dirName: string): Promise<void> {
+    await rm(stateFilePath(stateDir, dirName), { force: true })
+}

--- a/src/lib/extensions/types.ts
+++ b/src/lib/extensions/types.ts
@@ -1,0 +1,162 @@
+/**
+ * Shared types for the extension system.
+ *
+ * Everything in `src/lib/extensions/` is host-agnostic: the CLI's name, its
+ * directories, its version and its reserved command names all arrive through
+ * `ExtensionManagerOptions`. Nothing here may import from `src/commands/` or
+ * read this CLI's config, so the whole directory can move to
+ * `@doist/cli-core` unchanged.
+ */
+
+/**
+ * How an extension got onto disk, which decides how it is upgraded and
+ * removed. Inferred from the directory, never stored in a registry.
+ */
+export type ExtensionKind = 'binary' | 'git' | 'local'
+
+/** Metadata an extension author ships in `<bin>-extension.json`. */
+export type AuthoredManifest = {
+    description?: string
+    /** Host version ranges, keyed by binary name, e.g. `{ td: '>=4.0.0' }`. */
+    requires?: Record<string, string>
+    /** Opt-in to the argument-completion protocol. Unused for now. */
+    completion?: boolean
+}
+
+/** Metadata the CLI writes for binary installs, in `.<bin>-manifest.json`. */
+export type InstalledManifest = AuthoredManifest & {
+    owner: string
+    /** Directory name, e.g. `td-goals`. */
+    name: string
+    host: string
+    tag: string
+    pinned: boolean
+    asset: string
+    sha256?: string
+    installedAt: string
+}
+
+/** One installed extension, as discovered on disk. */
+export type Extension = {
+    /** Command name, e.g. `goals`. */
+    name: string
+    /** Directory name, e.g. `td-goals`. */
+    dirName: string
+    kind: ExtensionKind
+    /** Directory holding the extension (the link target for local installs). */
+    dir: string
+    /** Absolute path to the executable that `dispatch` spawns. */
+    executablePath: string
+    /** Path of the entry inside the extensions directory. */
+    entryPath: string
+    /** `owner/repo`, a git URL, or a local path — whatever `list` should show. */
+    source?: string
+    host?: string
+    owner?: string
+    pinned: boolean
+    official: boolean
+    description?: string
+    requires?: Record<string, string>
+    manifest?: InstalledManifest
+}
+
+/** An extension plus the details that cost a subprocess or extra I/O to learn. */
+export type ExtensionListing = Extension & {
+    /** Release tag for binary installs, short SHA for git, undefined for local. */
+    version?: string
+    /** True when a built-in command of the same name hides this extension. */
+    shadowed: boolean
+    /** False when the executable is missing or lacks the executable bit. */
+    executable: boolean
+}
+
+export type InstallOptions = {
+    /** Release tag or git ref to install and hold at. */
+    pin?: string
+    /** Replace an extension that is already installed. */
+    force?: boolean
+}
+
+export type InstallResult = {
+    name: string
+    dirName: string
+    kind: ExtensionKind
+    source: string
+    version?: string
+    dir: string
+}
+
+export type UpgradeOptions = {
+    force?: boolean
+    dryRun?: boolean
+}
+
+export type UpgradeOutcome = 'upgraded' | 'up-to-date' | 'skipped' | 'would-upgrade'
+
+export type UpgradeResult = {
+    name: string
+    outcome: UpgradeOutcome
+    /** Why a skip happened, or what changed on an upgrade. */
+    detail?: string
+    from?: string
+    to?: string
+}
+
+export type RemoveOptions = {
+    force?: boolean
+}
+
+export type RemoveResult = {
+    name: string
+    kind: ExtensionKind
+    /** What was deleted: the whole directory, or just the link for local installs. */
+    removed: 'directory' | 'link'
+    path: string
+}
+
+export type DispatchOptions = {
+    /** Value of `--user` seen before the command token, forwarded as `<PREFIX>_USER`. */
+    user?: string
+    /** Extra environment for the child, merged last. */
+    env?: Record<string, string | undefined>
+}
+
+/** Colour helpers. Defaults are identity functions, so the library never needs chalk. */
+export type ExtensionTheme = {
+    dim: (text: string) => string
+    bold: (text: string) => string
+    green: (text: string) => string
+    yellow: (text: string) => string
+}
+
+export type ExtensionManagerOptions = {
+    /** Binary name of the host CLI, e.g. `td`. Drives every naming convention. */
+    binName: string
+    /** Environment variable prefix for the child process, e.g. `TD`. */
+    envPrefix: string
+    /** Host version, used for `<PREFIX>_VERSION` and the `requires` check. */
+    version: string
+    /** Per-user data directory for this CLI. Extensions live in `<dataDir>/extensions`. */
+    dataDir: string
+    /** Per-user state directory for this CLI. */
+    stateDir: string
+    /** Config directory, passed to extensions as `<PREFIX>_CONFIG_DIR`. */
+    configDir: string
+    /** Absolute path to the host's entry script, passed as `<PREFIX>_PATH`. */
+    hostPath: string
+    /** Built-in command names and aliases an extension must not shadow. */
+    reservedNames: () => Iterable<string>
+    /** Install source that earns the first-party marker. */
+    officialSource: { host: string; owner: string }
+    /** Label shown for first-party extensions, e.g. `Todoist`. */
+    officialLabel: string
+    /** True when colour must not carry meaning on its own. */
+    isAccessible?: () => boolean
+    theme?: Partial<ExtensionTheme>
+    /** Wraps a slow operation in the host's spinner. Defaults to running it directly. */
+    withSpinner?: <T>(text: string, run: () => Promise<T>) => Promise<T>
+    log?: (message: string) => void
+    warn?: (message: string) => void
+    /** Injectable for tests. Defaults to the global `fetch`. */
+    fetchImpl?: typeof fetch
+}

--- a/src/lib/extensions/upgrade.test.ts
+++ b/src/lib/extensions/upgrade.test.ts
@@ -1,0 +1,234 @@
+import { mkdir, mkdtemp, readFile, rm, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { writeFixtureExtension } from '../../test-support/extension-fixture.js'
+import { discoverExtensions } from './discover.js'
+import { createGitHubClient } from './github.js'
+import type { InstallContext } from './install.js'
+import { writeState } from './state.js'
+import { mapWithConcurrency, upgradeExtension } from './upgrade.js'
+
+const OFFICIAL = { host: 'github.com', owner: 'Doist' }
+const PLATFORM_SUFFIX = `${process.platform}-${process.arch}`
+const BINARY = Buffer.from('#!/bin/sh\necho new\n')
+
+function manifestFor(tag: string) {
+    return {
+        owner: 'Doist',
+        name: 'td-goals',
+        host: 'github.com',
+        tag,
+        pinned: false,
+        asset: `td-goals_${tag}_${PLATFORM_SUFFIX}`,
+        installedAt: '2026-09-01T00:00:00Z',
+    }
+}
+
+function stubGitHub(latestTag: string) {
+    return vi.fn(async (input: string | URL | Request) => {
+        const url = String(input)
+        if (url.includes('/releases/latest')) {
+            return new Response(
+                JSON.stringify({
+                    tag_name: latestTag,
+                    assets: [
+                        {
+                            name: `td-goals_${latestTag}_${PLATFORM_SUFFIX}`,
+                            url: 'https://api.github.com/assets/bin',
+                            size: BINARY.length,
+                        },
+                    ],
+                }),
+                { status: 200 },
+            )
+        }
+        if (url.endsWith('/assets/bin'))
+            return new Response(new Uint8Array(BINARY), { status: 200 })
+        return new Response('', { status: 404 })
+    }) as unknown as typeof fetch
+}
+
+describe('mapWithConcurrency', () => {
+    it('never runs more than the limit at once', async () => {
+        let active = 0
+        let peak = 0
+
+        await mapWithConcurrency(
+            Array.from({ length: 12 }, (_, i) => i),
+            4,
+            async (item) => {
+                active += 1
+                peak = Math.max(peak, active)
+                await new Promise((resolve) => setTimeout(resolve, 5))
+                active -= 1
+                return item
+            },
+        )
+
+        expect(peak).toBeLessThanOrEqual(4)
+    })
+
+    it('keeps results in the order of the input', async () => {
+        const results = await mapWithConcurrency([3, 1, 2], 2, async (item) => {
+            await new Promise((resolve) => setTimeout(resolve, item))
+            return item * 10
+        })
+
+        expect(results).toEqual([30, 10, 20])
+    })
+})
+
+describe('upgradeExtension', () => {
+    let root: string
+    let extensionsDir: string
+    let stateDir: string
+
+    function contextFor(fetchImpl: typeof fetch): InstallContext {
+        return {
+            binName: 'td',
+            extensionsDir,
+            stateDir,
+            officialSource: OFFICIAL,
+            client: createGitHubClient(fetchImpl),
+            reservedNames: () => [],
+            log: () => undefined,
+            warn: () => undefined,
+            trustWarning: 'trust warning',
+        }
+    }
+
+    const find = async (name: string) => {
+        const found = await discoverExtensions({
+            extensionsDir,
+            stateDir,
+            binName: 'td',
+            officialSource: OFFICIAL,
+        })
+        const extension = found.find((candidate) => candidate.name === name)
+        if (!extension) throw new Error(`fixture ${name} not discovered`)
+        return extension
+    }
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-upgrade-'))
+        extensionsDir = join(root, 'extensions')
+        stateDir = join(root, 'state')
+        await mkdir(extensionsDir, { recursive: true })
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('leaves a local install alone', async () => {
+        const workspace = join(root, 'code')
+        await mkdir(workspace, { recursive: true })
+        const target = await writeFixtureExtension(workspace, 'scratch')
+        await symlink(target, join(extensionsDir, 'td-scratch'), 'dir')
+
+        const result = await upgradeExtension(
+            await find('scratch'),
+            {},
+            contextFor(stubGitHub('v2')),
+        )
+
+        expect(result).toMatchObject({ outcome: 'skipped' })
+        expect(result.detail).toMatch(/local installs/)
+    })
+
+    it('skips a pinned extension and says what it is pinned to', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: manifestFor('v1.0.0'),
+        })
+        await writeState(stateDir, 'td-goals', { pinned: 'v1.0.0' })
+
+        const result = await upgradeExtension(
+            await find('goals'),
+            {},
+            contextFor(stubGitHub('v2.0.0')),
+        )
+
+        expect(result).toMatchObject({ outcome: 'skipped', detail: 'pinned to v1.0.0' })
+    })
+
+    it('upgrades past a pin only when forced', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: manifestFor('v1.0.0'),
+        })
+        await writeState(stateDir, 'td-goals', { pinned: 'v1.0.0' })
+
+        const result = await upgradeExtension(
+            await find('goals'),
+            { force: true },
+            contextFor(stubGitHub('v2.0.0')),
+        )
+
+        expect(result).toMatchObject({ outcome: 'upgraded', from: 'v1.0.0', to: 'v2.0.0' })
+    })
+
+    it('reports an up-to-date binary without downloading anything', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: manifestFor('v1.0.0'),
+        })
+        const fetchImpl = stubGitHub('v1.0.0')
+
+        const result = await upgradeExtension(await find('goals'), {}, contextFor(fetchImpl))
+
+        expect(result).toMatchObject({ outcome: 'up-to-date' })
+        expect(
+            vi.mocked(fetchImpl).mock.calls.some(([url]) => String(url).includes('assets')),
+        ).toBe(false)
+    })
+
+    it('reports what a dry run would do without touching the install', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: manifestFor('v1.0.0'),
+        })
+
+        const result = await upgradeExtension(
+            await find('goals'),
+            { dryRun: true },
+            contextFor(stubGitHub('v2.0.0')),
+        )
+
+        expect(result).toMatchObject({ outcome: 'would-upgrade', from: 'v1.0.0', to: 'v2.0.0' })
+        const manifest = JSON.parse(
+            await readFile(join(extensionsDir, 'td-goals', '.td-manifest.json'), 'utf8'),
+        )
+        expect(manifest.tag).toBe('v1.0.0')
+    })
+
+    it('downloads and replaces a binary when the tag has moved', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: manifestFor('v1.0.0'),
+        })
+
+        const result = await upgradeExtension(
+            await find('goals'),
+            {},
+            contextFor(stubGitHub('v2.0.0')),
+        )
+
+        expect(result).toMatchObject({ outcome: 'upgraded', from: 'v1.0.0', to: 'v2.0.0' })
+        const executable = await readFile(join(extensionsDir, 'td-goals', 'td-goals'))
+        expect(executable.equals(BINARY)).toBe(true)
+        const manifest = JSON.parse(
+            await readFile(join(extensionsDir, 'td-goals', '.td-manifest.json'), 'utf8'),
+        )
+        expect(manifest.tag).toBe('v2.0.0')
+    })
+
+    it('skips a binary install that has no manifest to compare against', async () => {
+        await writeFixtureExtension(extensionsDir, 'orphan')
+
+        const result = await upgradeExtension(
+            await find('orphan'),
+            {},
+            contextFor(stubGitHub('v2.0.0')),
+        )
+
+        expect(result).toMatchObject({ outcome: 'skipped' })
+        expect(result.detail).toMatch(/no manifest/)
+    })
+})

--- a/src/lib/extensions/upgrade.ts
+++ b/src/lib/extensions/upgrade.ts
@@ -1,0 +1,172 @@
+/**
+ * Upgrading installed extensions.
+ *
+ * Git clones fast-forward, release binaries are re-downloaded when the tag has
+ * moved, and local installs are left alone because the user's own working
+ * directory is already the source of truth. A pin is honoured unless the user
+ * explicitly forces past it.
+ */
+
+import { changedFiles, headSha, pull, remoteHeadSha, resetToRemote } from './git.js'
+import { assetSuffixes, pickAsset } from './github.js'
+import { installBinary, type InstallContext } from './install.js'
+import { installDependencies } from './npm.js'
+import { readState } from './state.js'
+import type { Extension, UpgradeOptions, UpgradeResult } from './types.js'
+
+/** Files whose change means the extension's dependencies must be reinstalled. */
+const DEPENDENCY_FILES = new Set(['package.json', 'package-lock.json'])
+
+/**
+ * Run `worker` over every item, at most `limit` at a time. Upgrades hit the
+ * GitHub API once per extension, and firing all of them at once is what
+ * triggers secondary rate limits.
+ */
+export async function mapWithConcurrency<T, R>(
+    items: T[],
+    limit: number,
+    worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+    const results = Array.from<R>({ length: items.length })
+    let next = 0
+
+    const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+        while (next < items.length) {
+            const index = next++
+            results[index] = await worker(items[index])
+        }
+    })
+
+    await Promise.all(runners)
+    return results
+}
+
+async function upgradeGit(extension: Extension, options: UpgradeOptions): Promise<UpgradeResult> {
+    const before = await headSha(extension.dir)
+
+    if (options.dryRun) {
+        const remote = await remoteHeadSha(extension.dir)
+        if (!remote || !before || remote === before) {
+            return { name: extension.name, outcome: 'up-to-date' }
+        }
+        return {
+            name: extension.name,
+            outcome: 'would-upgrade',
+            from: before.slice(0, 8),
+            to: remote.slice(0, 8),
+        }
+    }
+
+    const result = options.force ? await resetToRemote(extension.dir) : await pull(extension.dir)
+
+    if (result.error) {
+        return { name: extension.name, outcome: 'skipped', detail: result.error }
+    }
+    if (!result.changed) {
+        return { name: extension.name, outcome: 'up-to-date' }
+    }
+
+    if (result.from && result.to) {
+        const changed = await changedFiles(extension.dir, result.from, result.to)
+        if (changed.some((file) => DEPENDENCY_FILES.has(file))) {
+            await installDependencies(extension.dir)
+        }
+    }
+
+    return {
+        name: extension.name,
+        outcome: 'upgraded',
+        from: result.from?.slice(0, 8),
+        to: result.to?.slice(0, 8),
+    }
+}
+
+async function upgradeBinary(
+    extension: Extension,
+    options: UpgradeOptions,
+    context: InstallContext,
+): Promise<UpgradeResult> {
+    const manifest = extension.manifest
+    if (!manifest) {
+        return {
+            name: extension.name,
+            outcome: 'skipped',
+            detail: 'no manifest, so there is nothing to compare against',
+        }
+    }
+
+    const release = await context.client.fetchRelease(manifest.owner, manifest.name)
+    if (!release) {
+        return { name: extension.name, outcome: 'skipped', detail: 'no releases found' }
+    }
+    if (release.tag === manifest.tag) {
+        return { name: extension.name, outcome: 'up-to-date' }
+    }
+
+    const asset = pickAsset(release.assets, assetSuffixes())
+    if (!asset) {
+        return {
+            name: extension.name,
+            outcome: 'skipped',
+            detail: `release ${release.tag} has no asset for ${process.platform}-${process.arch}`,
+        }
+    }
+
+    if (options.dryRun) {
+        return {
+            name: extension.name,
+            outcome: 'would-upgrade',
+            from: manifest.tag,
+            to: release.tag,
+        }
+    }
+
+    await installBinary(
+        { host: manifest.host, owner: manifest.owner, repo: manifest.name },
+        release,
+        asset,
+        {},
+        context,
+        extension,
+    )
+
+    return { name: extension.name, outcome: 'upgraded', from: manifest.tag, to: release.tag }
+}
+
+export async function upgradeExtension(
+    extension: Extension,
+    options: UpgradeOptions,
+    context: InstallContext,
+): Promise<UpgradeResult> {
+    if (extension.kind === 'local') {
+        return {
+            name: extension.name,
+            outcome: 'skipped',
+            detail: 'local installs always run whatever is in their directory',
+        }
+    }
+
+    const state = await readState(context.stateDir, extension.dirName)
+    if (extension.pinned && !options.force) {
+        return {
+            name: extension.name,
+            outcome: 'skipped',
+            detail: `pinned to ${state.pinned ?? extension.manifest?.tag ?? 'a fixed version'}`,
+        }
+    }
+
+    return extension.kind === 'git'
+        ? upgradeGit(extension, options)
+        : upgradeBinary(extension, options, context)
+}
+
+/** Upgrade many extensions, bounding how many talk to GitHub at once. */
+export async function upgradeExtensions(
+    extensions: Extension[],
+    options: UpgradeOptions,
+    context: InstallContext,
+): Promise<UpgradeResult[]> {
+    return mapWithConcurrency(extensions, 4, (extension) =>
+        upgradeExtension(extension, options, context),
+    )
+}

--- a/src/lib/extensions/version-range.test.ts
+++ b/src/lib/extensions/version-range.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { satisfiesRange } from './version-range.js'
+
+describe('satisfiesRange', () => {
+    it('treats a missing or wildcard range as satisfied', () => {
+        expect(satisfiesRange('5.3.1', undefined)).toBe(true)
+        expect(satisfiesRange('5.3.1', '')).toBe(true)
+        expect(satisfiesRange('5.3.1', '*')).toBe(true)
+    })
+
+    it.each([
+        ['5.3.1', '>=4.0.0', true],
+        ['3.9.0', '>=4.0.0', false],
+        ['4.0.0', '>=4.0.0', true],
+        ['4.0.0', '>4.0.0', false],
+        ['4.0.0', '<5.0.0', true],
+        ['5.0.0', '<5.0.0', false],
+        ['5.3.1', '5.3.1', true],
+        ['5.3.2', '5.3.1', false],
+    ])('%s against %s is %s', (version, range, expected) => {
+        expect(satisfiesRange(version, range)).toBe(expected)
+    })
+
+    it('applies caret rules, including the 0.x special case', () => {
+        expect(satisfiesRange('4.9.0', '^4.1.0')).toBe(true)
+        expect(satisfiesRange('5.0.0', '^4.1.0')).toBe(false)
+        expect(satisfiesRange('4.0.0', '^4.1.0')).toBe(false)
+        expect(satisfiesRange('0.2.9', '^0.2.3')).toBe(true)
+        expect(satisfiesRange('0.3.0', '^0.2.3')).toBe(false)
+    })
+
+    it('applies tilde rules', () => {
+        expect(satisfiesRange('4.1.9', '~4.1.0')).toBe(true)
+        expect(satisfiesRange('4.2.0', '~4.1.0')).toBe(false)
+    })
+
+    it('supports a conjunction and a disjunction', () => {
+        expect(satisfiesRange('4.5.0', '>=4.0.0 <5.0.0')).toBe(true)
+        expect(satisfiesRange('5.1.0', '>=4.0.0 <5.0.0')).toBe(false)
+        expect(satisfiesRange('5.1.0', '^4.0.0 || >=5.0.0')).toBe(true)
+    })
+
+    it('passes ranges it cannot parse, since the check only drives a warning', () => {
+        expect(satisfiesRange('5.3.1', 'next')).toBe(true)
+        expect(satisfiesRange('5.3.1', '>=4.0.0-alpha.x.y.z.what')).toBe(true)
+    })
+})

--- a/src/lib/extensions/version-range.ts
+++ b/src/lib/extensions/version-range.ts
@@ -1,0 +1,76 @@
+/**
+ * A deliberately small semver range check for an extension's `requires` field.
+ *
+ * Supports the forms an extension author realistically writes: `>=4.1.0`,
+ * `^4.1.0`, `~4.1.0`, `4.1.0`, `*`, a space-separated conjunction
+ * (`>=4.1.0 <5.0.0`) and a `||` disjunction. Anything it cannot parse is
+ * treated as satisfied, because a version range is advisory here: failing it
+ * only prints a warning, so a false negative would be noise while a false
+ * positive costs nothing.
+ */
+
+import { compareVersions, parseVersion } from '@doist/cli-core/commands'
+
+type Comparator = { operator: string; version: string }
+
+const COMPARATOR = /^(>=|<=|>|<|=|\^|~)?\s*v?(\d.*)$/
+
+function parseComparator(raw: string): Comparator | undefined {
+    const match = raw.trim().match(COMPARATOR)
+    if (!match) return undefined
+    const [, operator, version] = match
+    return { operator: operator ?? '=', version }
+}
+
+/** Upper bound (exclusive) for `^` and `~`, following npm's rules. */
+function upperBound(operator: string, version: string): string | undefined {
+    const { major, minor } = parseVersion(version)
+    if (operator === '^') {
+        // ^0.2.3 allows patch changes only; ^1.2.3 allows minor changes.
+        return major === 0 ? `0.${minor + 1}.0` : `${major + 1}.0.0`
+    }
+    if (operator === '~') return `${major}.${minor + 1}.0`
+    return undefined
+}
+
+function satisfiesComparator(version: string, comparator: Comparator): boolean {
+    const { operator, version: target } = comparator
+    const compared = compareVersions(version, target)
+
+    switch (operator) {
+        case '>':
+            return compared > 0
+        case '>=':
+            return compared >= 0
+        case '<':
+            return compared < 0
+        case '<=':
+            return compared <= 0
+        case '^':
+        case '~': {
+            const bound = upperBound(operator, target)
+            return compared >= 0 && (bound === undefined || compareVersions(version, bound) < 0)
+        }
+        default:
+            return compared === 0
+    }
+}
+
+/**
+ * True when `version` satisfies `range`, or when the range is empty or in a
+ * form this checker does not understand.
+ */
+export function satisfiesRange(version: string, range: string | undefined): boolean {
+    const trimmed = range?.trim()
+    if (!trimmed || trimmed === '*' || trimmed === 'x') return true
+
+    return trimmed.split('||').some((clause) => {
+        const comparators = clause.trim().split(/\s+/).filter(Boolean).map(parseComparator)
+        if (comparators.length === 0) return true
+        // An unparseable comparator makes the whole clause pass; see the note
+        // at the top about preferring false positives.
+        return comparators.every(
+            (comparator) => comparator === undefined || satisfiesComparator(version, comparator),
+        )
+    })
+}

--- a/src/test-support/extension-fixture.ts
+++ b/src/test-support/extension-fixture.ts
@@ -1,0 +1,108 @@
+/**
+ * Builds real extensions on disk for tests.
+ *
+ * The extension contract is the process boundary, so the only way to test it
+ * honestly is to install and run an actual executable. These helpers write the
+ * smallest thing that can prove the contract: a script that reports the
+ * arguments and environment it was given, and exits with a code the test picks.
+ */
+
+import { chmod, mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export type FixtureOptions = {
+    /** Host binary name the extension belongs to. Defaults to `td`. */
+    binName?: string
+    /** Interpreter for the fixture. `node` exercises the shebang shortcut. */
+    interpreter?: 'node' | 'sh'
+    /** Contents of `<bin>-extension.json`, written only when given. */
+    authoredManifest?: Record<string, unknown>
+    /** Contents of `.<bin>-manifest.json`, which marks a binary install. */
+    installedManifest?: Record<string, unknown>
+    /** Leave the executable bit off, as an unbuilt compiled extension would. */
+    notExecutable?: boolean
+    /** Extra files to write into the extension directory. */
+    files?: Record<string, string>
+}
+
+/**
+ * A fixture that prints one JSON object to stdout describing how it was
+ * called, so a test can assert on argument passthrough and the environment
+ * contract in one go. It reports to the file named by `XX_REPORT` when that is
+ * set, and to stdout otherwise. `--exit-code N` makes it exit with N, and
+ * `--fail` writes to stderr.
+ */
+const NODE_FIXTURE = `#!/usr/bin/env node
+const args = process.argv.slice(2)
+const env = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => key.startsWith('TD_') || key.startsWith('XX_')),
+)
+const report = JSON.stringify({ args, env, cwd: process.cwd() })
+const exitFlag = args.indexOf('--exit-code')
+const code = exitFlag === -1 ? 0 : Number(args[exitFlag + 1])
+if (args.includes('--fail')) process.stderr.write('fixture failed')
+// Dynamic import works whether node loads this as CommonJS or ESM, which
+// depends on whatever package.json happens to sit above the fixture.
+if (process.env.XX_REPORT) {
+    import('node:fs').then((fs) => {
+        fs.writeFileSync(process.env.XX_REPORT, report)
+        process.exit(code)
+    })
+} else {
+    process.stdout.write(report)
+    process.exit(code)
+}
+`
+
+const SH_FIXTURE = `#!/bin/sh
+echo "args:$*"
+echo "name:$TD_EXTENSION_NAME"
+exit 0
+`
+
+/**
+ * Write an extension directory named `<binName>-<name>` under `parentDir` and
+ * return its path.
+ */
+export async function writeFixtureExtension(
+    parentDir: string,
+    name: string,
+    options: FixtureOptions = {},
+): Promise<string> {
+    const binName = options.binName ?? 'td'
+    const dirName = `${binName}-${name}`
+    const dir = join(parentDir, dirName)
+    await mkdir(dir, { recursive: true })
+
+    const executablePath = join(dir, dirName)
+    const body = options.interpreter === 'sh' ? SH_FIXTURE : NODE_FIXTURE
+    await writeFile(executablePath, body)
+    if (!options.notExecutable) await chmod(executablePath, 0o755)
+
+    if (options.authoredManifest) {
+        await writeFile(
+            join(dir, `${binName}-extension.json`),
+            JSON.stringify(options.authoredManifest, null, 2),
+        )
+    }
+    if (options.installedManifest) {
+        await writeFile(
+            join(dir, `.${binName}-manifest.json`),
+            JSON.stringify(options.installedManifest, null, 2),
+        )
+    }
+    for (const [file, contents] of Object.entries(options.files ?? {})) {
+        await writeFile(join(dir, file), contents)
+    }
+
+    return dir
+}
+
+/** Make a directory look like a git clone without running git. */
+export async function writeFakeGitRepo(dir: string, remoteUrl: string): Promise<void> {
+    await mkdir(join(dir, '.git'), { recursive: true })
+    await writeFile(
+        join(dir, '.git', 'config'),
+        `[core]\n\trepositoryformatversion = 0\n[remote "origin"]\n\turl = ${remoteUrl}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`,
+    )
+}


### PR DESCRIPTION
## Summary

First half of phase 1 of [the extensions spec](https://github.com/Doist/todoist-cli/blob/main/docs/specs/extensions.md): the library that discovers, installs, upgrades, removes and runs extensions. There is no user-facing command yet, so this changes nothing for users; the `td extension` group and the `src/index.ts` wiring follow in the next PR.

Everything lives in `src/lib/extensions/` and takes the host CLI's name, directories, version, reserved command names and first-party source through one options object, with no imports from the rest of the repo. That is decision 1 in the spec, and it is what makes the eventual move to `@doist/cli-core` a file move rather than a rewrite.

## What is here

- **Discovery** is one `readdir` plus a couple of small file reads, with no subprocesses and no network, because it runs on every invocation of `td` including the common case of no extensions at all. Kind is inferred from the directory in the spec's order: symlink or path file means local, `.git` means git, `.td-manifest.json` means binary.
- **Install** covers release binaries with checksum verification, git clones with npm dependency installation, and symlinks for local development. Everything is assembled in a staging directory and moved into place only once complete, so a failed install never leaves a half-written extension behind and never destroys the one already installed. The trust warning goes out before anything is downloaded, cloned or executed.
- **Upgrade** fast-forwards clones, re-downloads a binary when the release tag moves, honours pins unless forced, leaves local installs alone, and bounds GitHub requests with a worker pool of four.
- **Remove** deletes only the link for a local install, and refuses a clone with uncommitted work unless forced.
- **Dispatch** passes arguments through verbatim, sets the documented environment contract, runs node-shebang scripts under the host's own Node, and returns the extension's exit code. The API token is deliberately absent from the child environment.

## Testing

112 tests over nine files, using real files in temporary directories rather than a mocked filesystem, a stubbed GitHub API, and a fixture extension in `src/test-support/` that reports the arguments and environment it was given. The spec's named cases are covered: a mismatched checksum refuses the install and leaves nothing behind, `--pin` resolves the tagged release rather than the latest one, a reserved name fails before any request is made, and the trust warning precedes the first fetch.

## Not in this PR

The command group, root-command wiring, the command-token lookup change, `--user` scoping, doctor checks, and `SKILL_CONTENT`. Those are the user-facing half and land next.
