### PR TITLE
feat(extensions): git, npm and GitHub helpers, and removal

### DIFF
--- a/src/lib/extensions/git.ts
+++ b/src/lib/extensions/git.ts
@@ -1,0 +1,114 @@
+/**
+ * The git operations the extension system needs. Every one of them shells out
+ * to the user's own git, so clones inherit whatever credential helper and SSH
+ * configuration they already have.
+ */
+
+import { CliError } from '@doist/cli-core'
+import { outputHints, run, type RunResult } from './run.js'
+
+function requireGit(result: RunResult): void {
+    if (result.missing) {
+        throw new CliError('EXTENSION_INSTALL_FAILED', 'git was not found on PATH.', {
+            hints: ['Install git, or install this extension from a release binary instead.'],
+        })
+    }
+}
+
+export async function clone(url: string, destination: string): Promise<void> {
+    const result = await run('git', ['clone', '--quiet', url, destination])
+    requireGit(result)
+    if (result.code !== 0) {
+        throw new CliError('EXTENSION_NOT_INSTALLABLE', `Could not clone ${url}.`, {
+            hints: outputHints(result),
+        })
+    }
+}
+
+export async function checkout(dir: string, ref: string): Promise<void> {
+    const result = await run('git', ['checkout', '--quiet', ref], { cwd: dir })
+    requireGit(result)
+    if (result.code !== 0) {
+        throw new CliError('EXTENSION_NOT_INSTALLABLE', `Could not check out "${ref}".`, {
+            hints: outputHints(result),
+        })
+    }
+}
+
+/** Full commit SHA of HEAD, or undefined when the directory is not a clone. */
+export async function headSha(dir: string): Promise<string | undefined> {
+    const result = await run('git', ['rev-parse', 'HEAD'], { cwd: dir })
+    if (result.code !== 0) return undefined
+    return result.stdout.trim() || undefined
+}
+
+/**
+ * Whether the working tree holds changes the user would not want deleted.
+ *
+ * `unknown` is its own answer rather than being folded into `clean`: git may
+ * be missing, the repository may be flagged as unsafe to use, or `.git` may be
+ * damaged, and in each of those cases the honest position is that the state
+ * could not be established — callers treat that as a reason to stop, not a
+ * licence to delete.
+ */
+export type WorkingTreeState = 'clean' | 'dirty' | 'unknown'
+
+export async function workingTreeState(dir: string): Promise<WorkingTreeState> {
+    const result = await run('git', ['status', '--porcelain'], { cwd: dir })
+    if (result.missing || result.code !== 0) return 'unknown'
+    return result.stdout.trim().length > 0 ? 'dirty' : 'clean'
+}
+
+export type PullResult = { changed: boolean; from?: string; to?: string; error?: string }
+
+/** Fast-forward the clone. Never rewrites local work; `resetToRemote` does that. */
+export async function pull(dir: string): Promise<PullResult> {
+    const from = await headSha(dir)
+    const result = await run('git', ['pull', '--quiet', '--ff-only'], { cwd: dir })
+    requireGit(result)
+    if (result.code !== 0) {
+        return { changed: false, from, error: outputHints(result).join(' ') }
+    }
+    const to = await headSha(dir)
+    return { changed: from !== to, from, to }
+}
+
+/** Discard local commits and working-tree changes in favour of the remote. */
+export async function resetToRemote(dir: string): Promise<PullResult> {
+    const from = await headSha(dir)
+    const fetched = await run('git', ['fetch', '--quiet', 'origin'], { cwd: dir })
+    requireGit(fetched)
+    if (fetched.code !== 0) {
+        return { changed: false, from, error: outputHints(fetched).join(' ') }
+    }
+    const reset = await run('git', ['reset', '--quiet', '--hard', 'origin/HEAD'], { cwd: dir })
+    if (reset.code !== 0) {
+        return { changed: false, from, error: outputHints(reset).join(' ') }
+    }
+    const to = await headSha(dir)
+    return { changed: from !== to, from, to }
+}
+
+/** Commit the remote's default branch points at, without fetching it. */
+export async function remoteHeadSha(dir: string): Promise<string | undefined> {
+    const result = await run('git', ['ls-remote', 'origin', 'HEAD'], { cwd: dir })
+    if (result.code !== 0) return undefined
+    return result.stdout.trim().split(/\s+/)[0] || undefined
+}
+
+/** Resolve a ref to the SHA it names, used when pinning a clone. */
+export async function resolveRef(dir: string, ref: string): Promise<string | undefined> {
+    const result = await run('git', ['rev-parse', ref], { cwd: dir })
+    if (result.code !== 0) return undefined
+    return result.stdout.trim() || undefined
+}
+
+/** Files that changed between two commits, used to decide if deps need reinstalling. */
+export async function changedFiles(dir: string, from: string, to: string): Promise<string[]> {
+    const result = await run('git', ['diff', '--name-only', `${from}..${to}`], { cwd: dir })
+    if (result.code !== 0) return []
+    return result.stdout
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+}

--- a/src/lib/extensions/git.ts
+++ b/src/lib/extensions/git.ts
@@ -7,6 +7,33 @@
 import { CliError } from '@doist/cli-core'
 import { outputHints, run, type RunResult } from './run.js'
 
+/**
+ * Remove credentials from a URL before it is shown to anyone.
+ *
+ * A private-repo remote can legitimately carry `user:token@`, and a failed
+ * clone would otherwise print that token to the terminal and into any log
+ * that captured it.
+ */
+export function redactUrl(url: string): string {
+    return url.replace(/(\w+:\/\/)[^/@\s]*@/, '$1***@')
+}
+
+/**
+ * Refuse an argument that git would read as an option.
+ *
+ * Repository URLs and refs arrive from manifests and from the command line. A
+ * value starting with a dash would otherwise choose git's behaviour rather
+ * than being the thing git acts on, and for local transports some of those
+ * options run a command.
+ */
+function requirePositional(value: string, what: string): void {
+    if (value.startsWith('-')) {
+        throw new CliError('EXTENSION_NOT_INSTALLABLE', `A ${what} cannot start with "-".`, {
+            hints: [`Got: ${redactUrl(value)}`],
+        })
+    }
+}
+
 function requireGit(result: RunResult): void {
     if (result.missing) {
         throw new CliError('EXTENSION_INSTALL_FAILED', 'git was not found on PATH.', {
@@ -16,30 +43,30 @@ function requireGit(result: RunResult): void {
 }
 
 export async function clone(url: string, destination: string): Promise<void> {
-    const result = await run('git', ['clone', '--quiet', url, destination])
+    requirePositional(url, 'repository URL')
+    const result = await run('git', ['clone', '--quiet', '--', url, destination])
     requireGit(result)
     if (result.code !== 0) {
-        throw new CliError('EXTENSION_NOT_INSTALLABLE', `Could not clone ${url}.`, {
-            hints: outputHints(result),
+        throw new CliError('EXTENSION_NOT_INSTALLABLE', `Could not clone ${redactUrl(url)}.`, {
+            hints: outputHints(result).map(redactUrl),
         })
     }
 }
 
 export async function checkout(dir: string, ref: string): Promise<void> {
-    const result = await run('git', ['checkout', '--quiet', ref], { cwd: dir })
+    requirePositional(ref, 'git ref')
+    const result = await run('git', ['checkout', '--quiet', ref, '--'], { cwd: dir })
     requireGit(result)
     if (result.code !== 0) {
         throw new CliError('EXTENSION_NOT_INSTALLABLE', `Could not check out "${ref}".`, {
-            hints: outputHints(result),
+            hints: outputHints(result).map(redactUrl),
         })
     }
 }
 
 /** Full commit SHA of HEAD, or undefined when the directory is not a clone. */
 export async function headSha(dir: string): Promise<string | undefined> {
-    const result = await run('git', ['rev-parse', 'HEAD'], { cwd: dir })
-    if (result.code !== 0) return undefined
-    return result.stdout.trim() || undefined
+    return resolveRef(dir, 'HEAD')
 }
 
 /**
@@ -73,18 +100,38 @@ export async function pull(dir: string): Promise<PullResult> {
     return { changed: from !== to, from, to }
 }
 
-/** Discard local commits and working-tree changes in favour of the remote. */
+/**
+ * Discard local commits and working-tree changes in favour of the remote.
+ *
+ * The target comes from the remote itself rather than from `origin/HEAD`,
+ * which is written at clone time and never updated by a fetch: after a
+ * repository renames its default branch, that symref still names the old one.
+ * Untracked files are cleared too, since leaving them would keep local code in
+ * a clone the user asked to be reset.
+ */
 export async function resetToRemote(dir: string): Promise<PullResult> {
     const from = await headSha(dir)
+
     const fetched = await run('git', ['fetch', '--quiet', 'origin'], { cwd: dir })
     requireGit(fetched)
     if (fetched.code !== 0) {
         return { changed: false, from, error: outputHints(fetched).join(' ') }
     }
-    const reset = await run('git', ['reset', '--quiet', '--hard', 'origin/HEAD'], { cwd: dir })
+
+    const target = await remoteHeadSha(dir)
+    if (!target) {
+        return { changed: false, from, error: 'could not resolve the remote HEAD' }
+    }
+
+    const reset = await run('git', ['reset', '--quiet', '--hard', target], { cwd: dir })
     if (reset.code !== 0) {
         return { changed: false, from, error: outputHints(reset).join(' ') }
     }
+
+    // Ignored files are left alone: they are build output and caches, not
+    // local work, and node_modules is among them.
+    await run('git', ['clean', '--quiet', '-fd'], { cwd: dir })
+
     const to = await headSha(dir)
     return { changed: from !== to, from, to }
 }
@@ -98,17 +145,29 @@ export async function remoteHeadSha(dir: string): Promise<string | undefined> {
 
 /** Resolve a ref to the SHA it names, used when pinning a clone. */
 export async function resolveRef(dir: string, ref: string): Promise<string | undefined> {
+    requirePositional(ref, 'git ref')
     const result = await run('git', ['rev-parse', ref], { cwd: dir })
     if (result.code !== 0) return undefined
     return result.stdout.trim() || undefined
 }
 
-/** Files that changed between two commits, used to decide if deps need reinstalling. */
-export async function changedFiles(dir: string, from: string, to: string): Promise<string[]> {
-    const result = await run('git', ['diff', '--name-only', `${from}..${to}`], { cwd: dir })
-    if (result.code !== 0) return []
-    return result.stdout
-        .split('\n')
-        .map((line) => line.trim())
-        .filter(Boolean)
+/**
+ * Whether any of the given paths changed between two commits.
+ *
+ * `unknown` rather than `false` when git could not answer, because the caller
+ * uses this to decide whether to reinstall dependencies, and "could not tell"
+ * is a reason to reinstall rather than a reason to skip.
+ */
+export async function pathsChanged(
+    dir: string,
+    from: string,
+    to: string,
+    paths: string[],
+): Promise<boolean | 'unknown'> {
+    const result = await run('git', ['diff', '--quiet', `${from}..${to}`, '--', ...paths], {
+        cwd: dir,
+    })
+    if (result.code === 0) return false
+    if (result.code === 1) return true
+    return 'unknown'
 }

--- a/src/lib/extensions/github.test.ts
+++ b/src/lib/extensions/github.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+    assetSuffixes,
+    createGitHubClient,
+    findExpectedChecksum,
+    pickAsset,
+    sha256,
+    verifyChecksum,
+} from './github.js'
+
+const BINARY = Buffer.from('binary contents')
+const HASH = sha256(BINARY)
+
+function clientFor(files: Record<string, string>) {
+    const calls: string[] = []
+    const impl = vi.fn(async (input: string | URL | Request) => {
+        const url = String(input)
+        calls.push(url)
+        const body = files[url]
+        if (body === undefined) return new Response('', { status: 404 })
+        return new Response(body, { status: 200 })
+    }) as unknown as typeof fetch
+    return { client: createGitHubClient(impl), calls }
+}
+
+describe('assetSuffixes', () => {
+    it('names the build this machine can run', () => {
+        expect(assetSuffixes('linux', 'x64')).toEqual(['linux-x64'])
+        expect(assetSuffixes('darwin', 'arm64')).toEqual(['darwin-arm64'])
+    })
+
+    it('prefers the .exe spelling on Windows but accepts either', () => {
+        expect(assetSuffixes('win32', 'x64')).toEqual(['win32-x64.exe', 'win32-x64'])
+    })
+})
+
+describe('pickAsset', () => {
+    const assets = [
+        { name: 'td-goals_v1_darwin-arm64', url: 'a', size: 1 },
+        { name: 'td-goals_v1_linux-x64', url: 'b', size: 1 },
+    ]
+
+    it('matches on the platform suffix wherever the version sits in the name', () => {
+        expect(pickAsset(assets, ['linux-x64'])?.url).toBe('b')
+    })
+
+    it('returns nothing when the release has no build for this machine', () => {
+        expect(pickAsset(assets, ['win32-x64.exe', 'win32-x64'])).toBeUndefined()
+    })
+})
+
+describe('findExpectedChecksum', () => {
+    const asset = { name: 'td-goals_v1_linux-x64', url: 'https://api.github.com/a', size: 1 }
+    const sums = { name: 'checksums.txt', url: 'https://api.github.com/sums', size: 1 }
+
+    it('reports that a release publishes no checksums', async () => {
+        const { client } = clientFor({})
+        const release = { tag: 'v1', assets: [asset] }
+
+        await expect(findExpectedChecksum(client, release, asset.name)).resolves.toEqual({
+            published: false,
+        })
+    })
+
+    it('reads the coreutils format', async () => {
+        const { client } = clientFor({
+            'https://api.github.com/sums': `${HASH}  ${asset.name}\n`,
+        })
+        const release = { tag: 'v1', assets: [asset, sums] }
+
+        await expect(findExpectedChecksum(client, release, asset.name)).resolves.toEqual({
+            published: true,
+            hash: HASH,
+        })
+    })
+
+    it('reads the BSD format that macOS tooling produces', async () => {
+        const { client } = clientFor({
+            'https://api.github.com/sums': `SHA256 (${asset.name}) = ${HASH}\n`,
+        })
+        const release = { tag: 'v1', assets: [asset, sums] }
+
+        await expect(findExpectedChecksum(client, release, asset.name)).resolves.toEqual({
+            published: true,
+            hash: HASH,
+        })
+    })
+
+    it('reports a checksum file that says nothing about this asset', async () => {
+        const { client } = clientFor({
+            'https://api.github.com/sums': `${HASH}  some-other-asset\n`,
+        })
+        const release = { tag: 'v1', assets: [asset, sums] }
+
+        await expect(findExpectedChecksum(client, release, asset.name)).resolves.toEqual({
+            published: true,
+        })
+    })
+})
+
+describe('verifyChecksum', () => {
+    it('accepts a download the release vouches for', () => {
+        expect(() => verifyChecksum(BINARY, { published: true, hash: HASH }, 'asset')).not.toThrow()
+    })
+
+    it('refuses a download that does not match', () => {
+        expect(() =>
+            verifyChecksum(BINARY, { published: true, hash: '0'.repeat(64) }, 'asset'),
+        ).toThrow(/does not match/)
+    })
+
+    it('allows a release that publishes no checksums at all', () => {
+        expect(() => verifyChecksum(BINARY, { published: false }, 'asset')).not.toThrow()
+    })
+
+    it('refuses a release that publishes checksums but omits this asset', () => {
+        // Installing unverified here would be worse than failing: the release
+        // meant to cover this file and does not.
+        expect(() => verifyChecksum(BINARY, { published: true }, 'asset')).toThrow(
+            /lists none for asset/,
+        )
+    })
+})
+
+describe('fetchRepoFile', () => {
+    it('refuses a path that would climb out of the repository', async () => {
+        const { client, calls } = clientFor({})
+
+        // The request carries the user's GitHub token, so a path that escapes
+        // /contents/ would read from a repository they never asked about.
+        await expect(
+            client.fetchRepoFile('Doist', 'td-goals', '../../../other/repo/contents/secret'),
+        ).rejects.toThrow(/not a valid path/)
+        expect(calls).toEqual([])
+    })
+
+    it('encodes each segment of a legitimate path', async () => {
+        const { client, calls } = clientFor({})
+
+        await client.fetchRepoFile('Doist', 'td-goals', 'dir/td extension.json', 'v1.0.0')
+
+        expect(calls[0]).toBe(
+            'https://api.github.com/repos/Doist/td-goals/contents/dir/td%20extension.json?ref=v1.0.0',
+        )
+    })
+})

--- a/src/lib/extensions/github.ts
+++ b/src/lib/extensions/github.ts
@@ -1,0 +1,191 @@
+/**
+ * The slice of the GitHub API the extension system uses: look up a release,
+ * download an asset, and read a file out of the repository.
+ *
+ * `GH_TOKEN` / `GITHUB_TOKEN` are honoured when set, so extensions in private
+ * repositories install without any extra configuration.
+ */
+
+import { createHash } from 'node:crypto'
+import { CliError } from '@doist/cli-core'
+
+export type ReleaseAsset = {
+    name: string
+    /** API URL that serves the bytes when asked for `application/octet-stream`. */
+    url: string
+    size: number
+}
+
+export type Release = {
+    tag: string
+    assets: ReleaseAsset[]
+}
+
+export type GitHubClient = {
+    fetchRelease(owner: string, repo: string, tag?: string): Promise<Release | undefined>
+    downloadAsset(asset: ReleaseAsset): Promise<Buffer>
+    fetchAssetText(asset: ReleaseAsset): Promise<string>
+    fetchRepoFile(
+        owner: string,
+        repo: string,
+        path: string,
+        ref?: string,
+    ): Promise<string | undefined>
+}
+
+const API_ROOT = 'https://api.github.com'
+
+function authHeaders(): Record<string, string> {
+    const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN
+    return token ? { authorization: `Bearer ${token}` } : {}
+}
+
+function failed(response: Response, what: string): CliError {
+    const hints =
+        response.status === 403 || response.status === 429
+            ? ['GitHub may be rate limiting you. Set GH_TOKEN to raise the limit.']
+            : response.status === 401
+              ? ['Check that GH_TOKEN or GITHUB_TOKEN is valid.']
+              : []
+    return new CliError(
+        'EXTENSION_NOT_INSTALLABLE',
+        `GitHub returned ${response.status} for ${what}.`,
+        { hints },
+    )
+}
+
+export function createGitHubClient(fetchImpl: typeof fetch = fetch): GitHubClient {
+    async function request(url: string, accept: string): Promise<Response> {
+        return fetchImpl(url, {
+            headers: {
+                accept,
+                'user-agent': 'doist-cli-extensions',
+                'x-github-api-version': '2022-11-28',
+                ...authHeaders(),
+            },
+        })
+    }
+
+    return {
+        async fetchRelease(owner, repo, tag) {
+            const path = tag ? `releases/tags/${encodeURIComponent(tag)}` : 'releases/latest'
+            const url = `${API_ROOT}/repos/${owner}/${repo}/${path}`
+            const response = await request(url, 'application/vnd.github+json')
+
+            if (response.status === 404) return undefined
+            if (!response.ok) throw failed(response, `${owner}/${repo} ${path}`)
+
+            const body = (await response.json()) as {
+                tag_name?: string
+                assets?: { name?: string; url?: string; size?: number }[]
+            }
+            return {
+                tag: body.tag_name ?? tag ?? '',
+                assets: (body.assets ?? [])
+                    .filter(
+                        (asset): asset is { name: string; url: string; size: number } =>
+                            typeof asset.name === 'string' && typeof asset.url === 'string',
+                    )
+                    .map((asset) => ({ name: asset.name, url: asset.url, size: asset.size ?? 0 })),
+            }
+        },
+
+        async downloadAsset(asset) {
+            const response = await request(asset.url, 'application/octet-stream')
+            if (!response.ok) throw failed(response, `asset ${asset.name}`)
+            return Buffer.from(await response.arrayBuffer())
+        },
+
+        async fetchAssetText(asset) {
+            const response = await request(asset.url, 'application/octet-stream')
+            if (!response.ok) throw failed(response, `asset ${asset.name}`)
+            return response.text()
+        },
+
+        async fetchRepoFile(owner, repo, path, ref) {
+            const query = ref ? `?ref=${encodeURIComponent(ref)}` : ''
+            const url = `${API_ROOT}/repos/${owner}/${repo}/contents/${path}${query}`
+            const response = await request(url, 'application/vnd.github.raw')
+            if (response.status === 404) return undefined
+            if (!response.ok) throw failed(response, `${owner}/${repo} ${path}`)
+            return response.text()
+        },
+    }
+}
+
+/**
+ * Asset name endings that identify a build for this machine. Node's own
+ * `platform`-`arch` spelling is used, since an extension author working in
+ * Node already has those values to hand.
+ */
+export function assetSuffixes(
+    platform: NodeJS.Platform = process.platform,
+    arch: string = process.arch,
+): string[] {
+    const base = `${platform}-${arch}`
+    return platform === 'win32' ? [`${base}.exe`, base] : [base]
+}
+
+export function pickAsset(assets: ReleaseAsset[], suffixes: string[]): ReleaseAsset | undefined {
+    for (const suffix of suffixes) {
+        const match = assets.find((asset) => asset.name.endsWith(suffix))
+        if (match) return match
+    }
+    return undefined
+}
+
+/**
+ * The checksum a release publishes for one asset, from either a shared
+ * `checksums.txt` or a per-asset `<asset>.sha256`. Returns undefined when the
+ * release publishes neither, which is not an error — only a mismatch is.
+ */
+export async function findExpectedChecksum(
+    client: GitHubClient,
+    release: Release,
+    assetName: string,
+): Promise<string | undefined> {
+    const perAsset = release.assets.find((asset) => asset.name === `${assetName}.sha256`)
+    if (perAsset) {
+        const text = await client.fetchAssetText(perAsset)
+        return text.trim().split(/\s+/)[0]?.toLowerCase()
+    }
+
+    const combined = release.assets.find(
+        (asset) => asset.name === 'checksums.txt' || asset.name.endsWith('_checksums.txt'),
+    )
+    if (!combined) return undefined
+
+    const text = await client.fetchAssetText(combined)
+    for (const line of text.split('\n')) {
+        const [hash, ...rest] = line.trim().split(/\s+/)
+        const name = rest.join(' ').replace(/^\*/, '')
+        if (name === assetName) return hash.toLowerCase()
+    }
+    return undefined
+}
+
+export function sha256(data: Buffer): string {
+    return createHash('sha256').update(data).digest('hex')
+}
+
+export function verifyChecksum(
+    data: Buffer,
+    expected: string | undefined,
+    assetName: string,
+): void {
+    if (!expected) return
+    const actual = sha256(data)
+    if (actual !== expected) {
+        throw new CliError(
+            'EXTENSION_CHECKSUM_MISMATCH',
+            `The downloaded asset ${assetName} does not match the published checksum.`,
+            {
+                hints: [
+                    `Expected ${expected}`,
+                    `Got      ${actual}`,
+                    'The download may be corrupt or the release may have been tampered with.',
+                ],
+            },
+        )
+    }
+}

--- a/src/lib/extensions/github.ts
+++ b/src/lib/extensions/github.ts
@@ -36,6 +36,16 @@ export type GitHubClient = {
 const API_ROOT = 'https://api.github.com'
 
 /**
+ * The REST API version to ask for.
+ *
+ * Pinned rather than left to default, so that GitHub moving its default can
+ * never change what an install sees. Raise it deliberately, after checking the
+ * endpoints used here still answer the same way: a release by tag and by
+ * latest, an asset download, and a file's contents.
+ */
+const API_VERSION = '2026-03-10'
+
+/**
  * Turn a repository-relative path into one URL path segment at a time.
  *
  * Encoding alone is not enough, because `..` is made of unreserved characters
@@ -79,7 +89,7 @@ export function createGitHubClient(fetchImpl: typeof fetch = fetch): GitHubClien
             headers: {
                 accept,
                 'user-agent': 'doist-cli-extensions',
-                'x-github-api-version': '2022-11-28',
+                'x-github-api-version': API_VERSION,
                 ...authHeaders(),
             },
         })

--- a/src/lib/extensions/github.ts
+++ b/src/lib/extensions/github.ts
@@ -35,6 +35,25 @@ export type GitHubClient = {
 
 const API_ROOT = 'https://api.github.com'
 
+/**
+ * Turn a repository-relative path into one URL path segment at a time.
+ *
+ * Encoding alone is not enough, because `..` is made of unreserved characters
+ * and survives `encodeURIComponent` intact. Left in, it would climb out of
+ * `/contents/` and point this authenticated request — which carries the
+ * user's GitHub token — at a different repository.
+ */
+export function encodeRepoPath(path: string): string {
+    const segments = path.split('/').filter(Boolean)
+    if (segments.length === 0 || segments.some((segment) => segment === '.' || segment === '..')) {
+        throw new CliError(
+            'EXTENSION_NOT_INSTALLABLE',
+            `"${path}" is not a valid path inside a repository.`,
+        )
+    }
+    return segments.map(encodeURIComponent).join('/')
+}
+
 function authHeaders(): Record<string, string> {
     const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN
     return token ? { authorization: `Bearer ${token}` } : {}
@@ -104,7 +123,7 @@ export function createGitHubClient(fetchImpl: typeof fetch = fetch): GitHubClien
 
         async fetchRepoFile(owner, repo, path, ref) {
             const query = ref ? `?ref=${encodeURIComponent(ref)}` : ''
-            const url = `${API_ROOT}/repos/${owner}/${repo}/contents/${path}${query}`
+            const url = `${API_ROOT}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${encodeRepoPath(path)}${query}`
             const response = await request(url, 'application/vnd.github.raw')
             if (response.status === 404) return undefined
             if (!response.ok) throw failed(response, `${owner}/${repo} ${path}`)
@@ -135,29 +154,59 @@ export function pickAsset(assets: ReleaseAsset[], suffixes: string[]): ReleaseAs
 }
 
 /**
- * The checksum a release publishes for one asset, from either a shared
- * `checksums.txt` or a per-asset `<asset>.sha256`. Returns undefined when the
- * release publishes neither, which is not an error — only a mismatch is.
+ * What a release says the checksum of one asset should be, from either a
+ * per-asset `<asset>.sha256` or a shared checksum file.
  */
+export type ChecksumLookup = {
+    /** True when the release publishes checksums at all. */
+    published: boolean
+    /** The checksum for this asset, when the release names it. */
+    hash?: string
+}
+
 export async function findExpectedChecksum(
     client: GitHubClient,
     release: Release,
     assetName: string,
-): Promise<string | undefined> {
+): Promise<ChecksumLookup> {
     const perAsset = release.assets.find((asset) => asset.name === `${assetName}.sha256`)
     if (perAsset) {
         const text = await client.fetchAssetText(perAsset)
-        return text.trim().split(/\s+/)[0]?.toLowerCase()
+        const hash = findChecksumLine(text, assetName) ?? text.trim().split(/\s+/)[0]?.toLowerCase()
+        return hash ? { published: true, hash } : { published: true }
     }
 
     const combined = release.assets.find(
         (asset) => asset.name === 'checksums.txt' || asset.name.endsWith('_checksums.txt'),
     )
-    if (!combined) return undefined
+    if (!combined) return { published: false }
 
     const text = await client.fetchAssetText(combined)
-    for (const line of text.split('\n')) {
-        const [hash, ...rest] = line.trim().split(/\s+/)
+    const hash = findChecksumLine(text, assetName)
+    // A published checksum file that says nothing about this asset is a
+    // problem with the release, not an absence of checksums: treating it as
+    // "none published" would install an unverified binary and say so
+    // inaccurately.
+    return hash ? { published: true, hash } : { published: true }
+}
+
+/**
+ * Both spellings a checksum file comes in: the coreutils form
+ * `<hash>  <name>`, and the BSD form `SHA256 (<name>) = <hash>` that macOS
+ * and some release tooling produce.
+ */
+function findChecksumLine(text: string, assetName: string): string | undefined {
+    for (const rawLine of text.split('\n')) {
+        const line = rawLine.trim()
+        if (!line) continue
+
+        const bsd = line.match(/^\w+\s*\(([^)]+)\)\s*=\s*([0-9a-fA-F]+)$/)
+        if (bsd) {
+            if (bsd[1] === assetName) return bsd[2].toLowerCase()
+            continue
+        }
+
+        const [hash, ...rest] = line.split(/\s+/)
         const name = rest.join(' ').replace(/^\*/, '')
         if (name === assetName) return hash.toLowerCase()
     }
@@ -168,12 +217,30 @@ export function sha256(data: Buffer): string {
     return createHash('sha256').update(data).digest('hex')
 }
 
-export function verifyChecksum(
-    data: Buffer,
-    expected: string | undefined,
-    assetName: string,
-): void {
-    if (!expected) return
+/**
+ * Check a download against what the release published.
+ *
+ * A release that publishes checksums but names no entry for this asset is
+ * refused rather than installed unverified: the file the user is about to run
+ * was meant to be covered and is not.
+ */
+export function verifyChecksum(data: Buffer, lookup: ChecksumLookup, assetName: string): void {
+    if (!lookup.published) return
+
+    if (!lookup.hash) {
+        throw new CliError(
+            'EXTENSION_CHECKSUM_MISMATCH',
+            `This release publishes checksums but lists none for ${assetName}.`,
+            {
+                hints: [
+                    'The release is incomplete, so the download cannot be verified.',
+                    'Ask the extension author to publish a checksum for every asset.',
+                ],
+            },
+        )
+    }
+
+    const expected = lookup.hash
     const actual = sha256(data)
     if (actual !== expected) {
         throw new CliError(

--- a/src/lib/extensions/npm.test.ts
+++ b/src/lib/extensions/npm.test.ts
@@ -1,0 +1,104 @@
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installDependencies } from './npm.js'
+
+/**
+ * These tests put a fake `npm` on PATH and inspect how it was called, which is
+ * the only way to prove what the real one would receive. Windows resolves and
+ * invokes npm differently, so the fake would not stand in for it.
+ */
+describe.skipIf(process.platform === 'win32')('installDependencies', () => {
+    let root: string
+    let extensionDir: string
+    let recordPath: string
+
+    async function fakeNpmOnPath(exitCode = 0): Promise<void> {
+        const binDir = join(root, 'bin')
+        await writeFile(
+            join(binDir, 'npm'),
+            `#!/bin/sh\n{ echo "ARGS:$*"; env; } > "${recordPath}"\nexit ${exitCode}\n`,
+        )
+        await chmod(join(binDir, 'npm'), 0o755)
+        vi.stubEnv('PATH', binDir)
+    }
+
+    async function record(): Promise<string> {
+        return readFile(recordPath, 'utf8')
+    }
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-npm-'))
+        extensionDir = join(root, 'td-goals')
+        recordPath = join(root, 'npm-call.txt')
+        await mkdir(join(root, 'bin'), { recursive: true })
+        await mkdir(extensionDir, { recursive: true })
+    })
+
+    afterEach(async () => {
+        vi.unstubAllEnvs()
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('does nothing when the extension has no package.json', async () => {
+        await fakeNpmOnPath()
+
+        await installDependencies(extensionDir)
+
+        await expect(record()).rejects.toThrow()
+    })
+
+    it('uses npm ci when a lockfile is present', async () => {
+        await writeFile(join(extensionDir, 'package.json'), '{}')
+        await writeFile(join(extensionDir, 'package-lock.json'), '{}')
+        await fakeNpmOnPath()
+
+        await installDependencies(extensionDir)
+
+        expect(await record()).toContain('ARGS:ci --omit=dev')
+    })
+
+    it('avoids writing a lockfile into a clone that has none', async () => {
+        await writeFile(join(extensionDir, 'package.json'), '{}')
+        await fakeNpmOnPath()
+
+        await installDependencies(extensionDir)
+
+        // Writing one would leave the clone looking modified, which later makes
+        // `remove` refuse on an extension the user never touched.
+        expect(await record()).toContain('ARGS:install --omit=dev --no-package-lock')
+    })
+
+    it('keeps the CLI’s own credentials away from lifecycle scripts', async () => {
+        vi.stubEnv('TODOIST_API_TOKEN', 'secret-todoist-token')
+        vi.stubEnv('GH_TOKEN', 'secret-github-token')
+        vi.stubEnv('GITHUB_TOKEN', 'secret-github-token')
+        await writeFile(join(extensionDir, 'package.json'), '{}')
+        await fakeNpmOnPath()
+
+        await installDependencies(extensionDir)
+
+        const environment = await record()
+        expect(environment).not.toContain('secret-todoist-token')
+        expect(environment).not.toContain('secret-github-token')
+    })
+
+    it('reports a missing npm as its own failure', async () => {
+        await writeFile(join(extensionDir, 'package.json'), '{}')
+        vi.stubEnv('PATH', join(root, 'empty'))
+
+        await expect(installDependencies(extensionDir)).rejects.toMatchObject({
+            code: 'EXTENSION_NPM_MISSING',
+        })
+    })
+
+    it('surfaces an npm failure with its output as hints', async () => {
+        await writeFile(join(extensionDir, 'package.json'), '{}')
+        await fakeNpmOnPath(1)
+
+        await expect(installDependencies(extensionDir)).rejects.toMatchObject({
+            code: 'EXTENSION_INSTALL_FAILED',
+        })
+    })
+})

--- a/src/lib/extensions/npm.test.ts
+++ b/src/lib/extensions/npm.test.ts
@@ -16,9 +16,20 @@ describe.skipIf(process.platform === 'win32')('installDependencies', () => {
 
     async function fakeNpmOnPath(exitCode = 0): Promise<void> {
         const binDir = join(root, 'bin')
+        // `export -p` is a shell builtin, so the dump works whatever the
+        // stubbed PATH contains. Using `env` here would silently record
+        // nothing and make the credential assertions pass vacuously.
         await writeFile(
             join(binDir, 'npm'),
-            `#!/bin/sh\n{ echo "ARGS:$*"; env; } > "${recordPath}"\nexit ${exitCode}\n`,
+            [
+                '#!/bin/sh',
+                // The availability probe must succeed even when the install is
+                // meant to fail, or the test would exercise the wrong branch.
+                'if [ "$1" = "--version" ]; then echo 10.0.0; exit 0; fi',
+                `{ echo "ARGS:$*"; export -p; } > "${recordPath}"`,
+                `exit ${exitCode}`,
+                '',
+            ].join('\n'),
         )
         await chmod(join(binDir, 'npm'), 0o755)
         vi.stubEnv('PATH', binDir)
@@ -70,10 +81,21 @@ describe.skipIf(process.platform === 'win32')('installDependencies', () => {
         expect(await record()).toContain('ARGS:install --omit=dev --no-package-lock')
     })
 
+    it('records the environment it was given, so the credential test cannot pass vacuously', async () => {
+        vi.stubEnv('XX_CANARY', 'canary-value')
+        await writeFile(join(extensionDir, 'package.json'), '{}')
+        await fakeNpmOnPath()
+
+        await installDependencies(extensionDir)
+
+        expect(await record()).toContain('canary-value')
+    })
+
     it('keeps the CLI’s own credentials away from lifecycle scripts', async () => {
         vi.stubEnv('TODOIST_API_TOKEN', 'secret-todoist-token')
         vi.stubEnv('GH_TOKEN', 'secret-github-token')
         vi.stubEnv('GITHUB_TOKEN', 'secret-github-token')
+        vi.stubEnv('gh_token', 'secret-lowercase-token')
         await writeFile(join(extensionDir, 'package.json'), '{}')
         await fakeNpmOnPath()
 
@@ -82,11 +104,13 @@ describe.skipIf(process.platform === 'win32')('installDependencies', () => {
         const environment = await record()
         expect(environment).not.toContain('secret-todoist-token')
         expect(environment).not.toContain('secret-github-token')
+        expect(environment).not.toContain('secret-lowercase-token')
     })
 
     it('reports a missing npm as its own failure', async () => {
         await writeFile(join(extensionDir, 'package.json'), '{}')
         vi.stubEnv('PATH', join(root, 'empty'))
+        vi.stubEnv('ComSpec', join(root, 'empty', 'cmd.exe'))
 
         await expect(installDependencies(extensionDir)).rejects.toMatchObject({
             code: 'EXTENSION_NPM_MISSING',

--- a/src/lib/extensions/npm.ts
+++ b/src/lib/extensions/npm.ts
@@ -24,12 +24,17 @@ export async function hasPackageJson(dir: string): Promise<boolean> {
  * settings), so naming what must not travel is both safer in practice and
  * easier to keep correct than naming everything that may.
  */
-const SECRET_ENV_VARS = ['TODOIST_API_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN']
+const SECRET_ENV_VARS = new Set(['TODOIST_API_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN'])
 
+/**
+ * Compared without regard to case: Windows environment lookups are
+ * case-insensitive, so a token exported as `gh_token` is still the token, and
+ * an exact-key delete would leave it in place.
+ */
 function environmentWithoutSecrets(): NodeJS.ProcessEnv {
-    const env = { ...process.env }
-    for (const name of SECRET_ENV_VARS) delete env[name]
-    return env
+    return Object.fromEntries(
+        Object.entries(process.env).filter(([name]) => !SECRET_ENV_VARS.has(name.toUpperCase())),
+    )
 }
 
 /**
@@ -51,8 +56,35 @@ function npmCommand(): { command: string; prefix: string[] } {
  * clone is a git working tree, and writing a lockfile into it would leave the
  * extension looking modified for every later `remove` and `upgrade`.
  */
+/**
+ * Whether npm can be run at all.
+ *
+ * On Windows npm is reached through the command interpreter, so a missing npm
+ * looks like an ordinary non-zero exit rather than a program that could not be
+ * spawned. Asking first keeps the "npm is not installed" message reachable
+ * there instead of surfacing cmd's own wording as an install failure.
+ */
+async function npmIsAvailable(): Promise<boolean> {
+    const { command, prefix } = npmCommand()
+    const probe = await run(command, [...prefix, '--version'])
+    return !probe.missing && probe.code === 0
+}
+
 export async function installDependencies(dir: string): Promise<void> {
     if (!(await hasPackageJson(dir))) return
+
+    if (!(await npmIsAvailable())) {
+        throw new CliError(
+            'EXTENSION_NPM_MISSING',
+            'This extension has dependencies but npm was not found on PATH.',
+            {
+                hints: [
+                    'Install npm, then run the install again.',
+                    'Extension authors can avoid this by vendoring dependencies or shipping a release binary.',
+                ],
+            },
+        )
+    }
 
     const hasLockfile = await exists(join(dir, 'package-lock.json'))
     const args = hasLockfile ? ['ci', '--omit=dev'] : ['install', '--omit=dev', '--no-package-lock']

--- a/src/lib/extensions/npm.ts
+++ b/src/lib/extensions/npm.ts
@@ -1,0 +1,85 @@
+/**
+ * Dependency installation for extensions that ship a `package.json`.
+ *
+ * Lifecycle scripts are allowed to run: packages with native dependencies need
+ * them, and by the time this runs the user has already been shown the trust
+ * warning and chosen to install code from this publisher. Those scripts are
+ * third-party code that the user never chose directly, though, so they run
+ * without the credentials the CLI itself uses.
+ */
+
+import { join } from 'node:path'
+import { CliError } from '@doist/cli-core'
+import { exists } from './fs-utils.js'
+import { outputHints, run } from './run.js'
+
+export async function hasPackageJson(dir: string): Promise<boolean> {
+    return exists(join(dir, 'package.json'))
+}
+
+/**
+ * Variables removed before running npm. A denylist rather than an allowlist:
+ * npm legitimately needs a large and open-ended slice of the environment
+ * (proxies, certificate bundles, registry credentials, package-manager
+ * settings), so naming what must not travel is both safer in practice and
+ * easier to keep correct than naming everything that may.
+ */
+const SECRET_ENV_VARS = ['TODOIST_API_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN']
+
+function environmentWithoutSecrets(): NodeJS.ProcessEnv {
+    const env = { ...process.env }
+    for (const name of SECRET_ENV_VARS) delete env[name]
+    return env
+}
+
+/**
+ * How to invoke npm on this platform.
+ *
+ * On Windows npm is a `.cmd` shim, and since Node's fix for CVE-2024-27980 a
+ * `.cmd` file cannot be spawned directly — it has to go through the command
+ * interpreter, which this CLI's supported Node versions all enforce.
+ */
+function npmCommand(): { command: string; prefix: string[] } {
+    return process.platform === 'win32'
+        ? { command: process.env.ComSpec ?? 'cmd.exe', prefix: ['/d', '/s', '/c', 'npm'] }
+        : { command: 'npm', prefix: [] }
+}
+
+/**
+ * Install production dependencies in place. Uses `npm ci` when a lockfile is
+ * present. Without one it falls back to `npm install --no-package-lock`: the
+ * clone is a git working tree, and writing a lockfile into it would leave the
+ * extension looking modified for every later `remove` and `upgrade`.
+ */
+export async function installDependencies(dir: string): Promise<void> {
+    if (!(await hasPackageJson(dir))) return
+
+    const hasLockfile = await exists(join(dir, 'package-lock.json'))
+    const args = hasLockfile ? ['ci', '--omit=dev'] : ['install', '--omit=dev', '--no-package-lock']
+    const { command, prefix } = npmCommand()
+    const result = await run(command, [...prefix, ...args], {
+        cwd: dir,
+        env: environmentWithoutSecrets(),
+    })
+
+    if (result.missing) {
+        throw new CliError(
+            'EXTENSION_NPM_MISSING',
+            'This extension has dependencies but npm was not found on PATH.',
+            {
+                hints: [
+                    'Install npm, then run the install again.',
+                    'Extension authors can avoid this by vendoring dependencies or shipping a release binary.',
+                ],
+            },
+        )
+    }
+
+    if (result.code !== 0) {
+        throw new CliError(
+            'EXTENSION_INSTALL_FAILED',
+            "Could not install the extension's dependencies.",
+            { hints: outputHints(result) },
+        )
+    }
+}

--- a/src/lib/extensions/remove.test.ts
+++ b/src/lib/extensions/remove.test.ts
@@ -118,10 +118,11 @@ describe('removeExtension', () => {
 
         it('refuses when it cannot tell whether the clone is dirty', async () => {
             const dir = await writeFixtureExtension(extensionsDir, 'broken')
-            // A `.git` that git cannot read: discovery still sees a clone, but
-            // its state cannot be established, and deleting on that basis is
-            // how uncommitted work gets lost.
-            await writeFile(join(dir, '.git'), 'not a git directory')
+            // A `.git` directory git cannot make sense of: discovery still
+            // sees a clone, but its state cannot be established, and deleting
+            // on that basis is how uncommitted work gets lost.
+            await mkdir(join(dir, '.git'), { recursive: true })
+            await writeFile(join(dir, '.git', 'HEAD'), 'nonsense')
 
             await expect(
                 removeExtension(await find('broken'), {}, context()),

--- a/src/lib/extensions/remove.test.ts
+++ b/src/lib/extensions/remove.test.ts
@@ -1,0 +1,150 @@
+import { mkdir, mkdtemp, rm, stat, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { writeFixtureExtension } from '../../test-support/extension-fixture.js'
+import { discoverExtensions } from './discover.js'
+import { removeExtension } from './remove.js'
+import { run } from './run.js'
+import { readState, stateFilePath, writeState } from './state.js'
+
+const HAS_GIT = (await run('git', ['--version'])).code === 0
+const OFFICIAL = { host: 'github.com', owner: 'Doist' }
+
+describe('removeExtension', () => {
+    let root: string
+    let extensionsDir: string
+    let stateDir: string
+
+    const context = () => ({ binName: 'td', stateDir })
+    const find = async (name: string) => {
+        const found = await discoverExtensions({
+            extensionsDir,
+            stateDir,
+            binName: 'td',
+            officialSource: OFFICIAL,
+        })
+        const extension = found.find((candidate) => candidate.name === name)
+        if (!extension) throw new Error(`fixture ${name} not discovered`)
+        return extension
+    }
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-remove-'))
+        extensionsDir = join(root, 'extensions')
+        stateDir = join(root, 'state')
+        await mkdir(extensionsDir, { recursive: true })
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('removes a binary install and its state file', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: {
+                owner: 'Doist',
+                name: 'td-goals',
+                host: 'github.com',
+                tag: 'v1',
+                pinned: false,
+                asset: 'a',
+                installedAt: 'now',
+            },
+        })
+        await writeState(stateDir, 'td-goals', { latestRelease: 'v1' })
+
+        const result = await removeExtension(await find('goals'), {}, context())
+
+        expect(result).toMatchObject({ name: 'goals', kind: 'binary', removed: 'directory' })
+        await expect(stat(join(extensionsDir, 'td-goals'))).rejects.toThrow()
+        await expect(stat(stateFilePath(stateDir, 'td-goals'))).rejects.toThrow()
+    })
+
+    it('removes only the link for a local install, never the user’s directory', async () => {
+        const workspace = join(root, 'code')
+        await mkdir(workspace, { recursive: true })
+        const target = await writeFixtureExtension(workspace, 'scratch')
+        await symlink(target, join(extensionsDir, 'td-scratch'), 'dir')
+
+        const result = await removeExtension(await find('scratch'), {}, context())
+
+        expect(result).toMatchObject({ kind: 'local', removed: 'link' })
+        await expect(stat(join(extensionsDir, 'td-scratch'))).rejects.toThrow()
+        await expect(stat(join(target, 'td-scratch'))).resolves.toBeTruthy()
+    })
+
+    describe.skipIf(!HAS_GIT)('git clones', () => {
+        async function makeClone(name: string, dirty: boolean): Promise<void> {
+            const dir = await writeFixtureExtension(extensionsDir, name)
+            await run('git', ['init', '--quiet', '--initial-branch=main'], { cwd: dir })
+            await run('git', ['add', '.'], { cwd: dir })
+            await run(
+                'git',
+                [
+                    '-c',
+                    'user.email=t@example.com',
+                    '-c',
+                    'user.name=T',
+                    'commit',
+                    '--quiet',
+                    '-m',
+                    'init',
+                ],
+                { cwd: dir },
+            )
+            if (dirty) await writeFile(join(dir, 'notes.md'), 'work in progress')
+        }
+
+        it('refuses a clone with uncommitted work', async () => {
+            await makeClone('wip', true)
+
+            await expect(removeExtension(await find('wip'), {}, context())).rejects.toMatchObject({
+                code: 'EXTENSION_DIRTY',
+            })
+
+            await expect(stat(join(extensionsDir, 'td-wip'))).resolves.toBeTruthy()
+        })
+
+        it('removes a clone with uncommitted work when forced', async () => {
+            await makeClone('wip', true)
+
+            await expect(
+                removeExtension(await find('wip'), { force: true }, context()),
+            ).resolves.toMatchObject({ removed: 'directory' })
+
+            await expect(stat(join(extensionsDir, 'td-wip'))).rejects.toThrow()
+        })
+
+        it('refuses when it cannot tell whether the clone is dirty', async () => {
+            const dir = await writeFixtureExtension(extensionsDir, 'broken')
+            // A `.git` that git cannot read: discovery still sees a clone, but
+            // its state cannot be established, and deleting on that basis is
+            // how uncommitted work gets lost.
+            await writeFile(join(dir, '.git'), 'not a git directory')
+
+            await expect(
+                removeExtension(await find('broken'), {}, context()),
+            ).rejects.toMatchObject({ code: 'EXTENSION_DIRTY' })
+
+            await expect(stat(join(extensionsDir, 'td-broken'))).resolves.toBeTruthy()
+        })
+
+        it('removes a clean clone without being forced', async () => {
+            await makeClone('clean', false)
+
+            await expect(
+                removeExtension(await find('clean'), {}, context()),
+            ).resolves.toMatchObject({ kind: 'git', removed: 'directory' })
+        })
+    })
+
+    it('leaves no state behind for a reinstall to inherit', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals')
+        await writeState(stateDir, 'td-goals', { pinned: 'v1.0.0' })
+
+        await removeExtension(await find('goals'), {}, context())
+
+        await expect(readState(stateDir, 'td-goals')).resolves.toEqual({})
+    })
+})

--- a/src/lib/extensions/remove.ts
+++ b/src/lib/extensions/remove.ts
@@ -1,0 +1,72 @@
+/**
+ * Removing an extension.
+ *
+ * The rule is that nothing the user wrote is deleted without them saying so:
+ * a local install only loses its link, and a clone with uncommitted work
+ * refuses to go until it is forced.
+ */
+
+import { rm } from 'node:fs/promises'
+import { CliError } from '@doist/cli-core'
+import { workingTreeState } from './git.js'
+import { removeState } from './state.js'
+import type { Extension, RemoveOptions, RemoveResult } from './types.js'
+
+export type RemoveContext = {
+    binName: string
+    stateDir: string
+}
+
+export async function removeExtension(
+    extension: Extension,
+    options: RemoveOptions,
+    context: RemoveContext,
+): Promise<RemoveResult> {
+    if (extension.kind === 'local') {
+        // Only the link inside the extensions directory. The directory it
+        // points at belongs to the user.
+        await rm(extension.entryPath, { force: true })
+        await removeState(context.stateDir, extension.dirName)
+        return {
+            name: extension.name,
+            kind: extension.kind,
+            removed: 'link',
+            path: extension.entryPath,
+        }
+    }
+
+    if (extension.kind === 'git' && !options.force) {
+        const state = await workingTreeState(extension.dir)
+        const forceHint = `Run \`${context.binName} extension remove ${extension.name} --force\` to delete it anyway.`
+
+        if (state === 'dirty') {
+            throw new CliError(
+                'EXTENSION_DIRTY',
+                `"${extension.name}" has uncommitted changes in ${extension.dir}.`,
+                { hints: ['Commit or push the changes first, so they are not lost.', forceHint] },
+            )
+        }
+        if (state === 'unknown') {
+            throw new CliError(
+                'EXTENSION_DIRTY',
+                `Could not tell whether "${extension.name}" has uncommitted changes in ${extension.dir}.`,
+                {
+                    hints: [
+                        'git may be missing, or the clone may be damaged or flagged as unsafe to use.',
+                        forceHint,
+                    ],
+                },
+            )
+        }
+    }
+
+    await rm(extension.entryPath, { recursive: true, force: true })
+    await removeState(context.stateDir, extension.dirName)
+
+    return {
+        name: extension.name,
+        kind: extension.kind,
+        removed: 'directory',
+        path: extension.entryPath,
+    }
+}

--- a/src/lib/extensions/run.ts
+++ b/src/lib/extensions/run.ts
@@ -1,0 +1,83 @@
+/**
+ * A small wrapper around `spawn` for the helper programs the extension system
+ * shells out to (git, npm). It captures output instead of inheriting the
+ * terminal, and it never throws on a non-zero exit — callers decide what a
+ * failure means and which error code to surface.
+ *
+ * Dispatching an extension itself is a different job and lives in `dispatch.ts`.
+ */
+
+import { spawn } from 'node:child_process'
+
+export type RunResult = {
+    code: number
+    stdout: string
+    stderr: string
+    /** True when the program itself could not be found on PATH. */
+    missing: boolean
+}
+
+export type RunOptions = {
+    cwd?: string
+    env?: NodeJS.ProcessEnv
+}
+
+/**
+ * How much of each stream to keep. Callers only ever read the last few lines,
+ * and `npm install` deliberately runs extension lifecycle scripts, so an
+ * unbounded buffer would let a chatty or looping script exhaust the heap.
+ * The streams are still drained in full; only the tail is retained.
+ */
+const MAX_CAPTURED_BYTES = 64 * 1024
+
+function appendTail(current: string, chunk: string): string {
+    const combined = current + chunk
+    return combined.length > MAX_CAPTURED_BYTES
+        ? combined.slice(combined.length - MAX_CAPTURED_BYTES)
+        : combined
+}
+
+export async function run(
+    command: string,
+    args: string[],
+    options: RunOptions = {},
+): Promise<RunResult> {
+    return new Promise((resolve) => {
+        const child = spawn(command, args, {
+            cwd: options.cwd,
+            env: options.env ?? process.env,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        })
+
+        let stdout = ''
+        let stderr = ''
+        child.stdout?.on('data', (chunk: Buffer) => {
+            stdout = appendTail(stdout, chunk.toString())
+        })
+        child.stderr?.on('data', (chunk: Buffer) => {
+            stderr = appendTail(stderr, chunk.toString())
+        })
+
+        child.on('error', (error: NodeJS.ErrnoException) => {
+            resolve({
+                code: 127,
+                stdout,
+                stderr: stderr || error.message,
+                missing: error.code === 'ENOENT',
+            })
+        })
+
+        child.on('close', (code) => {
+            resolve({ code: code ?? 1, stdout, stderr, missing: false })
+        })
+    })
+}
+
+/** The last few lines of a failed command's output, for use as error hints. */
+export function outputHints(result: RunResult, limit = 4): string[] {
+    return `${result.stderr}\n${result.stdout}`
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .slice(-limit)
+}

--- a/src/lib/extensions/run.ts
+++ b/src/lib/extensions/run.ts
@@ -28,12 +28,12 @@ export type RunOptions = {
  * unbounded buffer would let a chatty or looping script exhaust the heap.
  * The streams are still drained in full; only the tail is retained.
  */
-const MAX_CAPTURED_BYTES = 64 * 1024
+const MAX_CAPTURED_CHARACTERS = 64 * 1024
 
 function appendTail(current: string, chunk: string): string {
     const combined = current + chunk
-    return combined.length > MAX_CAPTURED_BYTES
-        ? combined.slice(combined.length - MAX_CAPTURED_BYTES)
+    return combined.length > MAX_CAPTURED_CHARACTERS
+        ? combined.slice(combined.length - MAX_CAPTURED_CHARACTERS)
         : combined
 }
 
@@ -51,11 +51,16 @@ export async function run(
 
         let stdout = ''
         let stderr = ''
-        child.stdout?.on('data', (chunk: Buffer) => {
-            stdout = appendTail(stdout, chunk.toString())
+        // Decoding per stream rather than per chunk: a multi-byte character
+        // split across two reads would otherwise come back as replacement
+        // characters, which npm's progress output makes likely.
+        child.stdout?.setEncoding('utf8')
+        child.stderr?.setEncoding('utf8')
+        child.stdout?.on('data', (chunk: string) => {
+            stdout = appendTail(stdout, chunk)
         })
-        child.stderr?.on('data', (chunk: Buffer) => {
-            stderr = appendTail(stderr, chunk.toString())
+        child.stderr?.on('data', (chunk: string) => {
+            stderr = appendTail(stderr, chunk)
         })
 
         child.on('error', (error: NodeJS.ErrnoException) => {


### PR DESCRIPTION
Slice 4 of 7, on top of slice 3.

The outside world an install has to talk to, plus the one operation that needs no installer.

- A subprocess wrapper that captures a bounded tail of output, since npm runs extension lifecycle scripts that could otherwise print without end.
- Git operations, with working-tree state reported as clean, dirty or unknown, so that "could not tell" is never mistaken for "safe to delete".
- npm dependency installation, run without the CLI's own credentials, invoked through the command interpreter on Windows because a `.cmd` shim cannot be spawned directly on supported Node versions, and without writing a lockfile into a clone that has none.
- The GitHub client: releases, asset downloads and checksum verification.
- Removal, which deletes only the link for a local install and refuses a clone with uncommitted or unreadable state unless forced.

**Stack:** #521 core · #522 discovery · #523 dispatch · #524 tools · #525 install · #526 upgrade · #527 manager