### PR TITLE
feat(extensions): install extensions

### DIFF
--- a/src/lib/extensions/install.test.ts
+++ b/src/lib/extensions/install.test.ts
@@ -7,7 +7,7 @@ import { writeFixtureExtension } from '../../test-support/extension-fixture.js'
 import { createGitHubClient } from './github.js'
 import { installExtension, type InstallContext } from './install.js'
 import { run } from './run.js'
-import { readState } from './state.js'
+import { readState, writeState } from './state.js'
 
 // Resolved once: a machine without git skips the clone tests visibly rather
 // than passing them vacuously.
@@ -241,22 +241,65 @@ describe('installExtension', () => {
             await expect(
                 installExtension('Doist/td-goals', { force: true }, contextFor(github.impl)),
             ).resolves.toMatchObject({ kind: 'binary' })
+
+            // The fixture really is gone, not merely reported as replaced.
+            const executable = await readFile(join(extensionsDir, 'td-goals', 'td-goals'))
+            expect(executable.equals(BINARY)).toBe(true)
+        })
+
+        it('puts the previous install back when the replacement cannot be finished', async () => {
+            await mkdir(extensionsDir, { recursive: true })
+            await writeFixtureExtension(extensionsDir, 'goals', {
+                authoredManifest: { description: 'the original' },
+            })
+            const github = stubGitHub()
+            const context = contextFor(github.impl)
+            // The state directory is a file, so recording the install fails
+            // after the new version is already in place.
+            await writeFile(stateDir, 'not a directory')
+
+            await expect(
+                installExtension('Doist/td-goals', { force: true }, context),
+            ).rejects.toThrow()
+
+            const manifest = JSON.parse(
+                await readFile(join(extensionsDir, 'td-goals', 'td-extension.json'), 'utf8'),
+            )
+            expect(manifest.description).toBe('the original')
         })
     })
 
     describe('local installs', () => {
-        it('links the directory instead of copying it', async () => {
+        it.skipIf(process.platform === 'win32')(
+            'links the directory instead of copying it',
+            async () => {
+                const workspace = join(root, 'code')
+                await mkdir(workspace, { recursive: true })
+                const target = await writeFixtureExtension(workspace, 'scratch')
+                const github = stubGitHub()
+
+                const result = await installExtension(target, {}, contextFor(github.impl))
+
+                expect(result).toMatchObject({ name: 'scratch', kind: 'local', dir: target })
+                const entry = join(extensionsDir, 'td-scratch')
+                expect((await lstat(entry)).isSymbolicLink()).toBe(true)
+                expect(github.calls).toEqual([])
+            },
+        )
+
+        it('clears state left behind by whatever was installed under that name', async () => {
             const workspace = join(root, 'code')
             await mkdir(workspace, { recursive: true })
-            const target = await writeFixtureExtension(workspace, 'scratch')
-            const github = stubGitHub()
+            const target = await writeFixtureExtension(workspace, 'goals')
+            await mkdir(extensionsDir, { recursive: true })
+            await writeFixtureExtension(extensionsDir, 'goals')
+            await writeState(stateDir, 'td-goals', { pinned: 'v1.0.0' })
 
-            const result = await installExtension(target, {}, contextFor(github.impl))
+            await installExtension(target, { force: true }, contextFor(stubGitHub().impl))
 
-            expect(result).toMatchObject({ name: 'scratch', kind: 'local', dir: target })
-            const entry = join(extensionsDir, 'td-scratch')
-            expect((await lstat(entry)).isSymbolicLink()).toBe(true)
-            expect(github.calls).toEqual([])
+            // A stale pin would otherwise make the new local install report as
+            // pinned and be skipped by every upgrade.
+            await expect(readState(stateDir, 'td-goals')).resolves.toEqual({})
         })
 
         it('warns when the directory has no executable yet, but still links it', async () => {
@@ -277,6 +320,16 @@ describe('installExtension', () => {
             await expect(
                 installExtension(workspace, {}, contextFor(github.impl)),
             ).rejects.toMatchObject({ code: 'EXTENSION_NAME_INVALID' })
+        })
+
+        it('refuses a plain file, which could never be dispatched', async () => {
+            const file = join(root, 'code', 'td-file')
+            await mkdir(join(root, 'code'), { recursive: true })
+            await writeFile(file, 'not a directory')
+
+            await expect(
+                installExtension(file, {}, contextFor(stubGitHub().impl)),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NOT_INSTALLABLE' })
         })
 
         it('refuses a directory that does not exist', async () => {
@@ -312,7 +365,7 @@ describe('installExtension', () => {
             return repo
         }
 
-        it('clones when the repository publishes no matching asset', async () => {
+        it('clones a repository given as a file URL', async () => {
             const repo = await makeRepo('td-cloned')
             const github = stubGitHub({ assetName: 'td-cloned_v1_other-arch' })
 
@@ -321,6 +374,34 @@ describe('installExtension', () => {
             expect(result).toMatchObject({ kind: 'git', name: 'cloned' })
             await expect(stat(join(extensionsDir, 'td-cloned', 'td-cloned'))).resolves.toBeTruthy()
             await expect(stat(join(extensionsDir, 'td-cloned', '.git'))).resolves.toBeTruthy()
+        })
+
+        it('refuses a repository whose entry point is not executable', async () => {
+            const repo = join(root, 'origin', 'Doist', 'td-unexecutable')
+            await mkdir(repo, { recursive: true })
+            await writeFile(join(repo, 'td-unexecutable'), '#!/bin/sh\necho hi\n', { mode: 0o644 })
+            await run('git', ['init', '--quiet', '--initial-branch=main'], { cwd: repo })
+            await run('git', ['add', '.'], { cwd: repo })
+            await run(
+                'git',
+                [
+                    '-c',
+                    'user.email=t@example.com',
+                    '-c',
+                    'user.name=T',
+                    'commit',
+                    '--quiet',
+                    '-m',
+                    'init',
+                ],
+                { cwd: repo },
+            )
+
+            await expect(
+                installExtension(`file://${repo}`, {}, contextFor(stubGitHub().impl)),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NOT_INSTALLABLE' })
+
+            await expect(stat(join(extensionsDir, 'td-unexecutable'))).rejects.toThrow()
         })
 
         it('refuses a repository with no executable at its root, leaving nothing behind', async () => {

--- a/src/lib/extensions/install.test.ts
+++ b/src/lib/extensions/install.test.ts
@@ -126,6 +126,7 @@ describe('installExtension', () => {
                 await readFile(join(extensionsDir, 'td-goals', '.td-manifest.json'), 'utf8'),
             )
             expect(manifest).toMatchObject({
+                manifestVersion: 1,
                 owner: 'Doist',
                 name: 'td-goals',
                 host: 'github.com',
@@ -145,6 +146,26 @@ describe('installExtension', () => {
             )
             expect(manifest.description).toBe('Track goals')
             expect(manifest.requires).toEqual({ td: '>=4.0.0' })
+        })
+
+        it('installs an extension whose manifest format is newer, and says what it ignored', async () => {
+            const github = stubGitHub({
+                authoredManifest: JSON.stringify({
+                    manifestVersion: 99,
+                    description: 'from the future',
+                }),
+            })
+
+            await expect(
+                installExtension('Doist/td-goals', {}, contextFor(github.impl)),
+            ).resolves.toMatchObject({ kind: 'binary' })
+
+            expect(warnings.some((warning) => warning.includes('format newer than'))).toBe(true)
+            const manifest = JSON.parse(
+                await readFile(join(extensionsDir, 'td-goals', '.td-manifest.json'), 'utf8'),
+            )
+            // The fields this version knows are still kept.
+            expect(manifest.description).toBe('from the future')
         })
 
         it('installs without a manifest when the repository ships none', async () => {

--- a/src/lib/extensions/install.test.ts
+++ b/src/lib/extensions/install.test.ts
@@ -1,0 +1,355 @@
+import { createHash } from 'node:crypto'
+import { lstat, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { writeFixtureExtension } from '../../test-support/extension-fixture.js'
+import { createGitHubClient } from './github.js'
+import { installExtension, type InstallContext } from './install.js'
+import { run } from './run.js'
+import { readState } from './state.js'
+
+// Resolved once: a machine without git skips the clone tests visibly rather
+// than passing them vacuously.
+const HAS_GIT = (await run('git', ['--version'])).code === 0
+const PLATFORM_SUFFIX = `${process.platform}-${process.arch}`
+const ASSET_NAME = `td-goals_v1.0.0_${PLATFORM_SUFFIX}`
+const BINARY = Buffer.from('#!/bin/sh\necho goals\n')
+const CHECKSUM = createHash('sha256').update(BINARY).digest('hex')
+
+type StubOptions = {
+    tag?: string
+    assetName?: string
+    binary?: Buffer
+    checksums?: string | null
+    authoredManifest?: string | null
+    /** Tags that exist; a request for anything else answers 404. */
+    tags?: string[]
+}
+
+function stubGitHub(options: StubOptions = {}) {
+    const tag = options.tag ?? 'v1.0.0'
+    const assetName = options.assetName ?? ASSET_NAME
+    const binary = options.binary ?? BINARY
+    const assets = [
+        { name: assetName, url: `https://api.github.com/assets/bin`, size: binary.length },
+    ]
+    if (options.checksums !== null) {
+        assets.push({ name: 'checksums.txt', url: 'https://api.github.com/assets/sums', size: 64 })
+    }
+
+    const calls: string[] = []
+    const impl = vi.fn(async (input: string | URL | Request) => {
+        const url = String(input)
+        calls.push(url)
+
+        if (url.includes('/releases/latest') || url.includes('/releases/tags/')) {
+            const requested = url.includes('/releases/tags/')
+                ? decodeURIComponent(url.split('/releases/tags/')[1])
+                : tag
+            const known = options.tags ?? [tag]
+            if (!known.includes(requested)) return new Response('{}', { status: 404 })
+            return new Response(JSON.stringify({ tag_name: requested, assets }), { status: 200 })
+        }
+        if (url.endsWith('/assets/bin')) {
+            return new Response(new Uint8Array(binary), { status: 200 })
+        }
+        if (url.endsWith('/assets/sums')) {
+            const body = options.checksums ?? `${CHECKSUM}  ${assetName}\n`
+            return new Response(body, { status: 200 })
+        }
+        if (url.includes('/contents/td-extension.json')) {
+            if (options.authoredManifest === null) return new Response('', { status: 404 })
+            return new Response(
+                options.authoredManifest ??
+                    JSON.stringify({ description: 'Track goals', requires: { td: '>=4.0.0' } }),
+                { status: 200 },
+            )
+        }
+        return new Response('{}', { status: 404 })
+    })
+
+    return { impl: impl as unknown as typeof fetch, calls, spy: impl }
+}
+
+describe('installExtension', () => {
+    let root: string
+    let extensionsDir: string
+    let stateDir: string
+    let warnings: string[]
+    let logs: string[]
+
+    function contextFor(fetchImpl: typeof fetch, reserved: string[] = []): InstallContext {
+        return {
+            binName: 'td',
+            extensionsDir,
+            stateDir,
+            officialSource: { host: 'github.com', owner: 'Doist' },
+            client: createGitHubClient(fetchImpl),
+            reservedNames: () => reserved,
+            log: (message) => logs.push(message),
+            warn: (message) => warnings.push(message),
+            trustWarning: 'Extensions are not reviewed, signed, or endorsed by Todoist.',
+        }
+    }
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-install-'))
+        extensionsDir = join(root, 'extensions')
+        stateDir = join(root, 'state')
+        warnings = []
+        logs = []
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    describe('release binaries', () => {
+        it('downloads the asset for this platform and records a manifest', async () => {
+            const github = stubGitHub()
+            const result = await installExtension('Doist/td-goals', {}, contextFor(github.impl))
+
+            expect(result).toMatchObject({
+                name: 'goals',
+                dirName: 'td-goals',
+                kind: 'binary',
+                source: 'Doist/td-goals',
+                version: 'v1.0.0',
+            })
+
+            const executable = join(extensionsDir, 'td-goals', 'td-goals')
+            expect((await readFile(executable)).equals(BINARY)).toBe(true)
+            expect((await stat(executable)).mode & 0o111).not.toBe(0)
+
+            const manifest = JSON.parse(
+                await readFile(join(extensionsDir, 'td-goals', '.td-manifest.json'), 'utf8'),
+            )
+            expect(manifest).toMatchObject({
+                owner: 'Doist',
+                name: 'td-goals',
+                host: 'github.com',
+                tag: 'v1.0.0',
+                pinned: false,
+                asset: ASSET_NAME,
+                sha256: CHECKSUM,
+            })
+        })
+
+        it("copies the author's description and requires into the manifest", async () => {
+            const github = stubGitHub()
+            await installExtension('Doist/td-goals', {}, contextFor(github.impl))
+
+            const manifest = JSON.parse(
+                await readFile(join(extensionsDir, 'td-goals', '.td-manifest.json'), 'utf8'),
+            )
+            expect(manifest.description).toBe('Track goals')
+            expect(manifest.requires).toEqual({ td: '>=4.0.0' })
+        })
+
+        it('installs without a manifest when the repository ships none', async () => {
+            const github = stubGitHub({ authoredManifest: null })
+            await expect(
+                installExtension('Doist/td-goals', {}, contextFor(github.impl)),
+            ).resolves.toMatchObject({ kind: 'binary' })
+        })
+
+        it('refuses an asset whose checksum does not match, and installs nothing', async () => {
+            const github = stubGitHub({ checksums: `${'0'.repeat(64)}  ${ASSET_NAME}\n` })
+
+            await expect(
+                installExtension('Doist/td-goals', {}, contextFor(github.impl)),
+            ).rejects.toMatchObject({ code: 'EXTENSION_CHECKSUM_MISMATCH' })
+
+            await expect(stat(join(extensionsDir, 'td-goals'))).rejects.toThrow()
+        })
+
+        it('warns, but installs, when the release publishes no checksums', async () => {
+            const github = stubGitHub({ checksums: null })
+            await installExtension('Doist/td-goals', {}, contextFor(github.impl))
+
+            expect(warnings.some((warning) => warning.includes('publishes no checksums'))).toBe(
+                true,
+            )
+        })
+
+        it('resolves --pin against the tagged release rather than the latest one', async () => {
+            const github = stubGitHub({ tag: 'v0.9.0', tags: ['v0.9.0', 'v1.0.0'] })
+            const result = await installExtension(
+                'Doist/td-goals',
+                { pin: 'v0.9.0' },
+                contextFor(github.impl),
+            )
+
+            expect(result.version).toBe('v0.9.0')
+            expect(github.calls.some((url) => url.includes('/releases/tags/v0.9.0'))).toBe(true)
+            expect(github.calls.some((url) => url.includes('/releases/latest'))).toBe(false)
+            await expect(readState(stateDir, 'td-goals')).resolves.toMatchObject({
+                pinned: 'v0.9.0',
+            })
+        })
+
+        it('prints the trust warning before it fetches anything', async () => {
+            const github = stubGitHub()
+            const order: string[] = []
+            const context = contextFor(github.impl)
+            context.warn = (message) => {
+                order.push(`warn: ${message}`)
+                warnings.push(message)
+            }
+            // Fail the first request outright, so the install stops here
+            // rather than falling through to a clone over the network.
+            github.spy.mockImplementation((() => {
+                order.push('fetch')
+                throw new Error('network disabled in this test')
+            }) as never)
+
+            await expect(installExtension('Doist/td-goals', {}, context)).rejects.toThrow()
+
+            expect(order).toEqual(['warn: ' + context.trustWarning, 'fetch'])
+        })
+    })
+
+    describe('name and collision checks', () => {
+        it('refuses a name that a built-in command already owns, before any request', async () => {
+            const github = stubGitHub()
+
+            await expect(
+                installExtension('Doist/td-task', {}, contextFor(github.impl, ['task'])),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NAME_RESERVED' })
+
+            expect(github.calls).toEqual([])
+        })
+
+        it('refuses a repository whose name lacks the binary prefix', async () => {
+            const github = stubGitHub()
+
+            await expect(
+                installExtension('Doist/goals', {}, contextFor(github.impl)),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NAME_INVALID' })
+        })
+
+        it('refuses to replace an installed extension unless forced', async () => {
+            await mkdir(extensionsDir, { recursive: true })
+            await writeFixtureExtension(extensionsDir, 'goals')
+            const github = stubGitHub()
+
+            await expect(
+                installExtension('Doist/td-goals', {}, contextFor(github.impl)),
+            ).rejects.toMatchObject({ code: 'EXTENSION_ALREADY_INSTALLED' })
+
+            await expect(
+                installExtension('Doist/td-goals', { force: true }, contextFor(github.impl)),
+            ).resolves.toMatchObject({ kind: 'binary' })
+        })
+    })
+
+    describe('local installs', () => {
+        it('links the directory instead of copying it', async () => {
+            const workspace = join(root, 'code')
+            await mkdir(workspace, { recursive: true })
+            const target = await writeFixtureExtension(workspace, 'scratch')
+            const github = stubGitHub()
+
+            const result = await installExtension(target, {}, contextFor(github.impl))
+
+            expect(result).toMatchObject({ name: 'scratch', kind: 'local', dir: target })
+            const entry = join(extensionsDir, 'td-scratch')
+            expect((await lstat(entry)).isSymbolicLink()).toBe(true)
+            expect(github.calls).toEqual([])
+        })
+
+        it('warns when the directory has no executable yet, but still links it', async () => {
+            const workspace = join(root, 'code', 'td-unbuilt')
+            await mkdir(workspace, { recursive: true })
+            const github = stubGitHub()
+
+            await installExtension(workspace, {}, contextFor(github.impl))
+
+            expect(warnings.some((warning) => warning.includes('no executable named'))).toBe(true)
+        })
+
+        it('refuses a directory whose name is not <bin>-<name>', async () => {
+            const workspace = join(root, 'code', 'my-tool')
+            await mkdir(workspace, { recursive: true })
+            const github = stubGitHub()
+
+            await expect(
+                installExtension(workspace, {}, contextFor(github.impl)),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NAME_INVALID' })
+        })
+
+        it('refuses a directory that does not exist', async () => {
+            const github = stubGitHub()
+
+            await expect(
+                installExtension(join(root, 'nope', 'td-x'), {}, contextFor(github.impl)),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NOT_INSTALLABLE' })
+        })
+    })
+
+    describe.skipIf(!HAS_GIT)('git clones', () => {
+        async function makeRepo(name: string): Promise<string> {
+            const repo = join(root, 'origin', 'Doist', name)
+            await mkdir(repo, { recursive: true })
+            await writeFile(join(repo, name), '#!/bin/sh\necho hi\n', { mode: 0o755 })
+            await run('git', ['init', '--quiet', '--initial-branch=main'], { cwd: repo })
+            await run('git', ['add', '.'], { cwd: repo })
+            await run(
+                'git',
+                [
+                    '-c',
+                    'user.email=t@example.com',
+                    '-c',
+                    'user.name=T',
+                    'commit',
+                    '--quiet',
+                    '-m',
+                    'init',
+                ],
+                { cwd: repo },
+            )
+            return repo
+        }
+
+        it('clones when the repository publishes no matching asset', async () => {
+            const repo = await makeRepo('td-cloned')
+            const github = stubGitHub({ assetName: 'td-cloned_v1_other-arch' })
+
+            const result = await installExtension(`file://${repo}`, {}, contextFor(github.impl))
+
+            expect(result).toMatchObject({ kind: 'git', name: 'cloned' })
+            await expect(stat(join(extensionsDir, 'td-cloned', 'td-cloned'))).resolves.toBeTruthy()
+            await expect(stat(join(extensionsDir, 'td-cloned', '.git'))).resolves.toBeTruthy()
+        })
+
+        it('refuses a repository with no executable at its root, leaving nothing behind', async () => {
+            const repo = join(root, 'origin', 'Doist', 'td-empty')
+            await mkdir(repo, { recursive: true })
+            await writeFile(join(repo, 'README.md'), 'nothing here')
+            await run('git', ['init', '--quiet', '--initial-branch=main'], { cwd: repo })
+            await run('git', ['add', '.'], { cwd: repo })
+            await run(
+                'git',
+                [
+                    '-c',
+                    'user.email=t@example.com',
+                    '-c',
+                    'user.name=T',
+                    'commit',
+                    '--quiet',
+                    '-m',
+                    'init',
+                ],
+                { cwd: repo },
+            )
+            const github = stubGitHub({ assetName: 'td-empty_v1_other-arch' })
+
+            await expect(
+                installExtension(`file://${repo}`, {}, contextFor(github.impl)),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NOT_INSTALLABLE' })
+
+            await expect(stat(join(extensionsDir, 'td-empty'))).rejects.toThrow()
+        })
+    })
+})

--- a/src/lib/extensions/install.ts
+++ b/src/lib/extensions/install.ts
@@ -8,12 +8,22 @@
  * extension behind and never destroys the one already installed.
  */
 
-import { chmod, mkdir, readdir, rename, rm, symlink, writeFile } from 'node:fs/promises'
+import {
+    chmod,
+    lstat,
+    mkdir,
+    mkdtemp,
+    readdir,
+    rename,
+    rm,
+    symlink,
+    writeFile,
+} from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { basename, join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import { CliError } from '@doist/cli-core'
-import { discoverExtensions } from './discover.js'
-import { exists, isDirectory } from './fs-utils.js'
+import { findExtension } from './discover.js'
+import { exists, isDirectory, isExecutable } from './fs-utils.js'
 import { checkout, clone, headSha, resolveRef } from './git.js'
 import {
     assetSuffixes,
@@ -23,7 +33,7 @@ import {
     sha256,
     verifyChecksum,
 } from './github.js'
-import { writeInstalledManifest } from './manifest.js'
+import { pickAuthoredFields, writeInstalledManifest } from './manifest.js'
 import { installDependencies } from './npm.js'
 import {
     authoredManifestFileName,
@@ -31,7 +41,7 @@ import {
     toCommandName,
     validateExtensionName,
 } from './source.js'
-import { writeState } from './state.js'
+import { removeState, writeState } from './state.js'
 import type { AuthoredManifest, Extension, InstallOptions, InstallResult } from './types.js'
 
 export type InstallContext = {
@@ -75,13 +85,14 @@ async function preflight(
         )
     }
 
-    const installed = await discoverExtensions({
+    // Only the entry that could collide, rather than describing every
+    // installed extension to find out about one.
+    const existing = await findExtension(name, {
         extensionsDir: context.extensionsDir,
         stateDir: context.stateDir,
         binName: context.binName,
         officialSource: context.officialSource,
     })
-    const existing = installed.find((extension) => extension.name === name)
     if (existing && !options.force) {
         throw new CliError(
             'EXTENSION_ALREADY_INSTALLED',
@@ -99,10 +110,9 @@ async function preflight(
 
 async function stagingDir(extensionsDir: string, dirName: string): Promise<string> {
     await mkdir(extensionsDir, { recursive: true })
-    const path = join(extensionsDir, `.staging-${dirName}-${process.pid}-${Date.now()}`)
-    await rm(path, { recursive: true, force: true })
-    await mkdir(path, { recursive: true })
-    return path
+    // mkdtemp picks a name nothing else can be holding, which hand-rolling one
+    // from the process id and the clock does not guarantee.
+    return mkdtemp(join(extensionsDir, `.staging-${dirName}-`))
 }
 
 /**
@@ -112,19 +122,49 @@ async function stagingDir(extensionsDir: string, dirName: string): Promise<strin
  * part-way through leaves something to put back instead of leaving the user
  * with no extension at all.
  */
+/** True when anything at all occupies the path, a dangling symlink included. */
+async function occupied(path: string): Promise<boolean> {
+    try {
+        await lstat(path)
+        return true
+    } catch {
+        return false
+    }
+}
+
+type Displaced = { discard: () => Promise<void>; restore: () => Promise<void> }
+
+const NOTHING_DISPLACED: Displaced = {
+    discard: async () => undefined,
+    restore: async () => undefined,
+}
+
+/**
+ * Put the staged directory in place of whatever is installed, and hand back
+ * the means to finish or undo it.
+ *
+ * The old install is moved aside rather than deleted, and stays there until
+ * the caller has finished everything that could still fail. A failure part-way
+ * through therefore leaves something to put back, instead of leaving the user
+ * with no extension at all.
+ */
 async function moveIntoPlace(
     staged: string,
     destination: string,
     existing: Extension | undefined,
-): Promise<void> {
-    const displaced = `${destination}.replaced-${process.pid}-${Date.now()}`
+): Promise<Displaced> {
+    // A dot prefix keeps the set-aside copy from looking like an installed
+    // extension if anything stops this run before it is cleaned up.
+    const displaced = join(dirname(destination), `.replaced-${basename(destination)}-${Date.now()}`)
     let movedAside = false
 
     if (existing && existing.entryPath !== destination) {
         await rm(existing.entryPath, { recursive: true, force: true })
     }
 
-    if (await exists(destination)) {
+    // lstat, not stat: a local install whose target has been deleted is a
+    // dangling link, which still occupies the destination.
+    if (await occupied(destination)) {
         await rename(destination, displaced)
         movedAside = true
     }
@@ -136,7 +176,17 @@ async function moveIntoPlace(
         throw error
     }
 
-    if (movedAside) await rm(displaced, { recursive: true, force: true })
+    if (!movedAside) return NOTHING_DISPLACED
+
+    return {
+        discard: async () => {
+            await rm(displaced, { recursive: true, force: true })
+        },
+        restore: async () => {
+            await rm(destination, { recursive: true, force: true })
+            await rename(displaced, destination).catch(() => undefined)
+        },
+    }
 }
 
 export async function installBinary(
@@ -164,7 +214,7 @@ export async function installBinary(
         ])
 
         verifyChecksum(data, expected, asset.name)
-        if (!expected) {
+        if (!expected.published) {
             context.warn(
                 `${parsed.owner}/${parsed.repo} publishes no checksums, so the download could not be verified.`,
             )
@@ -177,11 +227,20 @@ export async function installBinary(
 
         let authored: AuthoredManifest = {}
         if (authoredRaw) {
+            // Parsed and then sifted, because a file that is valid JSON can
+            // still be null, an array, or full of the wrong types.
+            let parsedManifest: unknown
             try {
-                authored = JSON.parse(authoredRaw) as AuthoredManifest
+                parsedManifest = JSON.parse(authoredRaw)
             } catch {
+                parsedManifest = undefined
+            }
+            const picked = pickAuthoredFields(parsedManifest)
+            if (picked) {
+                authored = picked
+            } else {
                 context.warn(
-                    `Ignoring ${authoredManifestFileName(context.binName)} in ${parsed.owner}/${parsed.repo}: it is not valid JSON.`,
+                    `Ignoring ${authoredManifestFileName(context.binName)} in ${parsed.owner}/${parsed.repo}: it is not a JSON object.`,
                 )
             }
         }
@@ -200,10 +259,18 @@ export async function installBinary(
             completion: authored.completion,
         })
 
-        await moveIntoPlace(staged, destination, existing)
-        await writeState(context.stateDir, dirName, {
-            pinned: options.pin ? release.tag : undefined,
-        })
+        const displaced = await moveIntoPlace(staged, destination, existing)
+        try {
+            await writeState(context.stateDir, dirName, {
+                pinned: options.pin ? release.tag : undefined,
+            })
+        } catch (error) {
+            // Nothing is installed rather than half-installed: the previous
+            // extension goes back, and the command reports the failure.
+            await displaced.restore()
+            throw error
+        }
+        await displaced.discard()
 
         return {
             name: toCommandName(context.binName, dirName),
@@ -240,14 +307,20 @@ async function installGit(
             pinnedSha = await resolveRef(staged, 'HEAD')
         }
 
-        if (!(await exists(join(staged, dirName)))) {
+        // Executable, not merely present: a directory or an unexecutable file
+        // by that name would install happily and only fail when run.
+        if (!(await isExecutable(join(staged, dirName)))) {
+            const present = await exists(join(staged, dirName))
             throw new CliError(
                 'EXTENSION_NOT_INSTALLABLE',
-                `${parsed.owner}/${parsed.repo} has no executable named "${dirName}" at its root.`,
+                present
+                    ? `"${dirName}" in ${parsed.owner}/${parsed.repo} is not an executable file.`
+                    : `${parsed.owner}/${parsed.repo} has no executable named "${dirName}" at its root.`,
                 {
                     hints: [
                         `An extension repository must contain a file named ${dirName} that ${context.binName} can run.`,
-                    ],
+                        present ? 'Give it an executable bit: chmod +x it and commit that.' : '',
+                    ].filter(Boolean),
                 },
             )
         }
@@ -255,11 +328,17 @@ async function installGit(
         await installDependencies(staged)
 
         const version = (await headSha(staged))?.slice(0, 8)
-        await moveIntoPlace(staged, destination, existing)
+        const displaced = await moveIntoPlace(staged, destination, existing)
         moved = true
-        await writeState(context.stateDir, dirName, {
-            pinned: options.pin ? (pinnedSha ?? options.pin) : undefined,
-        })
+        try {
+            await writeState(context.stateDir, dirName, {
+                pinned: options.pin ? (pinnedSha ?? options.pin) : undefined,
+            })
+        } catch (error) {
+            await displaced.restore()
+            throw error
+        }
+        await displaced.discard()
 
         return {
             name: toCommandName(context.binName, dirName),
@@ -308,16 +387,32 @@ async function installLocal(
 
     await mkdir(context.extensionsDir, { recursive: true })
     const destination = join(context.extensionsDir, dirName)
-    if (existing) await rm(existing.entryPath, { recursive: true, force: true })
-    await rm(destination, { recursive: true, force: true })
 
+    // Built beside the destination and renamed over it, so a failure leaves
+    // the extension that is already installed alone.
+    const pending = join(context.extensionsDir, `.pending-${dirName}-${Date.now()}`)
     if (process.platform === 'win32') {
         // Symlinks need elevated rights on Windows, so record the target in a
         // plain file and resolve it at discovery time instead.
-        await writeFile(destination, target, 'utf8')
+        await writeFile(pending, target, 'utf8')
     } else {
-        await symlink(target, destination, 'dir')
+        await symlink(target, pending, 'dir')
     }
+
+    try {
+        if (existing && existing.entryPath !== destination) {
+            await rm(existing.entryPath, { recursive: true, force: true })
+        }
+        await rm(destination, { recursive: true, force: true })
+        await rename(pending, destination)
+    } catch (error) {
+        await rm(pending, { recursive: true, force: true })
+        throw error
+    }
+
+    // A local install tracks a directory, so any pin or update bookkeeping
+    // left by whatever was installed here before no longer describes anything.
+    if (existing) await removeState(context.stateDir, dirName)
 
     return {
         name: toCommandName(context.binName, dirName),

--- a/src/lib/extensions/install.ts
+++ b/src/lib/extensions/install.ts
@@ -1,0 +1,369 @@
+/**
+ * Installing an extension.
+ *
+ * Three shapes are supported: a prebuilt release binary, a git clone, and a
+ * symlink to a directory the user is working in. Everything is assembled in a
+ * staging directory inside the extensions directory and moved into place only
+ * once it is complete, so a failed install never leaves a half-written
+ * extension behind and never destroys the one already installed.
+ */
+
+import { chmod, mkdir, readdir, rename, rm, symlink, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { CliError } from '@doist/cli-core'
+import { discoverExtensions } from './discover.js'
+import { exists, isDirectory } from './fs-utils.js'
+import { checkout, clone, headSha, resolveRef } from './git.js'
+import {
+    assetSuffixes,
+    findExpectedChecksum,
+    type GitHubClient,
+    pickAsset,
+    sha256,
+    verifyChecksum,
+} from './github.js'
+import { writeInstalledManifest } from './manifest.js'
+import { installDependencies } from './npm.js'
+import {
+    authoredManifestFileName,
+    parseSource,
+    toCommandName,
+    validateExtensionName,
+} from './source.js'
+import { writeState } from './state.js'
+import type { AuthoredManifest, Extension, InstallOptions, InstallResult } from './types.js'
+
+export type InstallContext = {
+    binName: string
+    extensionsDir: string
+    stateDir: string
+    officialSource: { host: string; owner: string }
+    client: GitHubClient
+    reservedNames: () => Iterable<string>
+    log: (message: string) => void
+    warn: (message: string) => void
+    trustWarning: string
+}
+
+function expandHome(path: string): string {
+    return path.startsWith('~/') ? join(homedir(), path.slice(2)) : path
+}
+
+/**
+ * Name checks and collision handling, run before anything is downloaded or
+ * cloned so that a doomed install fails without touching the network.
+ */
+async function preflight(
+    dirName: string,
+    context: InstallContext,
+    options: InstallOptions,
+): Promise<Extension | undefined> {
+    validateExtensionName(context.binName, dirName)
+    const name = toCommandName(context.binName, dirName)
+
+    const reserved = new Set(context.reservedNames())
+    if (reserved.has(name)) {
+        throw new CliError(
+            'EXTENSION_NAME_RESERVED',
+            `"${name}" is the name of a built-in ${context.binName} command.`,
+            {
+                hints: [
+                    `An extension cannot take that name. It would only be reachable as \`${context.binName} extension exec ${name}\`.`,
+                ],
+            },
+        )
+    }
+
+    const installed = await discoverExtensions({
+        extensionsDir: context.extensionsDir,
+        stateDir: context.stateDir,
+        binName: context.binName,
+        officialSource: context.officialSource,
+    })
+    const existing = installed.find((extension) => extension.name === name)
+    if (existing && !options.force) {
+        throw new CliError(
+            'EXTENSION_ALREADY_INSTALLED',
+            `"${name}" is already installed${existing.source ? ` from ${existing.source}` : ''}.`,
+            {
+                hints: [
+                    `Run \`${context.binName} extension upgrade ${name}\` to update it.`,
+                    `Run \`${context.binName} extension install … --force\` to replace it.`,
+                ],
+            },
+        )
+    }
+    return existing
+}
+
+async function stagingDir(extensionsDir: string, dirName: string): Promise<string> {
+    await mkdir(extensionsDir, { recursive: true })
+    const path = join(extensionsDir, `.staging-${dirName}-${process.pid}-${Date.now()}`)
+    await rm(path, { recursive: true, force: true })
+    await mkdir(path, { recursive: true })
+    return path
+}
+
+/**
+ * Put the staged directory in place of whatever is installed.
+ *
+ * The old install is moved aside rather than deleted first, so that a failure
+ * part-way through leaves something to put back instead of leaving the user
+ * with no extension at all.
+ */
+async function moveIntoPlace(
+    staged: string,
+    destination: string,
+    existing: Extension | undefined,
+): Promise<void> {
+    const displaced = `${destination}.replaced-${process.pid}-${Date.now()}`
+    let movedAside = false
+
+    if (existing && existing.entryPath !== destination) {
+        await rm(existing.entryPath, { recursive: true, force: true })
+    }
+
+    if (await exists(destination)) {
+        await rename(destination, displaced)
+        movedAside = true
+    }
+
+    try {
+        await rename(staged, destination)
+    } catch (error) {
+        if (movedAside) await rename(displaced, destination).catch(() => undefined)
+        throw error
+    }
+
+    if (movedAside) await rm(displaced, { recursive: true, force: true })
+}
+
+export async function installBinary(
+    parsed: { host: string; owner: string; repo: string },
+    release: { tag: string; assets: { name: string; url: string; size: number }[] },
+    asset: { name: string; url: string; size: number },
+    options: InstallOptions,
+    context: InstallContext,
+    existing: Extension | undefined,
+): Promise<InstallResult> {
+    const dirName = parsed.repo
+    const destination = join(context.extensionsDir, dirName)
+    const staged = await stagingDir(context.extensionsDir, dirName)
+
+    try {
+        const [data, expected, authoredRaw] = await Promise.all([
+            context.client.downloadAsset(asset),
+            findExpectedChecksum(context.client, release, asset.name),
+            context.client.fetchRepoFile(
+                parsed.owner,
+                parsed.repo,
+                authoredManifestFileName(context.binName),
+                release.tag,
+            ),
+        ])
+
+        verifyChecksum(data, expected, asset.name)
+        if (!expected) {
+            context.warn(
+                `${parsed.owner}/${parsed.repo} publishes no checksums, so the download could not be verified.`,
+            )
+        }
+
+        const executableName = asset.name.endsWith('.exe') ? `${dirName}.exe` : dirName
+        const executablePath = join(staged, executableName)
+        await writeFile(executablePath, data)
+        await chmod(executablePath, 0o755)
+
+        let authored: AuthoredManifest = {}
+        if (authoredRaw) {
+            try {
+                authored = JSON.parse(authoredRaw) as AuthoredManifest
+            } catch {
+                context.warn(
+                    `Ignoring ${authoredManifestFileName(context.binName)} in ${parsed.owner}/${parsed.repo}: it is not valid JSON.`,
+                )
+            }
+        }
+
+        await writeInstalledManifest(staged, context.binName, {
+            owner: parsed.owner,
+            name: dirName,
+            host: parsed.host,
+            tag: release.tag,
+            pinned: Boolean(options.pin),
+            asset: asset.name,
+            sha256: sha256(data),
+            installedAt: new Date().toISOString(),
+            description: authored.description,
+            requires: authored.requires,
+            completion: authored.completion,
+        })
+
+        await moveIntoPlace(staged, destination, existing)
+        await writeState(context.stateDir, dirName, {
+            pinned: options.pin ? release.tag : undefined,
+        })
+
+        return {
+            name: toCommandName(context.binName, dirName),
+            dirName,
+            kind: 'binary',
+            source: `${parsed.owner}/${parsed.repo}`,
+            version: release.tag,
+            dir: destination,
+        }
+    } finally {
+        await rm(staged, { recursive: true, force: true })
+    }
+}
+
+async function installGit(
+    parsed: { host: string; owner: string; repo: string; url: string },
+    options: InstallOptions,
+    context: InstallContext,
+    existing: Extension | undefined,
+): Promise<InstallResult> {
+    const dirName = parsed.repo
+    const destination = join(context.extensionsDir, dirName)
+    const staged = await stagingDir(context.extensionsDir, dirName)
+    // git refuses to clone into a directory that already has entries.
+    await rm(staged, { recursive: true, force: true })
+
+    let moved = false
+    try {
+        await clone(parsed.url, staged)
+
+        let pinnedSha: string | undefined
+        if (options.pin) {
+            await checkout(staged, options.pin)
+            pinnedSha = await resolveRef(staged, 'HEAD')
+        }
+
+        if (!(await exists(join(staged, dirName)))) {
+            throw new CliError(
+                'EXTENSION_NOT_INSTALLABLE',
+                `${parsed.owner}/${parsed.repo} has no executable named "${dirName}" at its root.`,
+                {
+                    hints: [
+                        `An extension repository must contain a file named ${dirName} that ${context.binName} can run.`,
+                    ],
+                },
+            )
+        }
+
+        await installDependencies(staged)
+
+        const version = (await headSha(staged))?.slice(0, 8)
+        await moveIntoPlace(staged, destination, existing)
+        moved = true
+        await writeState(context.stateDir, dirName, {
+            pinned: options.pin ? (pinnedSha ?? options.pin) : undefined,
+        })
+
+        return {
+            name: toCommandName(context.binName, dirName),
+            dirName,
+            kind: 'git',
+            source: `${parsed.owner}/${parsed.repo}`,
+            version,
+            dir: destination,
+        }
+    } finally {
+        if (!moved) await rm(staged, { recursive: true, force: true })
+    }
+}
+
+async function installLocal(
+    path: string,
+    options: InstallOptions,
+    context: InstallContext,
+): Promise<InstallResult> {
+    const target = resolve(expandHome(path))
+    const dirName = basename(target)
+
+    if (!(await exists(target))) {
+        throw new CliError('EXTENSION_NOT_INSTALLABLE', `${target} does not exist.`)
+    }
+
+    if (!(await isDirectory(target))) {
+        throw new CliError(
+            'EXTENSION_NOT_INSTALLABLE',
+            `${target} is not a directory, so it cannot hold an extension.`,
+            {
+                hints: [
+                    `A local install points at a directory named ${dirName} that contains an executable of the same name.`,
+                ],
+            },
+        )
+    }
+
+    const existing = await preflight(dirName, context, options)
+
+    if (!(await exists(join(target, dirName)))) {
+        context.warn(
+            `${target} has no executable named "${dirName}" yet. Build it before running \`${context.binName} ${toCommandName(context.binName, dirName)}\`.`,
+        )
+    }
+
+    await mkdir(context.extensionsDir, { recursive: true })
+    const destination = join(context.extensionsDir, dirName)
+    if (existing) await rm(existing.entryPath, { recursive: true, force: true })
+    await rm(destination, { recursive: true, force: true })
+
+    if (process.platform === 'win32') {
+        // Symlinks need elevated rights on Windows, so record the target in a
+        // plain file and resolve it at discovery time instead.
+        await writeFile(destination, target, 'utf8')
+    } else {
+        await symlink(target, destination, 'dir')
+    }
+
+    return {
+        name: toCommandName(context.binName, dirName),
+        dirName,
+        kind: 'local',
+        source: target,
+        dir: target,
+    }
+}
+
+/** Install from `owner/repo`, a repository URL, or a local directory. */
+export async function installExtension(
+    source: string,
+    options: InstallOptions,
+    context: InstallContext,
+): Promise<InstallResult> {
+    const parsed = parseSource(source)
+
+    if (parsed.type === 'local') {
+        return installLocal(parsed.path, options, context)
+    }
+
+    const existing = await preflight(parsed.repo, context, options)
+
+    // Printed before anything is downloaded, cloned or executed, so the user
+    // sees it even when a later step runs code from the repository.
+    context.warn(context.trustWarning)
+
+    if (parsed.isGitHub) {
+        const release = await context.client.fetchRelease(parsed.owner, parsed.repo, options.pin)
+        const asset = release ? pickAsset(release.assets, assetSuffixes()) : undefined
+        if (release && asset) {
+            return installBinary(parsed, release, asset, options, context, existing)
+        }
+        // No release, or none carrying an asset for this machine: fall through
+        // to a clone, which can also resolve a pinned tag as a git ref.
+    }
+
+    return installGit(parsed, options, context, existing)
+}
+
+/** True when the extensions directory holds nothing at all. */
+export async function isEmpty(extensionsDir: string): Promise<boolean> {
+    try {
+        return (await readdir(extensionsDir)).length === 0
+    } catch {
+        return true
+    }
+}

--- a/src/lib/extensions/install.ts
+++ b/src/lib/extensions/install.ts
@@ -33,6 +33,7 @@ import {
     sha256,
     verifyChecksum,
 } from './github.js'
+import { isFromNewerFormat, MANIFEST_VERSION } from './manifest-format.js'
 import { pickAuthoredFields, writeInstalledManifest } from './manifest.js'
 import { installDependencies } from './npm.js'
 import {
@@ -235,7 +236,7 @@ export async function installBinary(
             } catch {
                 parsedManifest = undefined
             }
-            const picked = pickAuthoredFields(parsedManifest)
+            const picked = await pickAuthoredFields(parsedManifest)
             if (picked) {
                 authored = picked
             } else {
@@ -246,6 +247,7 @@ export async function installBinary(
         }
 
         await writeInstalledManifest(staged, context.binName, {
+            manifestVersion: MANIFEST_VERSION,
             owner: parsed.owner,
             name: dirName,
             host: parsed.host,
@@ -258,6 +260,12 @@ export async function installBinary(
             requires: authored.requires,
             completion: authored.completion,
         })
+
+        if (isFromNewerFormat(authored)) {
+            context.warn(
+                `${parsed.owner}/${parsed.repo} declares a ${authoredManifestFileName(context.binName)} format newer than this ${context.binName} understands, so some of its metadata was ignored.`,
+            )
+        }
 
         const displaced = await moveIntoPlace(staged, destination, existing)
         try {


### PR DESCRIPTION
Slice 5 of 7, on top of slice 4.

Installs from a release binary, a git clone, or a local directory.

Everything is assembled in a staging directory and moved into place only once complete, with the previous install moved aside rather than deleted, so a failure part-way through leaves the working extension recoverable. The trust warning is printed before anything is downloaded, cloned or executed.

Release assets are matched by platform and architecture, verified against the release's checksums when it publishes any, and recorded in a manifest that carries the author's description and version requirement.

**Stack:** #521 core · #522 discovery · #523 dispatch · #524 tools · #525 install · #526 upgrade · #527 manager