### PR TITLE
feat(extensions): core types, naming and manifests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "marked": "18.0.11",
         "marked-terminal-renderer": "2.2.0",
         "oauth4webapi": "3.8.8",
-        "open": "11.0.2"
+        "open": "11.0.2",
+        "zod": "4.3.6"
       },
       "bin": {
         "td": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "marked": "18.0.11",
     "marked-terminal-renderer": "2.2.0",
     "oauth4webapi": "3.8.8",
-    "open": "11.0.2"
+    "open": "11.0.2",
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@semantic-release/changelog": "7.0.0",

--- a/src/lib/extensions/fs-utils.ts
+++ b/src/lib/extensions/fs-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * The two filesystem questions the extension system asks everywhere: does this
+ * path exist, and can it be run.
+ */
+
+import { stat } from 'node:fs/promises'
+
+export async function exists(path: string): Promise<boolean> {
+    try {
+        await stat(path)
+        return true
+    } catch {
+        return false
+    }
+}
+
+export async function isDirectory(path: string): Promise<boolean> {
+    try {
+        return (await stat(path)).isDirectory()
+    } catch {
+        return false
+    }
+}
+
+/**
+ * True when the path is a file the operating system will run. Windows has no
+ * executable bit, so there existence is the only signal available.
+ */
+export async function isExecutable(path: string): Promise<boolean> {
+    try {
+        const stats = await stat(path)
+        if (!stats.isFile()) return false
+        return process.platform === 'win32' ? true : (stats.mode & 0o111) !== 0
+    } catch {
+        return false
+    }
+}

--- a/src/lib/extensions/fs-utils.ts
+++ b/src/lib/extensions/fs-utils.ts
@@ -3,7 +3,8 @@
  * path exist, and can it be run.
  */
 
-import { stat } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { access, stat } from 'node:fs/promises'
 
 export async function exists(path: string): Promise<boolean> {
     try {
@@ -23,14 +24,17 @@ export async function isDirectory(path: string): Promise<boolean> {
 }
 
 /**
- * True when the path is a file the operating system will run. Windows has no
- * executable bit, so there existence is the only signal available.
+ * True when the path is a file this process can actually run.
+ *
+ * `access` is asked rather than the mode bits, because permission can come
+ * from an access-control list the mode does not describe, and on Windows it
+ * reduces to an existence check, which is the only signal available there.
  */
 export async function isExecutable(path: string): Promise<boolean> {
     try {
-        const stats = await stat(path)
-        if (!stats.isFile()) return false
-        return process.platform === 'win32' ? true : (stats.mode & 0o111) !== 0
+        if (!(await stat(path)).isFile()) return false
+        await access(path, constants.X_OK)
+        return true
     } catch {
         return false
     }

--- a/src/lib/extensions/json-file.ts
+++ b/src/lib/extensions/json-file.ts
@@ -1,0 +1,55 @@
+/**
+ * Reading and writing the small JSON files the extension system keeps on disk.
+ *
+ * One place decides the on-disk shape — two-space indent, trailing newline,
+ * owner-only permissions — so the manifest and the state file cannot drift
+ * apart, and one place decides what counts as a JSON object.
+ */
+
+import { readFile, writeFile } from 'node:fs/promises'
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function isMissingFile(error: unknown): boolean {
+    return (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT'
+}
+
+export type JsonReadResult =
+    | { status: 'ok'; value: unknown }
+    | { status: 'absent' }
+    /** The file is there but could not be read or parsed. */
+    | { status: 'unreadable'; reason: string }
+
+/**
+ * Read a JSON file, keeping "not there" and "there but broken" apart. Callers
+ * that only want the value can use `readJsonValue`; `doctor` needs the
+ * distinction, because an unreadable manifest is a problem worth reporting and
+ * a missing one is not.
+ */
+export async function readJsonFile(path: string): Promise<JsonReadResult> {
+    let raw: string
+    try {
+        raw = await readFile(path, 'utf8')
+    } catch (error) {
+        if (isMissingFile(error)) return { status: 'absent' }
+        return { status: 'unreadable', reason: (error as Error).message }
+    }
+
+    try {
+        return { status: 'ok', value: JSON.parse(raw) }
+    } catch {
+        return { status: 'unreadable', reason: 'not valid JSON' }
+    }
+}
+
+/** The parsed value, or undefined when the file is missing or unusable. */
+export async function readJsonValue(path: string): Promise<unknown> {
+    const result = await readJsonFile(path)
+    return result.status === 'ok' ? result.value : undefined
+}
+
+export async function writeJsonFile(path: string, value: unknown): Promise<void> {
+    await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 })
+}

--- a/src/lib/extensions/manifest-format.ts
+++ b/src/lib/extensions/manifest-format.ts
@@ -1,0 +1,38 @@
+/**
+ * Which version of the manifest format this CLI speaks.
+ *
+ * This has a module of its own because the two places that need it cannot
+ * share either of themselves. The schemas define the format, but they live
+ * behind a dynamic import so that a validation library never loads on the way
+ * to `<bin> --version`; discovery, meanwhile, asks whether a manifest comes
+ * from a newer format while building a listing, and needs the answer without
+ * awaiting anything. One definition here, imported by both, so the number
+ * cannot be raised in one place and left behind in the other.
+ */
+
+import type { AuthoredManifest } from './schemas.js'
+
+/**
+ * The format this CLI writes and knows how to read in full.
+ *
+ * A file without a version is this one: the field arrived with the format, so
+ * its absence can only mean the first version.
+ */
+export const MANIFEST_VERSION = 1
+
+/** The version a manifest declares, defaulting to the original format. */
+export function manifestVersionOf(manifest: AuthoredManifest | undefined): number {
+    return manifest?.manifestVersion ?? MANIFEST_VERSION
+}
+
+/**
+ * True when a manifest was written to a format newer than this CLI knows.
+ *
+ * Such a manifest is still read for the fields this version understands. The
+ * extension itself is an executable and runs regardless: refusing to run it
+ * over the shape of a metadata file would break a working extension on a CLI
+ * downgrade, which is the failure the `requires` warning already avoids.
+ */
+export function isFromNewerFormat(manifest: AuthoredManifest | undefined): boolean {
+    return manifestVersionOf(manifest) > MANIFEST_VERSION
+}

--- a/src/lib/extensions/manifest.test.ts
+++ b/src/lib/extensions/manifest.test.ts
@@ -2,11 +2,9 @@ import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { isFromNewerFormat, MANIFEST_VERSION, manifestVersionOf } from './manifest-format.js'
 import {
     findManifestProblems,
-    isFromNewerFormat,
-    MANIFEST_VERSION,
-    manifestVersionOf,
     readAuthoredManifest,
     readInstalledManifest,
     writeInstalledManifest,

--- a/src/lib/extensions/manifest.test.ts
+++ b/src/lib/extensions/manifest.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -94,8 +94,54 @@ describe('manifests', () => {
         await writeFile(join(dir, '.td-manifest.json'), '["an array"]')
 
         await expect(findManifestProblems(dir, 'td')).resolves.toEqual([
-            'td-extension.json is not valid JSON',
+            'td-extension.json could not be read: not valid JSON',
             '.td-manifest.json is not a JSON object',
         ])
+    })
+
+    it('reports a manifest that exists but cannot be read', async () => {
+        const path = join(dir, 'td-extension.json')
+        await writeFile(path, JSON.stringify({ description: 'fine' }))
+        await chmod(path, 0o000)
+
+        const problems = await findManifestProblems(dir, 'td')
+
+        // Running as root defeats permission bits, so only assert when the
+        // file really is unreadable for this process.
+        if (
+            await readFile(path, 'utf8')
+                .then(() => false)
+                .catch(() => true)
+        ) {
+            expect(problems).toHaveLength(1)
+            expect(problems[0]).toContain('could not be read')
+        }
+        await chmod(path, 0o600)
+    })
+
+    it('rejects an install manifest that is missing fields upgrades rely on', async () => {
+        await writeFile(
+            join(dir, '.td-manifest.json'),
+            JSON.stringify({ name: 'td-goals', owner: 'Doist' }),
+        )
+
+        await expect(readInstalledManifest(dir, 'td')).resolves.toBeUndefined()
+    })
+
+    it('rejects an install manifest whose fields are the wrong type', async () => {
+        await writeFile(
+            join(dir, '.td-manifest.json'),
+            JSON.stringify({
+                owner: 'Doist',
+                name: 'td-goals',
+                host: 'github.com',
+                tag: 3,
+                pinned: false,
+                asset: 'a',
+                installedAt: 'now',
+            }),
+        )
+
+        await expect(readInstalledManifest(dir, 'td')).resolves.toBeUndefined()
     })
 })

--- a/src/lib/extensions/manifest.test.ts
+++ b/src/lib/extensions/manifest.test.ts
@@ -224,3 +224,69 @@ describe('manifests', () => {
         await expect(readInstalledManifest(dir, 'td')).resolves.toBeUndefined()
     })
 })
+
+describe('schema validation', () => {
+    let dir: string
+
+    beforeEach(async () => {
+        dir = await mkdtemp(join(tmpdir(), 'td-ext-schema-'))
+    })
+
+    afterEach(async () => {
+        await rm(dir, { recursive: true, force: true })
+    })
+
+    it('keeps unknown keys out without rejecting the manifest that carries them', async () => {
+        await writeFile(
+            join(dir, 'td-extension.json'),
+            JSON.stringify({ description: 'fine', somethingNewer: { deeply: 'nested' } }),
+        )
+
+        // The format has to be able to grow without older CLIs refusing it.
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({ description: 'fine' })
+    })
+
+    it('drops one malformed requires entry rather than the whole field', async () => {
+        await writeFile(
+            join(dir, 'td-extension.json'),
+            JSON.stringify({ requires: { td: 42, tdc: '>=1.0.0' } }),
+        )
+
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({
+            requires: { tdc: '>=1.0.0' },
+        })
+    })
+
+    it('treats an empty requires map as asking for nothing', async () => {
+        await writeFile(join(dir, 'td-extension.json'), JSON.stringify({ requires: {} }))
+
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({})
+    })
+
+    it.each([
+        ['a JSON array', '[]'],
+        ['a bare string', '"nope"'],
+        ['null', 'null'],
+    ])('treats %s as no manifest at all', async (_label, contents) => {
+        await writeFile(join(dir, 'td-extension.json'), contents)
+
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toBeUndefined()
+    })
+
+    it('rejects an install manifest with an empty required field', async () => {
+        await writeFile(
+            join(dir, '.td-manifest.json'),
+            JSON.stringify({
+                owner: '',
+                name: 'td-goals',
+                host: 'github.com',
+                tag: 'v1',
+                pinned: false,
+                asset: 'a',
+                installedAt: 'now',
+            }),
+        )
+
+        await expect(readInstalledManifest(dir, 'td')).resolves.toBeUndefined()
+    })
+})

--- a/src/lib/extensions/manifest.test.ts
+++ b/src/lib/extensions/manifest.test.ts
@@ -1,0 +1,101 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+    findManifestProblems,
+    readAuthoredManifest,
+    readInstalledManifest,
+    writeInstalledManifest,
+} from './manifest.js'
+
+describe('manifests', () => {
+    let dir: string
+
+    beforeEach(async () => {
+        dir = await mkdtemp(join(tmpdir(), 'td-ext-manifest-'))
+    })
+
+    afterEach(async () => {
+        await rm(dir, { recursive: true, force: true })
+    })
+
+    it('reads the dedicated author manifest', async () => {
+        await writeFile(
+            join(dir, 'td-extension.json'),
+            JSON.stringify({ description: 'Goals', requires: { td: '>=4.0.0' }, completion: true }),
+        )
+
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({
+            description: 'Goals',
+            requires: { td: '>=4.0.0' },
+            completion: true,
+        })
+    })
+
+    it('falls back to the host key in package.json for Node extensions', async () => {
+        await writeFile(
+            join(dir, 'package.json'),
+            JSON.stringify({ name: 'td-goals', td: { description: 'From package.json' } }),
+        )
+
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({
+            description: 'From package.json',
+        })
+    })
+
+    it('prefers the dedicated file when both exist', async () => {
+        await writeFile(join(dir, 'td-extension.json'), JSON.stringify({ description: 'Wins' }))
+        await writeFile(join(dir, 'package.json'), JSON.stringify({ td: { description: 'Loses' } }))
+
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({ description: 'Wins' })
+    })
+
+    it('ignores fields of the wrong type instead of failing', async () => {
+        await writeFile(
+            join(dir, 'td-extension.json'),
+            JSON.stringify({ description: 42, requires: { td: 1, tdc: '>=1.0.0' } }),
+        )
+
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({
+            requires: { tdc: '>=1.0.0' },
+        })
+    })
+
+    it('returns nothing when there is no manifest at all', async () => {
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toBeUndefined()
+    })
+
+    it('round-trips the manifest written at install time', async () => {
+        const manifest = {
+            owner: 'Doist',
+            name: 'td-goals',
+            host: 'github.com',
+            tag: 'v1.0.0',
+            pinned: false,
+            asset: 'td-goals_v1.0.0_linux-x64',
+            installedAt: '2026-09-07T10:12:00Z',
+        }
+        await writeInstalledManifest(dir, 'td', manifest)
+
+        await expect(readInstalledManifest(dir, 'td')).resolves.toMatchObject(manifest)
+    })
+
+    it('treats a manifest without an owner or name as absent', async () => {
+        await writeFile(join(dir, '.td-manifest.json'), JSON.stringify({ tag: 'v1' }))
+
+        await expect(readInstalledManifest(dir, 'td')).resolves.toBeUndefined()
+    })
+
+    it('reports unparseable manifests for doctor, and stays quiet about missing ones', async () => {
+        await expect(findManifestProblems(dir, 'td')).resolves.toEqual([])
+
+        await writeFile(join(dir, 'td-extension.json'), '{ not json')
+        await writeFile(join(dir, '.td-manifest.json'), '["an array"]')
+
+        await expect(findManifestProblems(dir, 'td')).resolves.toEqual([
+            'td-extension.json is not valid JSON',
+            '.td-manifest.json is not a JSON object',
+        ])
+    })
+})

--- a/src/lib/extensions/manifest.test.ts
+++ b/src/lib/extensions/manifest.test.ts
@@ -4,6 +4,9 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
     findManifestProblems,
+    isFromNewerFormat,
+    MANIFEST_VERSION,
+    manifestVersionOf,
     readAuthoredManifest,
     readInstalledManifest,
     writeInstalledManifest,
@@ -18,6 +21,82 @@ describe('manifests', () => {
 
     afterEach(async () => {
         await rm(dir, { recursive: true, force: true })
+    })
+
+    describe('format version', () => {
+        it('treats a manifest without a version as the original format', async () => {
+            await writeFile(join(dir, 'td-extension.json'), JSON.stringify({ description: 'x' }))
+
+            const manifest = await readAuthoredManifest(dir, 'td')
+
+            expect(manifest?.manifestVersion).toBeUndefined()
+            expect(manifestVersionOf(manifest)).toBe(MANIFEST_VERSION)
+            expect(isFromNewerFormat(manifest)).toBe(false)
+        })
+
+        it('keeps a version it does not understand, so callers can explain themselves', async () => {
+            await writeFile(
+                join(dir, 'td-extension.json'),
+                JSON.stringify({ manifestVersion: 99, description: 'from the future' }),
+            )
+
+            const manifest = await readAuthoredManifest(dir, 'td')
+
+            // Still read for the fields this version knows: the extension is
+            // an executable, and its metadata being newer is not a reason to
+            // stop it working.
+            expect(manifest?.description).toBe('from the future')
+            expect(isFromNewerFormat(manifest)).toBe(true)
+        })
+
+        it('ignores a version that is not a whole number', async () => {
+            await writeFile(
+                join(dir, 'td-extension.json'),
+                JSON.stringify({ manifestVersion: '2', description: 'x' }),
+            )
+
+            const manifest = await readAuthoredManifest(dir, 'td')
+
+            expect(manifest?.manifestVersion).toBeUndefined()
+            expect(isFromNewerFormat(manifest)).toBe(false)
+        })
+
+        it('refuses an install manifest written by a newer CLI', async () => {
+            await writeFile(
+                join(dir, '.td-manifest.json'),
+                JSON.stringify({
+                    manifestVersion: MANIFEST_VERSION + 1,
+                    owner: 'Doist',
+                    name: 'td-goals',
+                    host: 'github.com',
+                    tag: 'v1',
+                    pinned: false,
+                    asset: 'a',
+                    installedAt: 'now',
+                }),
+            )
+
+            // Reading it as though it were this format would be guessing.
+            await expect(readInstalledManifest(dir, 'td')).resolves.toBeUndefined()
+        })
+
+        it('accepts an install manifest at the version it writes', async () => {
+            await writeInstalledManifest(dir, 'td', {
+                manifestVersion: MANIFEST_VERSION,
+                owner: 'Doist',
+                name: 'td-goals',
+                host: 'github.com',
+                tag: 'v1',
+                pinned: false,
+                asset: 'a',
+                installedAt: 'now',
+            })
+
+            await expect(readInstalledManifest(dir, 'td')).resolves.toMatchObject({
+                manifestVersion: MANIFEST_VERSION,
+                tag: 'v1',
+            })
+        })
     })
 
     it('reads the dedicated author manifest', async () => {

--- a/src/lib/extensions/manifest.ts
+++ b/src/lib/extensions/manifest.ts
@@ -7,30 +7,17 @@
  * dot-prefixed so it cannot collide with anything the extension itself ships.
  */
 
-import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { isRecord, readJsonFile, readJsonValue, writeJsonFile } from './json-file.js'
 import { authoredManifestFileName, manifestFileName } from './source.js'
 import type { AuthoredManifest, InstalledManifest } from './types.js'
 
-async function readJson(path: string): Promise<unknown | undefined> {
-    let raw: string
-    try {
-        raw = await readFile(path, 'utf8')
-    } catch {
-        return undefined
-    }
-    try {
-        return JSON.parse(raw)
-    } catch {
-        return undefined
-    }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-function pickAuthoredFields(value: unknown): AuthoredManifest | undefined {
+/**
+ * Take only the fields this system understands, and only when they are the
+ * right type. A manifest is written by hand, so a wrong type is likelier than
+ * a missing field and neither should stop an extension from working.
+ */
+export function pickAuthoredFields(value: unknown): AuthoredManifest | undefined {
     if (!isRecord(value)) return undefined
     const manifest: AuthoredManifest = {}
     if (typeof value.description === 'string') manifest.description = value.description
@@ -55,23 +42,47 @@ export async function readAuthoredManifest(
     binName: string,
 ): Promise<AuthoredManifest | undefined> {
     const dedicated = pickAuthoredFields(
-        await readJson(join(dir, authoredManifestFileName(binName))),
+        await readJsonValue(join(dir, authoredManifestFileName(binName))),
     )
     if (dedicated) return dedicated
 
-    const packageJson = await readJson(join(dir, 'package.json'))
+    const packageJson = await readJsonValue(join(dir, 'package.json'))
     if (!isRecord(packageJson)) return undefined
     return pickAuthoredFields(packageJson[binName])
 }
 
+/**
+ * The manifest the CLI wrote at install time, or undefined when it is missing
+ * or does not describe an install.
+ *
+ * Every required field is checked rather than cast over, because upgrades read
+ * `tag` and `owner` back to decide what to fetch: a truncated or hand-edited
+ * file should read as "no manifest", which callers already handle, rather than
+ * as a manifest full of undefined.
+ */
 export async function readInstalledManifest(
     dir: string,
     binName: string,
 ): Promise<InstalledManifest | undefined> {
-    const value = await readJson(join(dir, manifestFileName(binName)))
+    const value = await readJsonValue(join(dir, manifestFileName(binName)))
     if (!isRecord(value)) return undefined
-    if (typeof value.name !== 'string' || typeof value.owner !== 'string') return undefined
-    return value as InstalledManifest
+
+    const strings = ['owner', 'name', 'host', 'tag', 'asset', 'installedAt'] as const
+    if (strings.some((field) => typeof value[field] !== 'string')) return undefined
+    if (typeof value.pinned !== 'boolean') return undefined
+    if (value.sha256 !== undefined && typeof value.sha256 !== 'string') return undefined
+
+    return {
+        owner: value.owner as string,
+        name: value.name as string,
+        host: value.host as string,
+        tag: value.tag as string,
+        asset: value.asset as string,
+        installedAt: value.installedAt as string,
+        pinned: value.pinned,
+        sha256: value.sha256 as string | undefined,
+        ...pickAuthoredFields(value),
+    }
 }
 
 export async function writeInstalledManifest(
@@ -79,36 +90,27 @@ export async function writeInstalledManifest(
     binName: string,
     manifest: InstalledManifest,
 ): Promise<void> {
-    await writeFile(
-        join(dir, manifestFileName(binName)),
-        `${JSON.stringify(manifest, null, 2)}\n`,
-        {
-            mode: 0o600,
-        },
-    )
+    await writeJsonFile(join(dir, manifestFileName(binName)), manifest)
 }
 
 /**
- * Manifest problems worth reporting in `doctor`: a file that exists but does
- * not parse, or parses to something that is not an object. Missing files are
- * not a problem — both manifests are optional.
+ * Manifest problems worth reporting in `doctor`: a file that is there but
+ * cannot be read or parsed, or that parses to something other than an object.
+ * A missing file is not a problem — both manifests are optional — but a file
+ * that exists and cannot be read is exactly what `doctor` is for.
  */
 export async function findManifestProblems(dir: string, binName: string): Promise<string[]> {
     const problems: string[] = []
+
     for (const fileName of [authoredManifestFileName(binName), manifestFileName(binName)]) {
-        const path = join(dir, fileName)
-        let raw: string
-        try {
-            raw = await readFile(path, 'utf8')
-        } catch {
+        const result = await readJsonFile(join(dir, fileName))
+        if (result.status === 'absent') continue
+        if (result.status === 'unreadable') {
+            problems.push(`${fileName} could not be read: ${result.reason}`)
             continue
         }
-        try {
-            const parsed: unknown = JSON.parse(raw)
-            if (!isRecord(parsed)) problems.push(`${fileName} is not a JSON object`)
-        } catch {
-            problems.push(`${fileName} is not valid JSON`)
-        }
+        if (!isRecord(result.value)) problems.push(`${fileName} is not a JSON object`)
     }
+
     return problems
 }

--- a/src/lib/extensions/manifest.ts
+++ b/src/lib/extensions/manifest.ts
@@ -5,6 +5,10 @@
  * `.<bin>-manifest.json` is written by the CLI for binary installs, which have
  * no repository on disk to read the authored file from. The CLI-written file is
  * dot-prefixed so it cannot collide with anything the extension itself ships.
+ *
+ * Validation lives in `schemas.ts`, which is imported only when a file is
+ * actually parsed: discovery runs on every invocation of the CLI, and most of
+ * those invocations never touch a manifest.
  */
 
 import { join } from 'node:path'
@@ -12,12 +16,7 @@ import { isRecord, readJsonFile, readJsonValue, writeJsonFile } from './json-fil
 import { authoredManifestFileName, manifestFileName } from './source.js'
 import type { AuthoredManifest, InstalledManifest } from './types.js'
 
-/**
- * The manifest format this CLI writes and knows how to read in full.
- *
- * A file without a version is this one: the field was introduced with the
- * format, so its absence can only mean the first version.
- */
+/** The manifest format this CLI writes and knows how to read in full. */
 export const MANIFEST_VERSION = 1
 
 /** The version a manifest declares, defaulting to the original format. */
@@ -37,29 +36,13 @@ export function isFromNewerFormat(manifest: AuthoredManifest | undefined): boole
     return manifestVersionOf(manifest) > MANIFEST_VERSION
 }
 
-/**
- * Take only the fields this system understands, and only when they are the
- * right type. A manifest is written by hand, so a wrong type is likelier than
- * a missing field and neither should stop an extension from working.
- */
-export function pickAuthoredFields(value: unknown): AuthoredManifest | undefined {
-    if (!isRecord(value)) return undefined
-    const manifest: AuthoredManifest = {}
-    // Kept whatever it says, including a version this CLI does not know, so
-    // callers can tell the user why some of the metadata was ignored.
-    if (typeof value.manifestVersion === 'number' && Number.isInteger(value.manifestVersion)) {
-        manifest.manifestVersion = value.manifestVersion
-    }
-    if (typeof value.description === 'string') manifest.description = value.description
-    if (isRecord(value.requires)) {
-        const requires: Record<string, string> = {}
-        for (const [key, range] of Object.entries(value.requires)) {
-            if (typeof range === 'string') requires[key] = range
-        }
-        if (Object.keys(requires).length > 0) manifest.requires = requires
-    }
-    if (typeof value.completion === 'boolean') manifest.completion = value.completion
-    return manifest
+async function schemas() {
+    return import('./schemas.js')
+}
+
+/** Validate a value that is already in hand, such as one fetched over HTTP. */
+export async function pickAuthoredFields(value: unknown): Promise<AuthoredManifest | undefined> {
+    return (await schemas()).parseAuthoredManifest(value)
 }
 
 /**
@@ -71,56 +54,32 @@ export async function readAuthoredManifest(
     dir: string,
     binName: string,
 ): Promise<AuthoredManifest | undefined> {
-    const dedicated = pickAuthoredFields(
-        await readJsonValue(join(dir, authoredManifestFileName(binName))),
-    )
-    if (dedicated) return dedicated
+    const dedicatedValue = await readJsonValue(join(dir, authoredManifestFileName(binName)))
+    const packageJson =
+        dedicatedValue === undefined ? await readJsonValue(join(dir, 'package.json')) : undefined
 
-    const packageJson = await readJsonValue(join(dir, 'package.json'))
-    if (!isRecord(packageJson)) return undefined
-    return pickAuthoredFields(packageJson[binName])
+    // Nothing to validate, so nothing to load a validator for.
+    if (dedicatedValue === undefined && !isRecord(packageJson)) return undefined
+
+    const { parseAuthoredManifest } = await schemas()
+    if (dedicatedValue !== undefined) {
+        const dedicated = parseAuthoredManifest(dedicatedValue)
+        if (dedicated) return dedicated
+    }
+    return isRecord(packageJson) ? parseAuthoredManifest(packageJson[binName]) : undefined
 }
 
 /**
  * The manifest the CLI wrote at install time, or undefined when it is missing
- * or does not describe an install.
- *
- * Every required field is checked rather than cast over, because upgrades read
- * `tag` and `owner` back to decide what to fetch: a truncated or hand-edited
- * file should read as "no manifest", which callers already handle, rather than
- * as a manifest full of undefined.
+ * or does not describe an install this version can read.
  */
 export async function readInstalledManifest(
     dir: string,
     binName: string,
 ): Promise<InstalledManifest | undefined> {
     const value = await readJsonValue(join(dir, manifestFileName(binName)))
-    if (!isRecord(value)) return undefined
-
-    const strings = ['owner', 'name', 'host', 'tag', 'asset', 'installedAt'] as const
-    if (strings.some((field) => typeof value[field] !== 'string')) return undefined
-    if (typeof value.pinned !== 'boolean') return undefined
-    if (value.sha256 !== undefined && typeof value.sha256 !== 'string') return undefined
-
-    // This file is written by the CLI, so a version it does not recognise
-    // means a newer CLI wrote it. Reading it as though it were this format
-    // would be guessing; treating it as absent makes callers say the
-    // extension needs reinstalling, which is the truth.
-    if (typeof value.manifestVersion === 'number' && value.manifestVersion > MANIFEST_VERSION) {
-        return undefined
-    }
-
-    return {
-        owner: value.owner as string,
-        name: value.name as string,
-        host: value.host as string,
-        tag: value.tag as string,
-        asset: value.asset as string,
-        installedAt: value.installedAt as string,
-        pinned: value.pinned,
-        sha256: value.sha256 as string | undefined,
-        ...pickAuthoredFields(value),
-    }
+    if (value === undefined) return undefined
+    return (await schemas()).parseInstalledManifest(value)
 }
 
 export async function writeInstalledManifest(

--- a/src/lib/extensions/manifest.ts
+++ b/src/lib/extensions/manifest.ts
@@ -1,0 +1,114 @@
+/**
+ * Reading and writing the two manifest files.
+ *
+ * `<bin>-extension.json` is written by the extension author and is optional.
+ * `.<bin>-manifest.json` is written by the CLI for binary installs, which have
+ * no repository on disk to read the authored file from. The CLI-written file is
+ * dot-prefixed so it cannot collide with anything the extension itself ships.
+ */
+
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { authoredManifestFileName, manifestFileName } from './source.js'
+import type { AuthoredManifest, InstalledManifest } from './types.js'
+
+async function readJson(path: string): Promise<unknown | undefined> {
+    let raw: string
+    try {
+        raw = await readFile(path, 'utf8')
+    } catch {
+        return undefined
+    }
+    try {
+        return JSON.parse(raw)
+    } catch {
+        return undefined
+    }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function pickAuthoredFields(value: unknown): AuthoredManifest | undefined {
+    if (!isRecord(value)) return undefined
+    const manifest: AuthoredManifest = {}
+    if (typeof value.description === 'string') manifest.description = value.description
+    if (isRecord(value.requires)) {
+        const requires: Record<string, string> = {}
+        for (const [key, range] of Object.entries(value.requires)) {
+            if (typeof range === 'string') requires[key] = range
+        }
+        if (Object.keys(requires).length > 0) manifest.requires = requires
+    }
+    if (typeof value.completion === 'boolean') manifest.completion = value.completion
+    return manifest
+}
+
+/**
+ * Author metadata for an extension, from `<bin>-extension.json` or, for Node
+ * extensions that would rather not carry a second file, the `<bin>` key of
+ * `package.json`. The dedicated file wins when both exist.
+ */
+export async function readAuthoredManifest(
+    dir: string,
+    binName: string,
+): Promise<AuthoredManifest | undefined> {
+    const dedicated = pickAuthoredFields(
+        await readJson(join(dir, authoredManifestFileName(binName))),
+    )
+    if (dedicated) return dedicated
+
+    const packageJson = await readJson(join(dir, 'package.json'))
+    if (!isRecord(packageJson)) return undefined
+    return pickAuthoredFields(packageJson[binName])
+}
+
+export async function readInstalledManifest(
+    dir: string,
+    binName: string,
+): Promise<InstalledManifest | undefined> {
+    const value = await readJson(join(dir, manifestFileName(binName)))
+    if (!isRecord(value)) return undefined
+    if (typeof value.name !== 'string' || typeof value.owner !== 'string') return undefined
+    return value as InstalledManifest
+}
+
+export async function writeInstalledManifest(
+    dir: string,
+    binName: string,
+    manifest: InstalledManifest,
+): Promise<void> {
+    await writeFile(
+        join(dir, manifestFileName(binName)),
+        `${JSON.stringify(manifest, null, 2)}\n`,
+        {
+            mode: 0o600,
+        },
+    )
+}
+
+/**
+ * Manifest problems worth reporting in `doctor`: a file that exists but does
+ * not parse, or parses to something that is not an object. Missing files are
+ * not a problem — both manifests are optional.
+ */
+export async function findManifestProblems(dir: string, binName: string): Promise<string[]> {
+    const problems: string[] = []
+    for (const fileName of [authoredManifestFileName(binName), manifestFileName(binName)]) {
+        const path = join(dir, fileName)
+        let raw: string
+        try {
+            raw = await readFile(path, 'utf8')
+        } catch {
+            continue
+        }
+        try {
+            const parsed: unknown = JSON.parse(raw)
+            if (!isRecord(parsed)) problems.push(`${fileName} is not a JSON object`)
+        } catch {
+            problems.push(`${fileName} is not valid JSON`)
+        }
+    }
+    return problems
+}

--- a/src/lib/extensions/manifest.ts
+++ b/src/lib/extensions/manifest.ts
@@ -16,26 +16,6 @@ import { isRecord, readJsonFile, readJsonValue, writeJsonFile } from './json-fil
 import { authoredManifestFileName, manifestFileName } from './source.js'
 import type { AuthoredManifest, InstalledManifest } from './types.js'
 
-/** The manifest format this CLI writes and knows how to read in full. */
-export const MANIFEST_VERSION = 1
-
-/** The version a manifest declares, defaulting to the original format. */
-export function manifestVersionOf(manifest: AuthoredManifest | undefined): number {
-    return manifest?.manifestVersion ?? MANIFEST_VERSION
-}
-
-/**
- * True when a manifest was written to a format newer than this CLI knows.
- *
- * Such a manifest is still read for the fields this version understands. The
- * extension itself is an executable and runs regardless: refusing to run it
- * over the shape of a metadata file would break a working extension on a CLI
- * downgrade, which is the failure the `requires` warning already avoids.
- */
-export function isFromNewerFormat(manifest: AuthoredManifest | undefined): boolean {
-    return manifestVersionOf(manifest) > MANIFEST_VERSION
-}
-
 async function schemas() {
     return import('./schemas.js')
 }

--- a/src/lib/extensions/manifest.ts
+++ b/src/lib/extensions/manifest.ts
@@ -13,6 +13,31 @@ import { authoredManifestFileName, manifestFileName } from './source.js'
 import type { AuthoredManifest, InstalledManifest } from './types.js'
 
 /**
+ * The manifest format this CLI writes and knows how to read in full.
+ *
+ * A file without a version is this one: the field was introduced with the
+ * format, so its absence can only mean the first version.
+ */
+export const MANIFEST_VERSION = 1
+
+/** The version a manifest declares, defaulting to the original format. */
+export function manifestVersionOf(manifest: AuthoredManifest | undefined): number {
+    return manifest?.manifestVersion ?? MANIFEST_VERSION
+}
+
+/**
+ * True when a manifest was written to a format newer than this CLI knows.
+ *
+ * Such a manifest is still read for the fields this version understands. The
+ * extension itself is an executable and runs regardless: refusing to run it
+ * over the shape of a metadata file would break a working extension on a CLI
+ * downgrade, which is the failure the `requires` warning already avoids.
+ */
+export function isFromNewerFormat(manifest: AuthoredManifest | undefined): boolean {
+    return manifestVersionOf(manifest) > MANIFEST_VERSION
+}
+
+/**
  * Take only the fields this system understands, and only when they are the
  * right type. A manifest is written by hand, so a wrong type is likelier than
  * a missing field and neither should stop an extension from working.
@@ -20,6 +45,11 @@ import type { AuthoredManifest, InstalledManifest } from './types.js'
 export function pickAuthoredFields(value: unknown): AuthoredManifest | undefined {
     if (!isRecord(value)) return undefined
     const manifest: AuthoredManifest = {}
+    // Kept whatever it says, including a version this CLI does not know, so
+    // callers can tell the user why some of the metadata was ignored.
+    if (typeof value.manifestVersion === 'number' && Number.isInteger(value.manifestVersion)) {
+        manifest.manifestVersion = value.manifestVersion
+    }
     if (typeof value.description === 'string') manifest.description = value.description
     if (isRecord(value.requires)) {
         const requires: Record<string, string> = {}
@@ -71,6 +101,14 @@ export async function readInstalledManifest(
     if (strings.some((field) => typeof value[field] !== 'string')) return undefined
     if (typeof value.pinned !== 'boolean') return undefined
     if (value.sha256 !== undefined && typeof value.sha256 !== 'string') return undefined
+
+    // This file is written by the CLI, so a version it does not recognise
+    // means a newer CLI wrote it. Reading it as though it were this format
+    // would be guessing; treating it as absent makes callers say the
+    // extension needs reinstalling, which is the truth.
+    if (typeof value.manifestVersion === 'number' && value.manifestVersion > MANIFEST_VERSION) {
+        return undefined
+    }
 
     return {
         owner: value.owner as string,

--- a/src/lib/extensions/schemas.ts
+++ b/src/lib/extensions/schemas.ts
@@ -1,0 +1,133 @@
+/**
+ * The shape of every file the extension system reads.
+ *
+ * Schemas rather than hand-written checks, because two of these files are
+ * written by people: an author's manifest comes from a repository this CLI
+ * does not control, and the state file sits in a directory the user can edit.
+ * One schema per file gives the type and the validation together, so they
+ * cannot drift.
+ *
+ * This module is the only place that imports zod, and it is only ever loaded
+ * through a dynamic import, when a file actually needs parsing. Discovery runs
+ * on every invocation of the CLI, and importing a validation library on the
+ * way to `--version` would be a cost paid by everyone for nothing. The types
+ * are re-exported elsewhere with `import type`, which TypeScript erases, so
+ * naming one never drags zod into the startup path.
+ */
+
+import { z } from 'zod'
+
+/**
+ * The manifest format this CLI writes and knows how to read in full.
+ *
+ * A file without a version is this one: the field arrived with the format, so
+ * its absence can only mean the first version.
+ */
+export const MANIFEST_VERSION = 1
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Version ranges keyed by binary name, e.g. `{ td: '>=4.0.0' }`.
+ *
+ * Entries that are not strings are dropped rather than failing the whole
+ * field: one malformed entry should not cost the extension a requirement it
+ * expressed correctly for another CLI.
+ */
+const requiresSchema = z
+    .preprocess(
+        (value) =>
+            isPlainObject(value)
+                ? Object.fromEntries(
+                      Object.entries(value).filter(([, range]) => typeof range === 'string'),
+                  )
+                : value,
+        z.record(z.string(), z.string()),
+    )
+    // An empty map asks for nothing, so it is not worth carrying.
+    .transform((requires) => (Object.keys(requires).length > 0 ? requires : undefined))
+
+/**
+ * Unknown keys are dropped rather than rejected, which is what lets the format
+ * grow: an extension written for a later CLI still reads correctly here, minus
+ * the parts this version has no meaning for.
+ */
+const authoredManifestSchema = z.object({
+    manifestVersion: z.int().positive().optional(),
+    description: z.string().optional(),
+    requires: requiresSchema.optional(),
+    /** Opt-in to the argument-completion protocol. Unused for now. */
+    completion: z.boolean().optional(),
+})
+
+/**
+ * Written by the CLI for binary installs, and read back to decide what to
+ * fetch on an upgrade, so every field it promises has to be there.
+ */
+const installedManifestSchema = authoredManifestSchema.extend({
+    owner: z.string().min(1),
+    /** Directory name, e.g. `td-goals`. */
+    name: z.string().min(1),
+    host: z.string().min(1),
+    tag: z.string().min(1),
+    pinned: z.boolean(),
+    asset: z.string().min(1),
+    sha256: z.string().optional(),
+    installedAt: z.string().min(1),
+})
+
+/** Bookkeeping the CLI keeps beside an extension, all of it optional. */
+const extensionStateSchema = z.object({
+    /** Git ref or release tag this extension is held at, if pinned. */
+    pinned: z.string().optional(),
+    checkedForUpdateAt: z.string().optional(),
+    latestRelease: z.string().optional(),
+})
+
+export type AuthoredManifest = z.infer<typeof authoredManifestSchema>
+export type InstalledManifest = z.infer<typeof installedManifestSchema>
+export type ExtensionState = z.infer<typeof extensionStateSchema>
+
+/**
+ * Take the fields the schema describes and drop everything else.
+ *
+ * Both manifests are hand-written, so a wrong type is likelier than a missing
+ * field, and neither should stop an extension from working. When the whole
+ * object does not validate, each field is tried on its own, so one bad entry
+ * does not discard an otherwise usable manifest.
+ */
+function pickValid<T extends z.ZodObject>(schema: T, value: unknown): z.infer<T> | undefined {
+    if (!isPlainObject(value)) return undefined
+
+    const parsed = schema.safeParse(value)
+    if (parsed.success) return parsed.data
+
+    const kept: Record<string, unknown> = {}
+    for (const [key, fieldSchema] of Object.entries(schema.shape)) {
+        const field = (fieldSchema as z.ZodType).safeParse(value[key])
+        if (field.success && field.data !== undefined) kept[key] = field.data
+    }
+    return kept as z.infer<T>
+}
+
+export function parseAuthoredManifest(value: unknown): AuthoredManifest | undefined {
+    return pickValid(authoredManifestSchema, value)
+}
+
+/**
+ * Strict, unlike the authored manifest: this file is the CLI's own record, so
+ * a shape it does not recognise means a different version of the CLI wrote it,
+ * and reading it anyway would be guessing.
+ */
+export function parseInstalledManifest(value: unknown): InstalledManifest | undefined {
+    const parsed = installedManifestSchema.safeParse(value)
+    if (!parsed.success) return undefined
+    if ((parsed.data.manifestVersion ?? MANIFEST_VERSION) > MANIFEST_VERSION) return undefined
+    return parsed.data
+}
+
+export function parseExtensionState(value: unknown): ExtensionState {
+    return pickValid(extensionStateSchema, value) ?? {}
+}

--- a/src/lib/extensions/schemas.ts
+++ b/src/lib/extensions/schemas.ts
@@ -16,14 +16,7 @@
  */
 
 import { z } from 'zod'
-
-/**
- * The manifest format this CLI writes and knows how to read in full.
- *
- * A file without a version is this one: the field arrived with the format, so
- * its absence can only mean the first version.
- */
-export const MANIFEST_VERSION = 1
+import { MANIFEST_VERSION } from './manifest-format.js'
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value)

--- a/src/lib/extensions/source.test.ts
+++ b/src/lib/extensions/source.test.ts
@@ -66,37 +66,59 @@ describe('parseSource', () => {
     })
 
     it('parses a full GitHub URL and strips the .git suffix', () => {
-        const parsed = parseSource('https://github.com/example/td-standup.git')
-        expect(parsed).toMatchObject({
+        // The whole object, because `url` is what install clones from.
+        expect(parseSource('https://github.com/example/td-standup.git')).toEqual({
             type: 'git',
             host: 'github.com',
             owner: 'example',
             repo: 'td-standup',
+            url: 'https://github.com/example/td-standup.git',
             isGitHub: true,
         })
     })
 
     it('marks a non-GitHub host so the API is never used for it', () => {
-        const parsed = parseSource('https://git.example.com/Doist/td-x')
-        expect(parsed).toMatchObject({ host: 'git.example.com', owner: 'Doist', isGitHub: false })
+        expect(parseSource('https://git.example.com/Doist/td-x')).toEqual({
+            type: 'git',
+            host: 'git.example.com',
+            owner: 'Doist',
+            repo: 'td-x',
+            url: 'https://git.example.com/Doist/td-x',
+            isGitHub: false,
+        })
     })
 
     it('parses scp-style git remotes', () => {
-        expect(parseSource('git@github.com:Doist/td-goals.git')).toMatchObject({
+        expect(parseSource('git@github.com:Doist/td-goals.git')).toEqual({
             type: 'git',
             host: 'github.com',
             owner: 'Doist',
             repo: 'td-goals',
+            url: 'git@github.com:Doist/td-goals.git',
             isGitHub: true,
         })
     })
 
-    it.each(['.', './td-scratch', '../td-scratch', '/tmp/td-scratch', '~/code/td-scratch'])(
-        'treats %s as a local path',
-        (source) => {
-            expect(parseSource(source)).toEqual({ type: 'local', path: source })
-        },
-    )
+    it('recognises the host however it was capitalised', () => {
+        expect(parseSource('git@GitHub.com:Doist/td-goals.git')).toMatchObject({
+            host: 'github.com',
+            isGitHub: true,
+        })
+        expect(parseRepoRef('https://GITHUB.com/Doist/td-goals')?.host).toBe('github.com')
+    })
+
+    it.each([
+        '.',
+        './td-scratch',
+        '../td-scratch',
+        '/tmp/td-scratch',
+        '~/code/td-scratch',
+        '.\\td-scratch',
+        '..\\td-scratch',
+        'C:\\code\\td-scratch',
+    ])('treats %s as a local path', (source) => {
+        expect(parseSource(source)).toEqual({ type: 'local', path: source })
+    })
 
     it('refuses input that names neither a repository nor a path', () => {
         expect(() => parseSource('not a source')).toThrow(/Cannot work out/)

--- a/src/lib/extensions/source.test.ts
+++ b/src/lib/extensions/source.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import {
+    authoredManifestFileName,
+    manifestFileName,
+    normalizeSelector,
+    parseRepoRef,
+    parseSource,
+    toCommandName,
+    toDirName,
+    validateExtensionName,
+} from './source.js'
+
+describe('naming', () => {
+    it('derives directory and command names from the host binary name', () => {
+        expect(toDirName('td', 'goals')).toBe('td-goals')
+        expect(toDirName('td', 'td-goals')).toBe('td-goals')
+        expect(toCommandName('td', 'td-goals')).toBe('goals')
+        expect(toCommandName('tdc', 'tdc-standup')).toBe('standup')
+    })
+
+    it('derives both manifest filenames from the host binary name', () => {
+        expect(authoredManifestFileName('td')).toBe('td-extension.json')
+        expect(manifestFileName('td')).toBe('.td-manifest.json')
+        expect(manifestFileName('tdc')).toBe('.tdc-manifest.json')
+    })
+
+    it('accepts a bare name, a prefixed name or an owner-qualified name', () => {
+        expect(normalizeSelector('td', 'goals')).toBe('goals')
+        expect(normalizeSelector('td', 'td-goals')).toBe('goals')
+        expect(normalizeSelector('td', 'Doist/td-goals')).toBe('goals')
+    })
+
+    it.each(['td-goals', 'td-weekly-review', 'td-g2'])('accepts %s', (name) => {
+        expect(() => validateExtensionName('td', name)).not.toThrow()
+    })
+
+    it.each(['goals', 'td-', 'td-Goals', 'td--x', 'tdgoals'])('rejects %s', (name) => {
+        expect(() => validateExtensionName('td', name)).toThrow(/not a valid extension name/)
+    })
+})
+
+describe('parseRepoRef', () => {
+    it.each([
+        ['https://github.com/Doist/td-goals.git', 'github.com', 'Doist', 'td-goals'],
+        ['https://git.example.com/Doist/td-goals', 'git.example.com', 'Doist', 'td-goals'],
+        ['git@github.com:example/td-standup.git', 'github.com', 'example', 'td-standup'],
+    ])('parses %s', (url, host, owner, repo) => {
+        expect(parseRepoRef(url)).toEqual({ host, owner, repo })
+    })
+
+    it('returns undefined for something that is not a remote', () => {
+        expect(parseRepoRef('not-a-remote')).toBeUndefined()
+    })
+})
+
+describe('parseSource', () => {
+    it('treats owner/repo as GitHub', () => {
+        expect(parseSource('Doist/td-goals')).toEqual({
+            type: 'git',
+            host: 'github.com',
+            owner: 'Doist',
+            repo: 'td-goals',
+            url: 'https://github.com/Doist/td-goals.git',
+            isGitHub: true,
+        })
+    })
+
+    it('parses a full GitHub URL and strips the .git suffix', () => {
+        const parsed = parseSource('https://github.com/example/td-standup.git')
+        expect(parsed).toMatchObject({
+            type: 'git',
+            host: 'github.com',
+            owner: 'example',
+            repo: 'td-standup',
+            isGitHub: true,
+        })
+    })
+
+    it('marks a non-GitHub host so the API is never used for it', () => {
+        const parsed = parseSource('https://git.example.com/Doist/td-x')
+        expect(parsed).toMatchObject({ host: 'git.example.com', owner: 'Doist', isGitHub: false })
+    })
+
+    it('parses scp-style git remotes', () => {
+        expect(parseSource('git@github.com:Doist/td-goals.git')).toMatchObject({
+            type: 'git',
+            host: 'github.com',
+            owner: 'Doist',
+            repo: 'td-goals',
+            isGitHub: true,
+        })
+    })
+
+    it.each(['.', './td-scratch', '../td-scratch', '/tmp/td-scratch', '~/code/td-scratch'])(
+        'treats %s as a local path',
+        (source) => {
+            expect(parseSource(source)).toEqual({ type: 'local', path: source })
+        },
+    )
+
+    it('refuses input that names neither a repository nor a path', () => {
+        expect(() => parseSource('not a source')).toThrow(/Cannot work out/)
+    })
+})

--- a/src/lib/extensions/source.ts
+++ b/src/lib/extensions/source.ts
@@ -64,7 +64,14 @@ export function parseRepoRef(
 ): { host: string; owner: string; repo: string } | undefined {
     const scpLike = url.match(/^(?:[^@]+@)?([^:/]+):(.+?)\/([^/]+?)(?:\.git)?$/)
     if (scpLike && !url.includes('://')) {
-        return { host: scpLike[1], owner: scpLike[2], repo: stripGitSuffix(scpLike[3]) }
+        // Hostnames are case-insensitive, and `new URL` lowercases them, so the
+        // scp-like form has to as well. Otherwise whether an extension counts
+        // as first-party would depend on how the user typed the remote.
+        return {
+            host: scpLike[1].toLowerCase(),
+            owner: scpLike[2],
+            repo: stripGitSuffix(scpLike[3]),
+        }
     }
 
     try {

--- a/src/lib/extensions/source.ts
+++ b/src/lib/extensions/source.ts
@@ -1,0 +1,148 @@
+/**
+ * Naming rules and install-source parsing.
+ *
+ * Every filename convention in the extension system derives from the host's
+ * binary name: `td` gives directories named `td-<name>`, an author manifest of
+ * `td-extension.json` and a CLI-written manifest of `.td-manifest.json`.
+ */
+
+import { isAbsolute } from 'node:path'
+import { CliError } from '@doist/cli-core'
+
+/** Directory (and executable) name for a command name: `goals` → `td-goals`. */
+export function toDirName(binName: string, name: string): string {
+    return name.startsWith(`${binName}-`) ? name : `${binName}-${name}`
+}
+
+/** Command name for a directory name: `td-goals` → `goals`. */
+export function toCommandName(binName: string, dirName: string): string {
+    const prefix = `${binName}-`
+    return dirName.startsWith(prefix) ? dirName.slice(prefix.length) : dirName
+}
+
+/** Name of the manifest the CLI writes for binary installs. */
+export function manifestFileName(binName: string): string {
+    return `.${binName}-manifest.json`
+}
+
+/** Name of the manifest an extension author ships. */
+export function authoredManifestFileName(binName: string): string {
+    return `${binName}-extension.json`
+}
+
+/**
+ * Accepts `goals`, `td-goals` or `Doist/td-goals` and returns the command
+ * name. Used by `remove`, `upgrade` and `exec`, which all take a loose ref.
+ */
+export function normalizeSelector(binName: string, selector: string): string {
+    const withoutOwner = selector.includes('/') ? (selector.split('/').pop() ?? selector) : selector
+    return toCommandName(binName, withoutOwner)
+}
+
+export function validateExtensionName(binName: string, dirName: string): void {
+    const pattern = new RegExp(`^${binName}-[a-z0-9][a-z0-9-]*$`)
+    if (!pattern.test(dirName)) {
+        throw new CliError(
+            'EXTENSION_NAME_INVALID',
+            `"${dirName}" is not a valid extension name.`,
+            {
+                hints: [
+                    `Extension repositories must be named ${binName}-<name>, lowercase, starting with a letter or digit.`,
+                ],
+            },
+        )
+    }
+}
+
+/**
+ * Host, owner and repository of a git remote, in either the URL or the
+ * scp-like form. Both `parseSource` and extension discovery route through
+ * this, so the two cannot drift apart.
+ */
+export function parseRepoRef(
+    url: string,
+): { host: string; owner: string; repo: string } | undefined {
+    const scpLike = url.match(/^(?:[^@]+@)?([^:/]+):(.+?)\/([^/]+?)(?:\.git)?$/)
+    if (scpLike && !url.includes('://')) {
+        return { host: scpLike[1], owner: scpLike[2], repo: stripGitSuffix(scpLike[3]) }
+    }
+
+    try {
+        const parsed = new URL(url)
+        const segments = parsed.pathname.split('/').filter(Boolean)
+        if (segments.length < 2) return undefined
+        return {
+            host: parsed.host,
+            owner: segments[segments.length - 2],
+            repo: stripGitSuffix(segments[segments.length - 1]),
+        }
+    } catch {
+        return undefined
+    }
+}
+
+export type ParsedSource =
+    | { type: 'local'; path: string }
+    | { type: 'git'; host: string; owner: string; repo: string; url: string; isGitHub: boolean }
+
+const GITHUB_HOST = 'github.com'
+
+function stripGitSuffix(repo: string): string {
+    return repo.endsWith('.git') ? repo.slice(0, -'.git'.length) : repo
+}
+
+function looksLikeLocalPath(source: string): boolean {
+    if (source === '.' || source === '..') return true
+    if (source.startsWith('./') || source.startsWith('../')) return true
+    if (source.startsWith('~/')) return true
+    if (source.startsWith('.\\') || source.startsWith('..\\')) return true
+    if (isAbsolute(source)) return true
+    // Windows drive-relative paths such as `C:foo` are not worth supporting.
+    return /^[a-zA-Z]:[\\/]/.test(source)
+}
+
+/**
+ * Work out what an install source refers to. A bare `owner/repo` means
+ * GitHub; any other URL is cloned with git and never touches the GitHub API.
+ */
+export function parseSource(source: string): ParsedSource {
+    if (looksLikeLocalPath(source)) {
+        return { type: 'local', path: source }
+    }
+
+    if (source.includes('://') || /^(?:[^@\s]+@)?[^:/\s]+:/.test(source)) {
+        const ref = parseRepoRef(source)
+        if (!ref) {
+            throw new CliError(
+                'EXTENSION_NOT_INSTALLABLE',
+                `"${source}" does not look like a repository URL.`,
+                { hints: ['Expected a URL ending in <owner>/<repo>.'] },
+            )
+        }
+        return {
+            type: 'git',
+            host: ref.host,
+            owner: ref.owner,
+            repo: ref.repo,
+            url: source,
+            isGitHub: ref.host === GITHUB_HOST,
+        }
+    }
+
+    const shorthand = source.match(/^([^/\s]+)\/([^/\s]+)$/)
+    if (shorthand) {
+        const [, owner, repo] = shorthand
+        return {
+            type: 'git',
+            host: GITHUB_HOST,
+            owner,
+            repo: stripGitSuffix(repo),
+            url: `https://${GITHUB_HOST}/${owner}/${stripGitSuffix(repo)}.git`,
+            isGitHub: true,
+        }
+    }
+
+    throw new CliError('EXTENSION_NOT_INSTALLABLE', `Cannot work out what "${source}" refers to.`, {
+        hints: ['Use <owner>/<repo>, a full repository URL, or a path to a local directory.'],
+    })
+}

--- a/src/lib/extensions/state.test.ts
+++ b/src/lib/extensions/state.test.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { readState, removeState, stateFilePath, writeState } from './state.js'
+
+describe('extension state', () => {
+    let stateDir: string
+
+    beforeEach(async () => {
+        stateDir = await mkdtemp(join(tmpdir(), 'td-ext-state-'))
+    })
+
+    afterEach(async () => {
+        await rm(stateDir, { recursive: true, force: true })
+    })
+
+    it('round-trips, creating the directory it needs', async () => {
+        await writeState(stateDir, 'td-goals', { pinned: 'v1.2.3', latestRelease: 'v2.0.0' })
+
+        await expect(readState(stateDir, 'td-goals')).resolves.toEqual({
+            pinned: 'v1.2.3',
+            latestRelease: 'v2.0.0',
+        })
+    })
+
+    it('reports an empty state when nothing has been written', async () => {
+        await expect(readState(stateDir, 'td-unknown')).resolves.toEqual({})
+    })
+
+    it('survives a state file that has been edited into nonsense', async () => {
+        const path = stateFilePath(stateDir, 'td-goals')
+        await writeState(stateDir, 'td-goals', {})
+        await writeFile(path, '{ not json')
+
+        // A hand-edited state file must not stop the CLI from running.
+        await expect(readState(stateDir, 'td-goals')).resolves.toEqual({})
+    })
+
+    it('ignores fields that are not the type the rest of the system expects', async () => {
+        await writeState(stateDir, 'td-goals', {})
+        await writeFile(
+            stateFilePath(stateDir, 'td-goals'),
+            JSON.stringify({ pinned: 5, latestRelease: 'v2.0.0' }),
+        )
+
+        await expect(readState(stateDir, 'td-goals')).resolves.toEqual({
+            latestRelease: 'v2.0.0',
+        })
+    })
+
+    it('treats a JSON array as no state at all', async () => {
+        await writeState(stateDir, 'td-goals', {})
+        await writeFile(stateFilePath(stateDir, 'td-goals'), '["pinned"]')
+
+        await expect(readState(stateDir, 'td-goals')).resolves.toEqual({})
+    })
+
+    it('writes the file for its owner only', async () => {
+        await writeState(stateDir, 'td-goals', { pinned: 'v1' })
+
+        expect((await stat(stateFilePath(stateDir, 'td-goals'))).mode & 0o777).toBe(0o600)
+    })
+
+    it('removes a state file, and stays quiet when there is none', async () => {
+        await writeState(stateDir, 'td-goals', { pinned: 'v1' })
+        await removeState(stateDir, 'td-goals')
+
+        await expect(readState(stateDir, 'td-goals')).resolves.toEqual({})
+        await expect(removeState(stateDir, 'td-goals')).resolves.toBeUndefined()
+    })
+
+    it('puts state under an extensions directory of its own', () => {
+        expect(stateFilePath('/state', 'td-goals')).toBe('/state/extensions/td-goals.json')
+        expect(dirname(stateFilePath('/state', 'td-goals'))).toBe('/state/extensions')
+    })
+})

--- a/src/lib/extensions/state.ts
+++ b/src/lib/extensions/state.ts
@@ -5,8 +5,9 @@
  * uninstall, and so a `git pull` can never clobber it.
  */
 
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, rm } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+import { isRecord, readJsonValue, writeJsonFile } from './json-file.js'
 
 export type ExtensionState = {
     /** Git ref or release tag this extension is held at, if pinned. */
@@ -19,15 +20,23 @@ export function stateFilePath(stateDir: string, dirName: string): string {
     return join(stateDir, 'extensions', `${dirName}.json`)
 }
 
+/**
+ * The recorded state, or an empty one. The file is in the user's state
+ * directory and can be edited by hand, so each field is taken only when it is
+ * the type the rest of the system expects; anything else is treated as absent
+ * rather than being handed on as a string that is not a string.
+ */
 export async function readState(stateDir: string, dirName: string): Promise<ExtensionState> {
-    try {
-        const raw = await readFile(stateFilePath(stateDir, dirName), 'utf8')
-        const parsed: unknown = JSON.parse(raw)
-        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
-        return parsed as ExtensionState
-    } catch {
-        return {}
+    const value = await readJsonValue(stateFilePath(stateDir, dirName))
+    if (!isRecord(value)) return {}
+
+    const state: ExtensionState = {}
+    if (typeof value.pinned === 'string') state.pinned = value.pinned
+    if (typeof value.checkedForUpdateAt === 'string') {
+        state.checkedForUpdateAt = value.checkedForUpdateAt
     }
+    if (typeof value.latestRelease === 'string') state.latestRelease = value.latestRelease
+    return state
 }
 
 export async function writeState(
@@ -37,7 +46,7 @@ export async function writeState(
 ): Promise<void> {
     const path = stateFilePath(stateDir, dirName)
     await mkdir(dirname(path), { recursive: true })
-    await writeFile(path, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 })
+    await writeJsonFile(path, state)
 }
 
 export async function removeState(stateDir: string, dirName: string): Promise<void> {

--- a/src/lib/extensions/state.ts
+++ b/src/lib/extensions/state.ts
@@ -1,0 +1,45 @@
+/**
+ * Per-extension state that is not part of the extension itself: the pin, and
+ * the bookkeeping a future update notice will need. It lives outside the
+ * extension directory so that deleting the directory by hand is still a clean
+ * uninstall, and so a `git pull` can never clobber it.
+ */
+
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+export type ExtensionState = {
+    /** Git ref or release tag this extension is held at, if pinned. */
+    pinned?: string
+    checkedForUpdateAt?: string
+    latestRelease?: string
+}
+
+export function stateFilePath(stateDir: string, dirName: string): string {
+    return join(stateDir, 'extensions', `${dirName}.json`)
+}
+
+export async function readState(stateDir: string, dirName: string): Promise<ExtensionState> {
+    try {
+        const raw = await readFile(stateFilePath(stateDir, dirName), 'utf8')
+        const parsed: unknown = JSON.parse(raw)
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
+        return parsed as ExtensionState
+    } catch {
+        return {}
+    }
+}
+
+export async function writeState(
+    stateDir: string,
+    dirName: string,
+    state: ExtensionState,
+): Promise<void> {
+    const path = stateFilePath(stateDir, dirName)
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 })
+}
+
+export async function removeState(stateDir: string, dirName: string): Promise<void> {
+    await rm(stateFilePath(stateDir, dirName), { force: true })
+}

--- a/src/lib/extensions/state.ts
+++ b/src/lib/extensions/state.ts
@@ -7,14 +7,10 @@
 
 import { mkdir, rm } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
-import { isRecord, readJsonValue, writeJsonFile } from './json-file.js'
+import { readJsonValue, writeJsonFile } from './json-file.js'
+import type { ExtensionState } from './schemas.js'
 
-export type ExtensionState = {
-    /** Git ref or release tag this extension is held at, if pinned. */
-    pinned?: string
-    checkedForUpdateAt?: string
-    latestRelease?: string
-}
+export type { ExtensionState }
 
 export function stateFilePath(stateDir: string, dirName: string): string {
     return join(stateDir, 'extensions', `${dirName}.json`)
@@ -28,15 +24,9 @@ export function stateFilePath(stateDir: string, dirName: string): string {
  */
 export async function readState(stateDir: string, dirName: string): Promise<ExtensionState> {
     const value = await readJsonValue(stateFilePath(stateDir, dirName))
-    if (!isRecord(value)) return {}
-
-    const state: ExtensionState = {}
-    if (typeof value.pinned === 'string') state.pinned = value.pinned
-    if (typeof value.checkedForUpdateAt === 'string') {
-        state.checkedForUpdateAt = value.checkedForUpdateAt
-    }
-    if (typeof value.latestRelease === 'string') state.latestRelease = value.latestRelease
-    return state
+    // No file, nothing to validate, and no reason to load a validator.
+    if (value === undefined) return {}
+    return (await import('./schemas.js')).parseExtensionState(value)
 }
 
 export async function writeState(

--- a/src/lib/extensions/types.ts
+++ b/src/lib/extensions/types.ts
@@ -15,37 +15,13 @@
 export type ExtensionKind = 'binary' | 'git' | 'local'
 
 /**
- * Metadata an extension author ships in `<bin>-extension.json`.
- *
- * `manifestVersion` is what makes a breaking change to this format possible
- * later. It cannot be migrated, because the file lives in someone else's
- * repository, so it exists to let two shapes coexist: the CLI reads the
- * version first and interprets the rest accordingly. It governs how the
- * metadata is read and never whether the extension runs, because an extension
- * is an executable and this file only describes it.
+ * The two manifest shapes are defined by their schemas, so the type and the
+ * validation cannot drift. Re-exported as types only, which TypeScript erases,
+ * so naming one here never pulls the validation library into the startup path.
  */
-export type AuthoredManifest = {
-    /** Format version. Absent means 1, the version this CLI writes and reads. */
-    manifestVersion?: number
-    description?: string
-    /** Host version ranges, keyed by binary name, e.g. `{ td: '>=4.0.0' }`. */
-    requires?: Record<string, string>
-    /** Opt-in to the argument-completion protocol. Unused for now. */
-    completion?: boolean
-}
+import type { AuthoredManifest, InstalledManifest } from './schemas.js'
 
-/** Metadata the CLI writes for binary installs, in `.<bin>-manifest.json`. */
-export type InstalledManifest = AuthoredManifest & {
-    owner: string
-    /** Directory name, e.g. `td-goals`. */
-    name: string
-    host: string
-    tag: string
-    pinned: boolean
-    asset: string
-    sha256?: string
-    installedAt: string
-}
+export type { AuthoredManifest, InstalledManifest }
 
 /** One installed extension, as discovered on disk. */
 export type Extension = {

--- a/src/lib/extensions/types.ts
+++ b/src/lib/extensions/types.ts
@@ -14,8 +14,19 @@
  */
 export type ExtensionKind = 'binary' | 'git' | 'local'
 
-/** Metadata an extension author ships in `<bin>-extension.json`. */
+/**
+ * Metadata an extension author ships in `<bin>-extension.json`.
+ *
+ * `manifestVersion` is what makes a breaking change to this format possible
+ * later. It cannot be migrated, because the file lives in someone else's
+ * repository, so it exists to let two shapes coexist: the CLI reads the
+ * version first and interprets the rest accordingly. It governs how the
+ * metadata is read and never whether the extension runs, because an extension
+ * is an executable and this file only describes it.
+ */
 export type AuthoredManifest = {
+    /** Format version. Absent means 1, the version this CLI writes and reads. */
+    manifestVersion?: number
     description?: string
     /** Host version ranges, keyed by binary name, e.g. `{ td: '>=4.0.0' }`. */
     requires?: Record<string, string>

--- a/src/lib/extensions/types.ts
+++ b/src/lib/extensions/types.ts
@@ -1,0 +1,160 @@
+/**
+ * Shared types for the extension system.
+ *
+ * Everything in `src/lib/extensions/` is host-agnostic: the CLI's name, its
+ * directories, its version and its reserved command names all arrive through
+ * `ExtensionManagerOptions`. Nothing here may import from `src/commands/` or
+ * read this CLI's config, so the whole directory can move to
+ * `@doist/cli-core` unchanged.
+ */
+
+/**
+ * How an extension got onto disk, which decides how it is upgraded and
+ * removed. Inferred from the directory, never stored in a registry.
+ */
+export type ExtensionKind = 'binary' | 'git' | 'local'
+
+/** Metadata an extension author ships in `<bin>-extension.json`. */
+export type AuthoredManifest = {
+    description?: string
+    /** Host version ranges, keyed by binary name, e.g. `{ td: '>=4.0.0' }`. */
+    requires?: Record<string, string>
+    /** Opt-in to the argument-completion protocol. Unused for now. */
+    completion?: boolean
+}
+
+/** Metadata the CLI writes for binary installs, in `.<bin>-manifest.json`. */
+export type InstalledManifest = AuthoredManifest & {
+    owner: string
+    /** Directory name, e.g. `td-goals`. */
+    name: string
+    host: string
+    tag: string
+    pinned: boolean
+    asset: string
+    sha256?: string
+    installedAt: string
+}
+
+/** One installed extension, as discovered on disk. */
+export type Extension = {
+    /** Command name, e.g. `goals`. */
+    name: string
+    /** Directory name, e.g. `td-goals`. */
+    dirName: string
+    kind: ExtensionKind
+    /** Directory holding the extension (the link target for local installs). */
+    dir: string
+    /** Absolute path to the executable that `dispatch` spawns. */
+    executablePath: string
+    /** Path of the entry inside the extensions directory. */
+    entryPath: string
+    /** `owner/repo`, a git URL, or a local path — whatever `list` should show. */
+    source?: string
+    host?: string
+    owner?: string
+    pinned: boolean
+    official: boolean
+    description?: string
+    requires?: Record<string, string>
+    manifest?: InstalledManifest
+}
+
+/** An extension plus the details that cost a subprocess or extra I/O to learn. */
+export type ExtensionListing = Extension & {
+    /** Release tag for binary installs, short SHA for git, undefined for local. */
+    version?: string
+    /** True when a built-in command of the same name hides this extension. */
+    shadowed: boolean
+    /** False when the executable is missing or lacks the executable bit. */
+    executable: boolean
+}
+
+export type InstallOptions = {
+    /** Release tag or git ref to install and hold at. */
+    pin?: string
+    /** Replace an extension that is already installed. */
+    force?: boolean
+}
+
+export type InstallResult = {
+    name: string
+    dirName: string
+    kind: ExtensionKind
+    source: string
+    version?: string
+    dir: string
+}
+
+export type UpgradeOptions = {
+    force?: boolean
+    dryRun?: boolean
+}
+
+export type UpgradeOutcome = 'upgraded' | 'up-to-date' | 'skipped' | 'would-upgrade'
+
+export type UpgradeResult = {
+    name: string
+    outcome: UpgradeOutcome
+    /** Why a skip happened, or what changed on an upgrade. */
+    detail?: string
+    from?: string
+    to?: string
+}
+
+export type RemoveOptions = {
+    force?: boolean
+}
+
+export type RemoveResult = {
+    name: string
+    kind: ExtensionKind
+    /** What was deleted: the whole directory, or just the link for local installs. */
+    removed: 'directory' | 'link'
+    path: string
+}
+
+export type DispatchOptions = {
+    /** Value of `--user` seen before the command token, forwarded as `<PREFIX>_USER`. */
+    user?: string
+    /** Extra environment for the child, merged last. */
+    env?: Record<string, string | undefined>
+}
+
+/** Colour helpers. Defaults are identity functions, so the library never needs chalk. */
+export type ExtensionTheme = {
+    dim: (text: string) => string
+    bold: (text: string) => string
+    green: (text: string) => string
+    yellow: (text: string) => string
+}
+
+export type ExtensionManagerOptions = {
+    /** Binary name of the host CLI, e.g. `td`. Drives every naming convention. */
+    binName: string
+    /** Environment variable prefix for the child process, e.g. `TD`. */
+    envPrefix: string
+    /** Host version, used for `<PREFIX>_VERSION` and the `requires` check. */
+    version: string
+    /** Per-user data directory for this CLI. Extensions live in `<dataDir>/extensions`. */
+    dataDir: string
+    /** Per-user state directory for this CLI. */
+    stateDir: string
+    /** Config directory, passed to extensions as `<PREFIX>_CONFIG_DIR`. */
+    configDir: string
+    /** Absolute path to the host's entry script, passed as `<PREFIX>_PATH`. */
+    hostPath: string
+    /** Built-in command names and aliases an extension must not shadow. */
+    reservedNames: () => Iterable<string>
+    /** Install source that earns the first-party marker. */
+    officialSource: { host: string; owner: string }
+    /** Label shown for first-party extensions, e.g. `Todoist`. */
+    officialLabel: string
+    /** True when colour must not carry meaning on its own. */
+    isAccessible?: () => boolean
+    theme?: Partial<ExtensionTheme>
+    log?: (message: string) => void
+    warn?: (message: string) => void
+    /** Injectable for tests. Defaults to the global `fetch`. */
+    fetchImpl?: typeof fetch
+}


### PR DESCRIPTION
Slice 1 of 7. Replaces #520, which was one 3.7k-line PR; this is the same work split along doistbot's suggested plan, with its review feedback already applied.

The vocabulary every later slice builds on: the types describing an installed extension, the naming rules derived from the host binary name (`td` gives `td-<name>` directories, `td-extension.json` and `.td-manifest.json`), one parser shared by install sources and by git remotes read back off disk, manifest reading and writing including the `package.json` fallback for Node extensions, and per-extension state kept outside the extension directory so that deleting that directory by hand is still a clean uninstall.

Nothing is wired up yet. See [the spec](https://github.com/Doist/todoist-cli/blob/main/docs/specs/extensions.md) for where this is going.

**Stack:** #521 core · #522 discovery · #523 dispatch · #524 tools · #525 install · #526 upgrade · #527 manager