### PR TITLE
feat(extensions): discover installed extensions

### DIFF
--- a/src/lib/extensions/concurrency.test.ts
+++ b/src/lib/extensions/concurrency.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { mapWithConcurrency } from './concurrency.js'
+
+describe('mapWithConcurrency', () => {
+    it('never runs more than the limit at once', async () => {
+        let active = 0
+        let peak = 0
+
+        await mapWithConcurrency(
+            Array.from({ length: 12 }, (_, index) => index),
+            4,
+            async (item) => {
+                active += 1
+                peak = Math.max(peak, active)
+                await new Promise((resolve) => setTimeout(resolve, 5))
+                active -= 1
+                return item
+            },
+        )
+
+        expect(peak).toBeLessThanOrEqual(4)
+    })
+
+    it('keeps results in the order of the input', async () => {
+        const results = await mapWithConcurrency([3, 1, 2], 2, async (item) => {
+            await new Promise((resolve) => setTimeout(resolve, item))
+            return item * 10
+        })
+
+        expect(results).toEqual([30, 10, 20])
+    })
+
+    it('runs everything even when there are fewer items than the limit', async () => {
+        const results = await mapWithConcurrency([1, 2], 8, async (item) => item * 2)
+
+        expect(results).toEqual([2, 4])
+    })
+
+    it('does nothing, successfully, for an empty list', async () => {
+        await expect(mapWithConcurrency([], 4, async () => 'never')).resolves.toEqual([])
+    })
+})

--- a/src/lib/extensions/concurrency.ts
+++ b/src/lib/extensions/concurrency.ts
@@ -1,0 +1,29 @@
+/**
+ * Bounded parallelism.
+ *
+ * Both discovery and upgrades fan out over installed extensions, and the
+ * number of those is up to the user. Without a bound, discovery would queue
+ * filesystem work for every extension at once on each invocation, and an
+ * upgrade would fire one GitHub request per extension at once, which is what
+ * secondary rate limits are for.
+ */
+
+/** Run `worker` over every item, at most `limit` at a time, in input order. */
+export async function mapWithConcurrency<T, R>(
+    items: T[],
+    limit: number,
+    worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+    const results = Array.from<R>({ length: items.length })
+    let next = 0
+
+    const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+        while (next < items.length) {
+            const index = next++
+            results[index] = await worker(items[index])
+        }
+    })
+
+    await Promise.all(runners)
+    return results
+}

--- a/src/lib/extensions/discover.test.ts
+++ b/src/lib/extensions/discover.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { writeFakeGitRepo, writeFixtureExtension } from '../../test-support/extension-fixture.js'
-import { discoverExtensions } from './discover.js'
+import { discoverExtensions, findExtension } from './discover.js'
 import { writeState } from './state.js'
 
 const OFFICIAL = { host: 'github.com', owner: 'Doist' }
@@ -93,18 +93,21 @@ describe('discoverExtensions', () => {
         expect(extension.official).toBe(true)
     })
 
-    it('follows a local install to its target and never marks it official', async () => {
-        const workspace = join(root, 'code')
-        await mkdir(workspace, { recursive: true })
-        const target = await writeFixtureExtension(workspace, 'scratch')
-        await writeFakeGitRepo(target, 'https://github.com/Doist/td-scratch.git')
-        await symlink(target, join(extensionsDir, 'td-scratch'), 'dir')
+    it.skipIf(process.platform === 'win32')(
+        'follows a local install to its target and never marks it official',
+        async () => {
+            const workspace = join(root, 'code')
+            await mkdir(workspace, { recursive: true })
+            const target = await writeFixtureExtension(workspace, 'scratch')
+            await writeFakeGitRepo(target, 'https://github.com/Doist/td-scratch.git')
+            await symlink(target, join(extensionsDir, 'td-scratch'), 'dir')
 
-        const [extension] = await discover()
-        expect(extension).toMatchObject({ name: 'scratch', kind: 'local', official: false })
-        expect(extension.dir).toBe(target)
-        expect(extension.executablePath).toBe(join(target, 'td-scratch'))
-    })
+            const [extension] = await discover()
+            expect(extension).toMatchObject({ name: 'scratch', kind: 'local', official: false })
+            expect(extension.dir).toBe(target)
+            expect(extension.executablePath).toBe(join(target, 'td-scratch'))
+        },
+    )
 
     it('follows a Windows-style path file for a local install', async () => {
         const workspace = join(root, 'code')
@@ -114,6 +117,55 @@ describe('discoverExtensions', () => {
 
         const [extension] = await discover()
         expect(extension).toMatchObject({ kind: 'local', dir: target })
+    })
+
+    it('resolves a relative path file against its own directory, not the cwd', async () => {
+        const target = await writeFixtureExtension(extensionsDir, 'sibling')
+        await writeFile(join(extensionsDir, 'td-scratch'), 'td-sibling', 'utf8')
+
+        const found = await discover()
+        const scratch = found.find((extension) => extension.name === 'scratch')
+        expect(scratch?.dir).toBe(target)
+    })
+
+    it('treats a plain file named .git as part of a binary install', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            files: { '.git': 'gitdir: elsewhere' },
+            installedManifest: {
+                owner: 'Doist',
+                name: 'td-goals',
+                host: 'github.com',
+                tag: 'v1',
+                pinned: false,
+                asset: 'a',
+                installedAt: 'now',
+            },
+        })
+
+        const [extension] = await discover()
+        expect(extension.kind).toBe('binary')
+        expect(extension.source).toBe('Doist/td-goals')
+    })
+
+    it('reports a failure to read the extensions directory rather than hiding it', async () => {
+        await writeFile(join(root, 'not-a-directory'), 'x')
+
+        await expect(
+            discoverExtensions({
+                extensionsDir: join(root, 'not-a-directory'),
+                stateDir,
+                binName: 'td',
+                officialSource: OFFICIAL,
+            }),
+        ).rejects.toThrow()
+    })
+
+    it('records what a pinned extension is pinned to', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals')
+        await writeState(stateDir, 'td-goals', { pinned: 'v1.2.3' })
+
+        const [extension] = await discover()
+        expect(extension.pinnedRef).toBe('v1.2.3')
     })
 
     it('prefers the authored manifest over the one written at install time', async () => {
@@ -142,6 +194,29 @@ describe('discoverExtensions', () => {
 
         const [extension] = await discover()
         expect(extension.pinned).toBe(true)
+    })
+
+    describe('findExtension', () => {
+        const find = (name: string) =>
+            findExtension(name, {
+                extensionsDir,
+                stateDir,
+                binName: 'td',
+                officialSource: OFFICIAL,
+            })
+
+        it('describes only the extension asked for', async () => {
+            await writeFixtureExtension(extensionsDir, 'goals')
+            await writeFixtureExtension(extensionsDir, 'standup')
+
+            await expect(find('goals')).resolves.toMatchObject({ name: 'goals' })
+        })
+
+        it('returns nothing when that extension is not installed', async () => {
+            await writeFixtureExtension(extensionsDir, 'goals')
+
+            await expect(find('missing')).resolves.toBeUndefined()
+        })
     })
 
     it('sorts by command name', async () => {

--- a/src/lib/extensions/discover.test.ts
+++ b/src/lib/extensions/discover.test.ts
@@ -1,0 +1,154 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { writeFakeGitRepo, writeFixtureExtension } from '../../test-support/extension-fixture.js'
+import { discoverExtensions } from './discover.js'
+import { writeState } from './state.js'
+
+const OFFICIAL = { host: 'github.com', owner: 'Doist' }
+
+describe('discoverExtensions', () => {
+    let root: string
+    let extensionsDir: string
+    let stateDir: string
+
+    const discover = () =>
+        discoverExtensions({ extensionsDir, stateDir, binName: 'td', officialSource: OFFICIAL })
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-discover-'))
+        extensionsDir = join(root, 'extensions')
+        stateDir = join(root, 'state')
+        await mkdir(extensionsDir, { recursive: true })
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('returns nothing when the extensions directory does not exist', async () => {
+        const missing = discoverExtensions({
+            extensionsDir: join(root, 'nope'),
+            stateDir,
+            binName: 'td',
+            officialSource: OFFICIAL,
+        })
+        await expect(missing).resolves.toEqual([])
+    })
+
+    it('ignores directories that do not carry the binary-name prefix', async () => {
+        await mkdir(join(extensionsDir, 'unrelated'), { recursive: true })
+        await mkdir(join(extensionsDir, 'td-'), { recursive: true })
+        await writeFixtureExtension(extensionsDir, 'goals')
+
+        const found = await discover()
+        expect(found.map((extension) => extension.name)).toEqual(['goals'])
+    })
+
+    it('reads a binary install from its manifest and marks a first-party source', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: {
+                owner: 'Doist',
+                name: 'td-goals',
+                host: 'github.com',
+                tag: 'v0.3.0',
+                pinned: false,
+                asset: 'td-goals_v0.3.0_linux-x64',
+                installedAt: '2026-09-07T10:12:00Z',
+                description: 'Track quarterly goals',
+            },
+        })
+
+        const [extension] = await discover()
+        expect(extension).toMatchObject({
+            name: 'goals',
+            dirName: 'td-goals',
+            kind: 'binary',
+            source: 'Doist/td-goals',
+            official: true,
+            description: 'Track quarterly goals',
+        })
+    })
+
+    it('reads a git install from its remote, and withholds the marker from another host', async () => {
+        const dir = await writeFixtureExtension(extensionsDir, 'x')
+        await writeFakeGitRepo(dir, 'https://git.example.com/Doist/td-x')
+
+        const [extension] = await discover()
+        expect(extension).toMatchObject({
+            kind: 'git',
+            host: 'git.example.com',
+            owner: 'Doist',
+            source: 'Doist/td-x',
+            official: false,
+        })
+    })
+
+    it('marks a git install from the official host and owner', async () => {
+        const dir = await writeFixtureExtension(extensionsDir, 'x')
+        await writeFakeGitRepo(dir, 'https://github.com/Doist/td-x.git')
+
+        const [extension] = await discover()
+        expect(extension.official).toBe(true)
+    })
+
+    it('follows a local install to its target and never marks it official', async () => {
+        const workspace = join(root, 'code')
+        await mkdir(workspace, { recursive: true })
+        const target = await writeFixtureExtension(workspace, 'scratch')
+        await writeFakeGitRepo(target, 'https://github.com/Doist/td-scratch.git')
+        await symlink(target, join(extensionsDir, 'td-scratch'), 'dir')
+
+        const [extension] = await discover()
+        expect(extension).toMatchObject({ name: 'scratch', kind: 'local', official: false })
+        expect(extension.dir).toBe(target)
+        expect(extension.executablePath).toBe(join(target, 'td-scratch'))
+    })
+
+    it('follows a Windows-style path file for a local install', async () => {
+        const workspace = join(root, 'code')
+        await mkdir(workspace, { recursive: true })
+        const target = await writeFixtureExtension(workspace, 'scratch')
+        await writeFile(join(extensionsDir, 'td-scratch'), target, 'utf8')
+
+        const [extension] = await discover()
+        expect(extension).toMatchObject({ kind: 'local', dir: target })
+    })
+
+    it('prefers the authored manifest over the one written at install time', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            authoredManifest: { description: 'from the author', requires: { td: '>=9.0.0' } },
+            installedManifest: {
+                owner: 'Doist',
+                name: 'td-goals',
+                host: 'github.com',
+                tag: 'v1',
+                pinned: false,
+                asset: 'a',
+                installedAt: 'now',
+                description: 'from install time',
+            },
+        })
+
+        const [extension] = await discover()
+        expect(extension.description).toBe('from the author')
+        expect(extension.requires).toEqual({ td: '>=9.0.0' })
+    })
+
+    it('reports a pin recorded in the state directory', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals')
+        await writeState(stateDir, 'td-goals', { pinned: 'v1.2.3' })
+
+        const [extension] = await discover()
+        expect(extension.pinned).toBe(true)
+    })
+
+    it('sorts by command name', async () => {
+        await writeFixtureExtension(extensionsDir, 'zulu')
+        await writeFixtureExtension(extensionsDir, 'alpha')
+
+        const found = await discover()
+        expect(found.map((extension) => extension.name)).toEqual(['alpha', 'zulu'])
+    })
+})

--- a/src/lib/extensions/discover.ts
+++ b/src/lib/extensions/discover.ts
@@ -9,10 +9,12 @@
  */
 
 import { lstat, readdir, readFile, realpath } from 'node:fs/promises'
-import { isAbsolute, join, resolve } from 'node:path'
-import { exists } from './fs-utils.js'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { mapWithConcurrency } from './concurrency.js'
+import { exists, isDirectory } from './fs-utils.js'
+import { isMissingFile } from './json-file.js'
 import { readAuthoredManifest, readInstalledManifest } from './manifest.js'
-import { parseRepoRef, toCommandName } from './source.js'
+import { parseRepoRef, toCommandName, toDirName } from './source.js'
 import { readState } from './state.js'
 import type { Extension, ExtensionKind } from './types.js'
 
@@ -55,15 +57,20 @@ async function resolveLocalTarget(entryPath: string, isLink: boolean): Promise<s
     try {
         const target = (await readFile(entryPath, 'utf8')).trim()
         if (!target) return undefined
-        return isAbsolute(target) ? target : resolve(target)
+        // Relative to the path file itself, not to wherever the CLI happens to
+        // have been run from, so the install points at one directory always.
+        return isAbsolute(target) ? target : resolve(dirname(entryPath), target)
     } catch {
         return undefined
     }
 }
 
-async function inferKind(entryPath: string, isDirectory: boolean): Promise<ExtensionKind> {
-    if (!isDirectory) return 'local'
-    if (await exists(join(entryPath, '.git'))) return 'git'
+async function inferKind(entryPath: string, entryIsDirectory: boolean): Promise<ExtensionKind> {
+    if (!entryIsDirectory) return 'local'
+    // A directory, not merely a `.git` of some kind: a release binary is free
+    // to ship a file by that name, and misreading it as a clone would hide its
+    // manifest and its source.
+    if (await isDirectory(join(entryPath, '.git'))) return 'git'
     return 'binary'
 }
 
@@ -95,10 +102,13 @@ async function describe(entry: string, options: DiscoverOptions): Promise<Extens
     const dir =
         kind === 'local' ? ((await resolveLocalTarget(entryPath, isLink)) ?? entryPath) : entryPath
 
-    const [authored, installed, state] = await Promise.all([
+    // Every per-extension read at once: they are independent, and discovery
+    // runs on every invocation of the CLI.
+    const [authored, installed, state, remote] = await Promise.all([
         readAuthoredManifest(dir, binName),
         kind === 'binary' ? readInstalledManifest(dir, binName) : Promise.resolve(undefined),
         readState(stateDir, entry),
+        kind === 'git' ? readGitRemote(dir) : Promise.resolve(undefined),
     ])
 
     let host: string | undefined
@@ -110,7 +120,6 @@ async function describe(entry: string, options: DiscoverOptions): Promise<Extens
         owner = installed.owner
         source = `${installed.owner}/${installed.name}`
     } else if (kind === 'git') {
-        const remote = await readGitRemote(dir)
         const parsed = remote ? parseRepoRef(remote) : undefined
         host = parsed?.host
         owner = parsed?.owner
@@ -133,6 +142,7 @@ async function describe(entry: string, options: DiscoverOptions): Promise<Extens
         host,
         owner,
         pinned: Boolean(state.pinned ?? installed?.pinned),
+        pinnedRef: state.pinned ?? (installed?.pinned ? installed.tag : undefined),
         official,
         description: authored?.description ?? installed?.description,
         requires: authored?.requires ?? installed?.requires,
@@ -140,20 +150,54 @@ async function describe(entry: string, options: DiscoverOptions): Promise<Extens
     }
 }
 
+/**
+ * How many extensions to inspect at once. Each one is a handful of small
+ * reads, and the number installed is up to the user.
+ */
+const DISCOVERY_CONCURRENCY = 8
+
+function candidateEntries(entries: string[], binName: string): string[] {
+    const prefix = `${binName}-`
+    return entries.filter((entry) => entry.startsWith(prefix) && entry !== prefix)
+}
+
 /** Every extension installed for this CLI, sorted by command name. */
 export async function discoverExtensions(options: DiscoverOptions): Promise<Extension[]> {
     let entries: string[]
     try {
         entries = await readdir(options.extensionsDir)
-    } catch {
-        return []
+    } catch (error) {
+        // No extensions directory is the ordinary case and means no
+        // extensions. Anything else — a permission problem, a broken mount —
+        // is a real failure, and reporting it as "none installed" would leave
+        // the user wondering where their extensions went.
+        if (isMissingFile(error)) return []
+        throw error
     }
 
-    const prefix = `${options.binName}-`
-    const candidates = entries.filter((entry) => entry.startsWith(prefix) && entry !== prefix)
-    const described = await Promise.all(candidates.map((entry) => describe(entry, options)))
+    const described = await mapWithConcurrency(
+        candidateEntries(entries, options.binName),
+        DISCOVERY_CONCURRENCY,
+        (entry) => describe(entry, options),
+    )
 
     return described
         .filter((extension): extension is Extension => extension !== undefined)
         .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/**
+ * One extension by command name, inspecting only the entry that could match.
+ *
+ * `dispatch`, `remove` and a targeted `upgrade` all know which extension they
+ * want, and reading every other extension's manifests and git remote to find
+ * it would be work done for nothing.
+ */
+export async function findExtension(
+    name: string,
+    options: DiscoverOptions,
+): Promise<Extension | undefined> {
+    const entry = toDirName(options.binName, name)
+    if (!(await exists(join(options.extensionsDir, entry)))) return undefined
+    return describe(entry, options)
 }

--- a/src/lib/extensions/discover.ts
+++ b/src/lib/extensions/discover.ts
@@ -1,0 +1,159 @@
+/**
+ * Finding what is installed.
+ *
+ * Discovery is one `readdir` of the extensions directory plus, for each entry
+ * found, a couple of small file reads. It runs on every invocation of the host
+ * CLI — including the overwhelmingly common case of no extensions at all,
+ * where it costs a single failed directory read — so nothing here may spawn a
+ * process or touch the network.
+ */
+
+import { lstat, readdir, readFile, realpath } from 'node:fs/promises'
+import { isAbsolute, join, resolve } from 'node:path'
+import { exists } from './fs-utils.js'
+import { readAuthoredManifest, readInstalledManifest } from './manifest.js'
+import { parseRepoRef, toCommandName } from './source.js'
+import { readState } from './state.js'
+import type { Extension, ExtensionKind } from './types.js'
+
+export type DiscoverOptions = {
+    extensionsDir: string
+    stateDir: string
+    binName: string
+    officialSource: { host: string; owner: string }
+}
+
+/**
+ * Pull `remote.origin.url` out of `.git/config` rather than shelling out to
+ * git, so that listing extensions stays free of subprocesses.
+ */
+async function readGitRemote(dir: string): Promise<string | undefined> {
+    let config: string
+    try {
+        config = await readFile(join(dir, '.git', 'config'), 'utf8')
+    } catch {
+        return undefined
+    }
+    const section = config.match(/\[remote "origin"\]([\s\S]*?)(?=\n\[|$)/)
+    if (!section) return undefined
+    return section[1].match(/^\s*url\s*=\s*(.+)$/m)?.[1].trim()
+}
+
+/**
+ * Resolve the directory a local install points at. On POSIX the entry is a
+ * symlink; on Windows it is a plain file holding the target path, because
+ * creating a symlink there needs elevated rights.
+ */
+async function resolveLocalTarget(entryPath: string, isLink: boolean): Promise<string | undefined> {
+    if (isLink) {
+        try {
+            return await realpath(entryPath)
+        } catch {
+            return undefined
+        }
+    }
+    try {
+        const target = (await readFile(entryPath, 'utf8')).trim()
+        if (!target) return undefined
+        return isAbsolute(target) ? target : resolve(target)
+    } catch {
+        return undefined
+    }
+}
+
+async function inferKind(entryPath: string, isDirectory: boolean): Promise<ExtensionKind> {
+    if (!isDirectory) return 'local'
+    if (await exists(join(entryPath, '.git'))) return 'git'
+    return 'binary'
+}
+
+/**
+ * The executable an extension is dispatched through: `<dir>/<dirName>`, with
+ * the `.exe` variant preferred on Windows when it is the one that exists.
+ */
+async function findExecutable(dir: string, dirName: string): Promise<string> {
+    const base = join(dir, dirName)
+    if (process.platform === 'win32') {
+        for (const candidate of [`${base}.exe`, `${base}.cmd`]) {
+            if (await exists(candidate)) return candidate
+        }
+    }
+    return base
+}
+
+async function describe(entry: string, options: DiscoverOptions): Promise<Extension | undefined> {
+    const { extensionsDir, stateDir, binName, officialSource } = options
+    const entryPath = join(extensionsDir, entry)
+
+    // `lstat` answers both questions for a regular entry — is it a link, and
+    // is it a directory — so discovery costs one call per entry, not two.
+    const entryStats = await lstat(entryPath).catch(() => undefined)
+    if (!entryStats) return undefined
+    const isLink = entryStats.isSymbolicLink()
+
+    const kind = await inferKind(entryPath, entryStats.isDirectory())
+    const dir =
+        kind === 'local' ? ((await resolveLocalTarget(entryPath, isLink)) ?? entryPath) : entryPath
+
+    const [authored, installed, state] = await Promise.all([
+        readAuthoredManifest(dir, binName),
+        kind === 'binary' ? readInstalledManifest(dir, binName) : Promise.resolve(undefined),
+        readState(stateDir, entry),
+    ])
+
+    let host: string | undefined
+    let owner: string | undefined
+    let source: string | undefined
+
+    if (kind === 'binary' && installed) {
+        host = installed.host
+        owner = installed.owner
+        source = `${installed.owner}/${installed.name}`
+    } else if (kind === 'git') {
+        const remote = await readGitRemote(dir)
+        const parsed = remote ? parseRepoRef(remote) : undefined
+        host = parsed?.host
+        owner = parsed?.owner
+        source = parsed ? `${parsed.owner}/${parsed.repo}` : remote
+    } else if (kind === 'local') {
+        source = dir
+    }
+
+    const official =
+        kind !== 'local' && host === officialSource.host && owner === officialSource.owner
+
+    return {
+        name: toCommandName(binName, entry),
+        dirName: entry,
+        kind,
+        dir,
+        entryPath,
+        executablePath: await findExecutable(dir, entry),
+        source,
+        host,
+        owner,
+        pinned: Boolean(state.pinned ?? installed?.pinned),
+        official,
+        description: authored?.description ?? installed?.description,
+        requires: authored?.requires ?? installed?.requires,
+        manifest: installed,
+    }
+}
+
+/** Every extension installed for this CLI, sorted by command name. */
+export async function discoverExtensions(options: DiscoverOptions): Promise<Extension[]> {
+    let entries: string[]
+    try {
+        entries = await readdir(options.extensionsDir)
+    } catch {
+        return []
+    }
+
+    const prefix = `${options.binName}-`
+    const candidates = entries.filter((entry) => entry.startsWith(prefix) && entry !== prefix)
+    const described = await Promise.all(candidates.map((entry) => describe(entry, options)))
+
+    return described
+        .filter((extension): extension is Extension => extension !== undefined)
+        .sort((a, b) => a.name.localeCompare(b.name))
+}

--- a/src/lib/extensions/types.ts
+++ b/src/lib/extensions/types.ts
@@ -41,6 +41,8 @@ export type Extension = {
     host?: string
     owner?: string
     pinned: boolean
+    /** The ref or tag it is pinned to, when it is pinned. */
+    pinnedRef?: string
     official: boolean
     description?: string
     requires?: Record<string, string>

--- a/src/test-support/extension-fixture.ts
+++ b/src/test-support/extension-fixture.ts
@@ -1,0 +1,108 @@
+/**
+ * Builds real extensions on disk for tests.
+ *
+ * The extension contract is the process boundary, so the only way to test it
+ * honestly is to install and run an actual executable. These helpers write the
+ * smallest thing that can prove the contract: a script that reports the
+ * arguments and environment it was given, and exits with a code the test picks.
+ */
+
+import { chmod, mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export type FixtureOptions = {
+    /** Host binary name the extension belongs to. Defaults to `td`. */
+    binName?: string
+    /** Interpreter for the fixture. `node` exercises the shebang shortcut. */
+    interpreter?: 'node' | 'sh'
+    /** Contents of `<bin>-extension.json`, written only when given. */
+    authoredManifest?: Record<string, unknown>
+    /** Contents of `.<bin>-manifest.json`, which marks a binary install. */
+    installedManifest?: Record<string, unknown>
+    /** Leave the executable bit off, as an unbuilt compiled extension would. */
+    notExecutable?: boolean
+    /** Extra files to write into the extension directory. */
+    files?: Record<string, string>
+}
+
+/**
+ * A fixture that prints one JSON object to stdout describing how it was
+ * called, so a test can assert on argument passthrough and the environment
+ * contract in one go. It reports to the file named by `XX_REPORT` when that is
+ * set, and to stdout otherwise. `--exit-code N` makes it exit with N, and
+ * `--fail` writes to stderr.
+ */
+const NODE_FIXTURE = `#!/usr/bin/env node
+const args = process.argv.slice(2)
+const env = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => key.startsWith('TD_') || key.startsWith('XX_')),
+)
+const report = JSON.stringify({ args, env, cwd: process.cwd() })
+const exitFlag = args.indexOf('--exit-code')
+const code = exitFlag === -1 ? 0 : Number(args[exitFlag + 1])
+if (args.includes('--fail')) process.stderr.write('fixture failed')
+// Dynamic import works whether node loads this as CommonJS or ESM, which
+// depends on whatever package.json happens to sit above the fixture.
+if (process.env.XX_REPORT) {
+    import('node:fs').then((fs) => {
+        fs.writeFileSync(process.env.XX_REPORT, report)
+        process.exit(code)
+    })
+} else {
+    process.stdout.write(report)
+    process.exit(code)
+}
+`
+
+const SH_FIXTURE = `#!/bin/sh
+echo "args:$*"
+echo "name:$TD_EXTENSION_NAME"
+exit 0
+`
+
+/**
+ * Write an extension directory named `<binName>-<name>` under `parentDir` and
+ * return its path.
+ */
+export async function writeFixtureExtension(
+    parentDir: string,
+    name: string,
+    options: FixtureOptions = {},
+): Promise<string> {
+    const binName = options.binName ?? 'td'
+    const dirName = `${binName}-${name}`
+    const dir = join(parentDir, dirName)
+    await mkdir(dir, { recursive: true })
+
+    const executablePath = join(dir, dirName)
+    const body = options.interpreter === 'sh' ? SH_FIXTURE : NODE_FIXTURE
+    await writeFile(executablePath, body)
+    if (!options.notExecutable) await chmod(executablePath, 0o755)
+
+    if (options.authoredManifest) {
+        await writeFile(
+            join(dir, `${binName}-extension.json`),
+            JSON.stringify(options.authoredManifest, null, 2),
+        )
+    }
+    if (options.installedManifest) {
+        await writeFile(
+            join(dir, `.${binName}-manifest.json`),
+            JSON.stringify(options.installedManifest, null, 2),
+        )
+    }
+    for (const [file, contents] of Object.entries(options.files ?? {})) {
+        await writeFile(join(dir, file), contents)
+    }
+
+    return dir
+}
+
+/** Make a directory look like a git clone without running git. */
+export async function writeFakeGitRepo(dir: string, remoteUrl: string): Promise<void> {
+    await mkdir(join(dir, '.git'), { recursive: true })
+    await writeFile(
+        join(dir, '.git', 'config'),
+        `[core]\n\trepositoryformatversion = 0\n[remote "origin"]\n\turl = ${remoteUrl}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`,
+    )
+}

--- a/src/test-support/extension-fixture.ts
+++ b/src/test-support/extension-fixture.ts
@@ -9,6 +9,7 @@
 
 import { chmod, mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { authoredManifestFileName, manifestFileName, toDirName } from '../lib/extensions/source.js'
 
 export type FixtureOptions = {
     /** Host binary name the extension belongs to. Defaults to `td`. */
@@ -41,16 +42,17 @@ const report = JSON.stringify({ args, env, cwd: process.cwd() })
 const exitFlag = args.indexOf('--exit-code')
 const code = exitFlag === -1 ? 0 : Number(args[exitFlag + 1])
 if (args.includes('--fail')) process.stderr.write('fixture failed')
-// Dynamic import works whether node loads this as CommonJS or ESM, which
-// depends on whatever package.json happens to sit above the fixture.
+// Setting exitCode rather than calling process.exit, so a report written to a
+// pipe is flushed before the process ends. Dynamic import works whether node
+// loads this as CommonJS or ESM, which depends on whatever package.json
+// happens to sit above the fixture.
+process.exitCode = code
 if (process.env.XX_REPORT) {
     import('node:fs').then((fs) => {
         fs.writeFileSync(process.env.XX_REPORT, report)
-        process.exit(code)
     })
 } else {
     process.stdout.write(report)
-    process.exit(code)
 }
 `
 
@@ -70,7 +72,7 @@ export async function writeFixtureExtension(
     options: FixtureOptions = {},
 ): Promise<string> {
     const binName = options.binName ?? 'td'
-    const dirName = `${binName}-${name}`
+    const dirName = toDirName(binName, name)
     const dir = join(parentDir, dirName)
     await mkdir(dir, { recursive: true })
 
@@ -81,13 +83,13 @@ export async function writeFixtureExtension(
 
     if (options.authoredManifest) {
         await writeFile(
-            join(dir, `${binName}-extension.json`),
+            join(dir, authoredManifestFileName(binName)),
             JSON.stringify(options.authoredManifest, null, 2),
         )
     }
     if (options.installedManifest) {
         await writeFile(
-            join(dir, `.${binName}-manifest.json`),
+            join(dir, manifestFileName(binName)),
             JSON.stringify(options.installedManifest, null, 2),
         )
     }


### PR DESCRIPTION
Slice 2 of 7, on top of slice 1.

Discovery walks the extensions directory and works out what each entry is: a symlink or path file is a local install, a `.git` directory is a clone, anything else is a release binary. It runs on every invocation of the CLI, including the common case of no extensions at all, so it costs one `readdir` plus a couple of small file reads and never spawns a process or touches the network. The git remote is read out of `.git/config` rather than by asking git.

Also adds the test fixture helpers, which build real extension directories in a temporary location so later slices can install and run something genuine rather than a mock.

**Stack:** #521 core · #522 discovery · #523 dispatch · #524 tools · #525 install · #526 upgrade · #527 manager