### PR TITLE
feat(extensions): run extensions

### DIFF
--- a/src/lib/extensions/dispatch.test.ts
+++ b/src/lib/extensions/dispatch.test.ts
@@ -1,10 +1,12 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { writeFixtureExtension } from '../../test-support/extension-fixture.js'
 import { buildExtensionEnv, buildSpawnPlan, dispatchExtension } from './dispatch.js'
 import type { Extension } from './types.js'
+
+const REAL_PLATFORM = process.platform
 
 function asExtension(dir: string, name: string): Extension {
     return {
@@ -38,13 +40,16 @@ describe('buildSpawnPlan', () => {
         expect(plan.args).toEqual([join(dir, 'td-goals'), 'list'])
     })
 
-    it('runs any other executable directly on POSIX', async () => {
-        const dir = await writeFixtureExtension(root, 'shell', { interpreter: 'sh' })
-        const plan = await buildSpawnPlan(join(dir, 'td-shell'), ['a', 'b'])
+    it.skipIf(process.platform === 'win32')(
+        'runs any other executable directly on POSIX',
+        async () => {
+            const dir = await writeFixtureExtension(root, 'shell', { interpreter: 'sh' })
+            const plan = await buildSpawnPlan(join(dir, 'td-shell'), ['a', 'b'])
 
-        expect(plan.command).toBe(join(dir, 'td-shell'))
-        expect(plan.args).toEqual(['a', 'b'])
-    })
+            expect(plan.command).toBe(join(dir, 'td-shell'))
+            expect(plan.args).toEqual(['a', 'b'])
+        },
+    )
 
     it('refuses an executable that has not been built or made executable', async () => {
         const dir = await writeFixtureExtension(root, 'compiled', { notExecutable: true })
@@ -125,6 +130,8 @@ describe('buildExtensionEnv', () => {
     })
 
     it('uses a different prefix for a different host CLI', () => {
+        vi.stubEnv('TD_EXTENSION', undefined)
+
         const env = buildExtensionEnv({
             envPrefix: 'TDC',
             version: '1.0.0',
@@ -132,8 +139,18 @@ describe('buildExtensionEnv', () => {
             hostPath: '/usr/lib/tdc/index.js',
             extension,
         })
+
         expect(env.TDC_EXTENSION).toBe('1')
-        expect(env.TD_EXTENSION).toBe(process.env.TD_EXTENSION)
+        expect(env.TD_EXTENSION).toBeUndefined()
+    })
+
+    it('clears an inherited user rather than passing it on', () => {
+        // Otherwise a nested call without --user would keep acting as the
+        // account the outer call chose.
+        vi.stubEnv('TD_USER', 'inherited@example.com')
+
+        expect(build().TD_USER).toBeUndefined()
+        expect(build({ user: 'alice@example.com' }).TD_USER).toBe('alice@example.com')
     })
 })
 
@@ -159,7 +176,7 @@ describe('dispatchExtension', () => {
             configDir: '/config',
             hostPath: '/host/index.js',
             extension,
-            extra: { XX_REPORT: reportPath, ...envOverrides },
+            env: { XX_REPORT: reportPath, ...envOverrides },
         })
         const code = await dispatchExtension(extension, args, env)
         return { code, extension }
@@ -192,9 +209,135 @@ describe('dispatchExtension', () => {
         expect(env.TD_VERSION).toBe('5.3.1')
     })
 
+    it.skipIf(process.platform === 'win32')(
+        'reports a child killed by a signal the way a shell does',
+        async () => {
+            const dir = await writeFixtureExtension(root, 'suicidal')
+            await writeFile(
+                join(dir, 'td-suicidal'),
+                "#!/usr/bin/env node\nprocess.kill(process.pid, 'SIGKILL')\n",
+            )
+            await chmod(join(dir, 'td-suicidal'), 0o755)
+            const extension = asExtension(dir, 'suicidal')
+
+            // 128 + SIGKILL(9). Returning 0 here would make the host report
+            // success after an extension was killed.
+            await expect(dispatchExtension(extension, [], process.env)).resolves.toBe(137)
+        },
+    )
+
     it('returns the exit code the extension chose', async () => {
         await expect(run(['--exit-code', '0'])).resolves.toMatchObject({ code: 0 })
         await expect(run(['--exit-code', '3'])).resolves.toMatchObject({ code: 3 })
         await expect(run(['--exit-code', '42'])).resolves.toMatchObject({ code: 42 })
+    })
+})
+
+describe('buildSpawnPlan on Windows', () => {
+    let root: string
+
+    // The Windows branches never run on CI, so drive them by declaring the
+    // platform. Everything they touch is decided from the path and the
+    // shebang, so no Windows filesystem behaviour is being faked.
+    function asWindows(): void {
+        Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    }
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-spawn-win-'))
+    })
+
+    afterEach(async () => {
+        Object.defineProperty(process, 'platform', { value: REAL_PLATFORM, configurable: true })
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('runs a .exe directly', async () => {
+        const dir = await writeFixtureExtension(root, 'compiled')
+        const exe = join(dir, 'td-compiled.exe')
+        await writeFile(exe, 'MZ fake binary')
+        await chmod(exe, 0o755)
+        asWindows()
+
+        const plan = await buildSpawnPlan(exe, ['a'])
+
+        expect(plan.command).toBe(exe)
+        expect(plan.args).toEqual(['a'])
+    })
+
+    it('runs a .cmd through the command interpreter, which is the only way it can run', async () => {
+        const dir = await writeFixtureExtension(root, 'batch')
+        const cmd = join(dir, 'td-batch.cmd')
+        await writeFile(cmd, '@echo off\r\n')
+        await chmod(cmd, 0o755)
+        asWindows()
+
+        const plan = await buildSpawnPlan(cmd, ['a', 'b'])
+
+        expect(plan.command).toMatch(/cmd\.exe$/i)
+        expect(plan.args).toEqual(['/d', '/s', '/c', cmd, 'a', 'b'])
+    })
+
+    it('runs a shell script through sh, keeping arguments as positional parameters', async () => {
+        const dir = await writeFixtureExtension(root, 'shell', { interpreter: 'sh' })
+        const script = join(dir, 'td-shell')
+        asWindows()
+
+        const plan = await buildSpawnPlan(script, ['a b', '--flag'])
+
+        expect(plan.command).toBe('sh')
+        expect(plan.args).toEqual(['-c', '"$0" "$@"', script, 'a b', '--flag'])
+    })
+
+    it('still prefers the host node for a node script', async () => {
+        const dir = await writeFixtureExtension(root, 'goals')
+        asWindows()
+
+        const plan = await buildSpawnPlan(join(dir, 'td-goals'), [])
+
+        expect(plan.command).toBe(process.execPath)
+    })
+})
+
+describe.skipIf(process.platform === 'win32')('node shebang options', () => {
+    let root: string
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-shebang-'))
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    async function planFor(shebang: string): Promise<Awaited<ReturnType<typeof buildSpawnPlan>>> {
+        const dir = join(root, 'td-x')
+        await mkdir(dir, { recursive: true })
+        const path = join(dir, 'td-x')
+        await writeFile(path, `${shebang}\nconsole.log('hi')\n`)
+        await chmod(path, 0o755)
+        return buildSpawnPlan(path, ['run'])
+    }
+
+    it('keeps options the script asked its interpreter for', async () => {
+        const plan = await planFor('#!/usr/bin/env -S node --conditions=development')
+
+        expect(plan.command).toBe(process.execPath)
+        expect(plan.args[0]).toBe('--conditions=development')
+        expect(plan.args.at(-1)).toBe('run')
+    })
+
+    it.each(['#!/usr/bin/env node', '#!/usr/bin/node', '#!/usr/local/bin/node'])(
+        'recognises %s',
+        async (shebang) => {
+            const plan = await planFor(shebang)
+            expect(plan.command).toBe(process.execPath)
+        },
+    )
+
+    it('leaves a non-node interpreter to the operating system', async () => {
+        const plan = await planFor('#!/bin/sh')
+
+        expect(plan.command).not.toBe(process.execPath)
     })
 })

--- a/src/lib/extensions/dispatch.test.ts
+++ b/src/lib/extensions/dispatch.test.ts
@@ -1,0 +1,200 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { writeFixtureExtension } from '../../test-support/extension-fixture.js'
+import { buildExtensionEnv, buildSpawnPlan, dispatchExtension } from './dispatch.js'
+import type { Extension } from './types.js'
+
+function asExtension(dir: string, name: string): Extension {
+    return {
+        name,
+        dirName: `td-${name}`,
+        kind: 'git',
+        dir,
+        entryPath: dir,
+        executablePath: join(dir, `td-${name}`),
+        pinned: false,
+        official: false,
+    }
+}
+
+describe('buildSpawnPlan', () => {
+    let root: string
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-spawn-'))
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('runs a node-shebang script with the host’s own node', async () => {
+        const dir = await writeFixtureExtension(root, 'goals')
+        const plan = await buildSpawnPlan(join(dir, 'td-goals'), ['list'])
+
+        expect(plan.command).toBe(process.execPath)
+        expect(plan.args).toEqual([join(dir, 'td-goals'), 'list'])
+    })
+
+    it('runs any other executable directly on POSIX', async () => {
+        const dir = await writeFixtureExtension(root, 'shell', { interpreter: 'sh' })
+        const plan = await buildSpawnPlan(join(dir, 'td-shell'), ['a', 'b'])
+
+        expect(plan.command).toBe(join(dir, 'td-shell'))
+        expect(plan.args).toEqual(['a', 'b'])
+    })
+
+    it('refuses an executable that has not been built or made executable', async () => {
+        const dir = await writeFixtureExtension(root, 'compiled', { notExecutable: true })
+
+        await expect(buildSpawnPlan(join(dir, 'td-compiled'), [])).rejects.toMatchObject({
+            code: 'EXTENSION_NOT_EXECUTABLE',
+        })
+    })
+
+    it('refuses when the executable is missing entirely', async () => {
+        await expect(buildSpawnPlan(join(root, 'td-ghost', 'td-ghost'), [])).rejects.toMatchObject({
+            code: 'EXTENSION_NOT_EXECUTABLE',
+        })
+    })
+})
+
+describe('buildExtensionEnv', () => {
+    const extension = asExtension('/ext/td-goals', 'goals')
+
+    beforeEach(() => {
+        // The contract is about what this function adds, so start from a known
+        // environment rather than whatever the machine running the tests has.
+        for (const name of ['TD_USER', 'TD_ACCESSIBLE', 'TD_TOKEN', 'TD_API_TOKEN']) {
+            vi.stubEnv(name, undefined)
+        }
+    })
+
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    const build = (overrides: Partial<Parameters<typeof buildExtensionEnv>[0]> = {}) =>
+        buildExtensionEnv({
+            envPrefix: 'TD',
+            version: '5.3.1',
+            configDir: '/config/todoist-cli',
+            hostPath: '/usr/lib/td/dist/index.js',
+            extension,
+            ...overrides,
+        })
+
+    it('sets the documented contract', () => {
+        const env = build()
+
+        expect(env.TD_EXTENSION).toBe('1')
+        expect(env.TD_EXTENSION_NAME).toBe('goals')
+        expect(env.TD_EXTENSION_DIR).toBe('/ext/td-goals')
+        expect(env.TD_PATH).toBe('/usr/lib/td/dist/index.js')
+        expect(env.TD_NODE).toBe(process.execPath)
+        expect(env.TD_VERSION).toBe('5.3.1')
+        expect(env.TD_CONFIG_DIR).toBe('/config/todoist-cli')
+    })
+
+    it('never injects a credential of its own', () => {
+        const env = build()
+        expect(env.TD_TOKEN).toBeUndefined()
+        expect(env.TD_API_TOKEN).toBeUndefined()
+    })
+
+    it('passes through a token the user exported themselves', () => {
+        // Documented in the spec as a deliberate exception: the CLI does not
+        // inject secrets, but it does not scrub the environment either, and
+        // stripping this would break nested calls for anyone who authenticates
+        // this way.
+        vi.stubEnv('TODOIST_API_TOKEN', 'user-exported-token')
+
+        expect(build().TODOIST_API_TOKEN).toBe('user-exported-token')
+    })
+
+    it('forwards --user only when one was given before the command token', () => {
+        expect(build().TD_USER).toBeUndefined()
+        expect(build({ user: 'alice@example.com' }).TD_USER).toBe('alice@example.com')
+    })
+
+    it('marks accessible mode so nested calls inherit it', () => {
+        expect(build().TD_ACCESSIBLE).toBeUndefined()
+        expect(build({ accessible: true }).TD_ACCESSIBLE).toBe('1')
+    })
+
+    it('uses a different prefix for a different host CLI', () => {
+        const env = buildExtensionEnv({
+            envPrefix: 'TDC',
+            version: '1.0.0',
+            configDir: '/config/comms-cli',
+            hostPath: '/usr/lib/tdc/index.js',
+            extension,
+        })
+        expect(env.TDC_EXTENSION).toBe('1')
+        expect(env.TD_EXTENSION).toBe(process.env.TD_EXTENSION)
+    })
+})
+
+describe('dispatchExtension', () => {
+    let root: string
+    let reportPath: string
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-dispatch-'))
+        reportPath = join(root, 'report.json')
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    async function run(args: string[], envOverrides: Record<string, string> = {}) {
+        const dir = await writeFixtureExtension(root, 'goals')
+        const extension = asExtension(dir, 'goals')
+        const env = buildExtensionEnv({
+            envPrefix: 'TD',
+            version: '5.3.1',
+            configDir: '/config',
+            hostPath: '/host/index.js',
+            extension,
+            extra: { XX_REPORT: reportPath, ...envOverrides },
+        })
+        const code = await dispatchExtension(extension, args, env)
+        return { code, extension }
+    }
+
+    async function report(): Promise<{ args: string[]; env: Record<string, string> }> {
+        return JSON.parse(await readFile(reportPath, 'utf8'))
+    }
+
+    it('passes every argument through untouched, flags included', async () => {
+        await run(['add', '--json', '-x', '--user', 'someone', '--', 'raw'])
+
+        expect((await report()).args).toEqual([
+            'add',
+            '--json',
+            '-x',
+            '--user',
+            'someone',
+            '--',
+            'raw',
+        ])
+    })
+
+    it('hands the environment contract to the child process', async () => {
+        await run([])
+
+        const { env } = await report()
+        expect(env.TD_EXTENSION).toBe('1')
+        expect(env.TD_EXTENSION_NAME).toBe('goals')
+        expect(env.TD_VERSION).toBe('5.3.1')
+    })
+
+    it('returns the exit code the extension chose', async () => {
+        await expect(run(['--exit-code', '0'])).resolves.toMatchObject({ code: 0 })
+        await expect(run(['--exit-code', '3'])).resolves.toMatchObject({ code: 3 })
+        await expect(run(['--exit-code', '42'])).resolves.toMatchObject({ code: 42 })
+    })
+})

--- a/src/lib/extensions/dispatch.ts
+++ b/src/lib/extensions/dispatch.ts
@@ -1,0 +1,172 @@
+/**
+ * Running an extension.
+ *
+ * The contract is the process boundary: arguments are passed through exactly
+ * as the user typed them, the three standard streams are the host's own, and
+ * the host exits with whatever the extension exited with. Nothing is parsed,
+ * rewritten or added on either side.
+ */
+
+import { spawn } from 'node:child_process'
+import { open } from 'node:fs/promises'
+import { constants } from 'node:os'
+import { CliError } from '@doist/cli-core'
+import { isExecutable } from './fs-utils.js'
+import type { Extension } from './types.js'
+
+export type SpawnPlan = { command: string; args: string[] }
+
+/** First line of a file, when it is a shebang. */
+async function readShebang(path: string): Promise<string | undefined> {
+    let handle: Awaited<ReturnType<typeof open>>
+    try {
+        handle = await open(path, 'r')
+    } catch {
+        return undefined
+    }
+    try {
+        const buffer = Buffer.alloc(256)
+        const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0)
+        const head = buffer.subarray(0, bytesRead).toString('utf8')
+        if (!head.startsWith('#!')) return undefined
+        return head.split('\n', 1)[0].trim()
+    } finally {
+        await handle.close()
+    }
+}
+
+/**
+ * Decide how to launch an extension's executable.
+ *
+ * Node scripts are launched with the host's own Node rather than through the
+ * shebang, which makes them work on Windows and pins them to the Node version
+ * the host already requires. Everything else runs directly on POSIX, and
+ * through `sh` on Windows, where shebangs mean nothing.
+ */
+export async function buildSpawnPlan(executablePath: string, args: string[]): Promise<SpawnPlan> {
+    const onWindows = process.platform === 'win32'
+
+    if (!(await isExecutable(executablePath))) {
+        throw new CliError(
+            'EXTENSION_NOT_EXECUTABLE',
+            `The executable for this extension is missing or not executable: ${executablePath}`,
+            {
+                hints: [
+                    'Compiled extensions need building after a source install.',
+                    'Script extensions need an executable bit: chmod +x the file.',
+                ],
+            },
+        )
+    }
+
+    if (onWindows && /\.(exe|cmd|bat)$/i.test(executablePath)) {
+        return { command: executablePath, args }
+    }
+
+    const shebang = await readShebang(executablePath)
+    if (shebang && /\bnode\b/.test(shebang)) {
+        return { command: process.execPath, args: [executablePath, ...args] }
+    }
+
+    if (onWindows) {
+        // Matches how `gh` runs script extensions on Windows: Git for Windows
+        // provides the interpreter, and without it a shebang script cannot run.
+        return {
+            command: 'sh',
+            args: ['-c', '"$0" "$@"', executablePath, ...args],
+        }
+    }
+
+    return { command: executablePath, args }
+}
+
+export type ExtensionEnvOptions = {
+    envPrefix: string
+    version: string
+    configDir: string
+    hostPath: string
+    extension: Extension
+    user?: string
+    accessible?: boolean
+    extra?: Record<string, string | undefined>
+}
+
+/**
+ * The variables an extension can rely on, layered onto the environment the
+ * user already has.
+ *
+ * The CLI never reads the credential store on an extension's behalf, so no
+ * token is ever injected here: an extension that needs one runs
+ * `<bin> auth token view`. A token the user has themselves exported stays in
+ * the environment, as every other variable does — the CLI does not inject
+ * secrets, but neither does it scrub the environment its user chose.
+ */
+export function buildExtensionEnv(options: ExtensionEnvOptions): NodeJS.ProcessEnv {
+    const { envPrefix: prefix, extension } = options
+    const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        [`${prefix}_EXTENSION`]: '1',
+        [`${prefix}_EXTENSION_NAME`]: extension.name,
+        [`${prefix}_EXTENSION_DIR`]: extension.dir,
+        [`${prefix}_PATH`]: options.hostPath,
+        [`${prefix}_NODE`]: process.execPath,
+        [`${prefix}_VERSION`]: options.version,
+        [`${prefix}_CONFIG_DIR`]: options.configDir,
+    }
+
+    if (options.user) env[`${prefix}_USER`] = options.user
+    if (options.accessible) env[`${prefix}_ACCESSIBLE`] = '1'
+
+    for (const [key, value] of Object.entries(options.extra ?? {})) {
+        if (value === undefined) delete env[key]
+        else env[key] = value
+    }
+
+    return env
+}
+
+/** Exit code convention for a child killed by a signal, as the shell reports it. */
+function exitCodeForSignal(signal: NodeJS.Signals): number {
+    const number = (constants.signals as Record<string, number | undefined>)[signal]
+    return number === undefined ? 1 : 128 + number
+}
+
+/** Run an extension to completion and return the code the host should exit with. */
+export async function dispatchExtension(
+    extension: Extension,
+    args: string[],
+    env: NodeJS.ProcessEnv,
+): Promise<number> {
+    const plan = await buildSpawnPlan(extension.executablePath, args)
+
+    return new Promise((resolve, reject) => {
+        const child = spawn(plan.command, plan.args, {
+            cwd: process.cwd(),
+            env,
+            stdio: 'inherit',
+        })
+
+        child.on('error', (error: NodeJS.ErrnoException) => {
+            if (error.code === 'ENOENT' && plan.command === 'sh') {
+                reject(
+                    new CliError(
+                        'EXTENSION_NEEDS_SHELL',
+                        `Running "${extension.name}" needs a POSIX shell, which was not found.`,
+                        { hints: ['Install Git for Windows, which provides sh.exe.'] },
+                    ),
+                )
+                return
+            }
+            reject(
+                new CliError(
+                    'EXTENSION_NOT_EXECUTABLE',
+                    `Could not run "${extension.name}": ${error.message}`,
+                ),
+            )
+        })
+
+        child.on('close', (code, signal) => {
+            resolve(signal ? exitCodeForSignal(signal) : (code ?? 0))
+        })
+    })
+}

--- a/src/lib/extensions/dispatch.ts
+++ b/src/lib/extensions/dispatch.ts
@@ -12,27 +12,60 @@ import { open } from 'node:fs/promises'
 import { constants } from 'node:os'
 import { CliError } from '@doist/cli-core'
 import { isExecutable } from './fs-utils.js'
-import type { Extension } from './types.js'
+import type { DispatchOptions, Extension } from './types.js'
 
 export type SpawnPlan = { command: string; args: string[] }
 
-/** First line of a file, when it is a shebang. */
-async function readShebang(path: string): Promise<string | undefined> {
+type ExecutableHead = {
+    /** The shebang line, when there is one. */
+    shebang?: string
+    isFile: boolean
+}
+
+/**
+ * Ask both questions about the executable through one open: is it a file, and
+ * how does it want to be run. Two separate calls would also leave a window in
+ * which the file could change between them.
+ */
+async function readExecutableHead(path: string): Promise<ExecutableHead> {
     let handle: Awaited<ReturnType<typeof open>>
     try {
         handle = await open(path, 'r')
     } catch {
-        return undefined
+        return { isFile: false }
     }
     try {
+        const stats = await handle.stat()
+        if (!stats.isFile()) return { isFile: false }
+
         const buffer = Buffer.alloc(256)
         const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0)
         const head = buffer.subarray(0, bytesRead).toString('utf8')
-        if (!head.startsWith('#!')) return undefined
-        return head.split('\n', 1)[0].trim()
+        if (!head.startsWith('#!')) return { isFile: true }
+        return { isFile: true, shebang: head.split('\n', 1)[0].trim() }
     } finally {
         await handle.close()
     }
+}
+
+/**
+ * Node options carried by a shebang, which have to survive the switch to the
+ * host's own Node. `#!/usr/bin/env -S node --conditions=development` means the
+ * script needs that option to resolve its imports at all.
+ */
+function nodeShebangOptions(shebang: string): string[] | undefined {
+    const words = shebang.replace(/^#!/, '').trim().split(/\s+/)
+    let index = 0
+
+    if (/(^|\/)env$/.test(words[index] ?? '')) {
+        index += 1
+        // `env -S` packs the rest of the line into one argument on systems that
+        // would otherwise pass it whole.
+        while (words[index] === '-S' || words[index] === '--split-string') index += 1
+    }
+
+    if (!/(^|\/)node(\.exe)?$/.test(words[index] ?? '')) return undefined
+    return words.slice(index + 1)
 }
 
 /**
@@ -45,8 +78,9 @@ async function readShebang(path: string): Promise<string | undefined> {
  */
 export async function buildSpawnPlan(executablePath: string, args: string[]): Promise<SpawnPlan> {
     const onWindows = process.platform === 'win32'
+    const head = await readExecutableHead(executablePath)
 
-    if (!(await isExecutable(executablePath))) {
+    if (!head.isFile || !(await isExecutable(executablePath))) {
         throw new CliError(
             'EXTENSION_NOT_EXECUTABLE',
             `The executable for this extension is missing or not executable: ${executablePath}`,
@@ -59,13 +93,22 @@ export async function buildSpawnPlan(executablePath: string, args: string[]): Pr
         )
     }
 
-    if (onWindows && /\.(exe|cmd|bat)$/i.test(executablePath)) {
+    if (onWindows && /\.exe$/i.test(executablePath)) {
         return { command: executablePath, args }
     }
 
-    const shebang = await readShebang(executablePath)
-    if (shebang && /\bnode\b/.test(shebang)) {
-        return { command: process.execPath, args: [executablePath, ...args] }
+    if (onWindows && /\.(cmd|bat)$/i.test(executablePath)) {
+        // A batch file is not a program: only the command interpreter can run
+        // one, and spawning it directly fails on every supported Node version.
+        return {
+            command: process.env.ComSpec ?? 'cmd.exe',
+            args: ['/d', '/s', '/c', executablePath, ...args],
+        }
+    }
+
+    const nodeOptions = head.shebang ? nodeShebangOptions(head.shebang) : undefined
+    if (nodeOptions) {
+        return { command: process.execPath, args: [...nodeOptions, executablePath, ...args] }
     }
 
     if (onWindows) {
@@ -80,15 +123,13 @@ export async function buildSpawnPlan(executablePath: string, args: string[]): Pr
     return { command: executablePath, args }
 }
 
-export type ExtensionEnvOptions = {
+export type ExtensionEnvOptions = DispatchOptions & {
     envPrefix: string
     version: string
     configDir: string
     hostPath: string
     extension: Extension
-    user?: string
     accessible?: boolean
-    extra?: Record<string, string | undefined>
 }
 
 /**
@@ -114,10 +155,14 @@ export function buildExtensionEnv(options: ExtensionEnvOptions): NodeJS.ProcessE
         [`${prefix}_CONFIG_DIR`]: options.configDir,
     }
 
+    // Set or cleared, never left as inherited: a nested call without --user
+    // must not act as the account the outer call chose.
     if (options.user) env[`${prefix}_USER`] = options.user
+    else delete env[`${prefix}_USER`]
+
     if (options.accessible) env[`${prefix}_ACCESSIBLE`] = '1'
 
-    for (const [key, value] of Object.entries(options.extra ?? {})) {
+    for (const [key, value] of Object.entries(options.env ?? {})) {
         if (value === undefined) delete env[key]
         else env[key] = value
     }


### PR DESCRIPTION
Slice 3 of 7, on top of slice 2.

The execution half of the contract: arguments reach the extension exactly as the user typed them, the three standard streams are the host's own, and the host exits with whatever the extension exited with.

Node-shebang scripts are launched with the host's own Node, which makes them work on Windows and pins them to the Node version the CLI already requires. Other scripts run directly on POSIX and through `sh` on Windows.

The environment adds the documented `TD_*` contract. No credential is ever injected: an extension that needs a token runs `td auth token view`. A token the user exported themselves is inherited like any other variable, which the spec records as a deliberate exception, and there is now a test pinning that behaviour so it cannot change by accident.

**Stack:** #521 core · #522 discovery · #523 dispatch · #524 tools · #525 install · #526 upgrade · #527 manager