### PR TITLE
feat(extensions): upgrade extensions

### DIFF
--- a/src/lib/extensions/upgrade.test.ts
+++ b/src/lib/extensions/upgrade.test.ts
@@ -10,7 +10,7 @@ import type { InstallContext } from './install.js'
 import { installDependencies } from './npm.js'
 import { run } from './run.js'
 import { readState, writeState } from './state.js'
-import { mapWithConcurrency, upgradeExtension } from './upgrade.js'
+import { upgradeExtension } from './upgrade.js'
 
 // Dependency installation is a real npm run; the upgrade tests only care that
 // it is triggered by the right change, so stand in for it here.
@@ -61,36 +61,6 @@ function stubGitHub(latestTag: string) {
     }) as unknown as typeof fetch
 }
 
-describe('mapWithConcurrency', () => {
-    it('never runs more than the limit at once', async () => {
-        let active = 0
-        let peak = 0
-
-        await mapWithConcurrency(
-            Array.from({ length: 12 }, (_, i) => i),
-            4,
-            async (item) => {
-                active += 1
-                peak = Math.max(peak, active)
-                await new Promise((resolve) => setTimeout(resolve, 5))
-                active -= 1
-                return item
-            },
-        )
-
-        expect(peak).toBeLessThanOrEqual(4)
-    })
-
-    it('keeps results in the order of the input', async () => {
-        const results = await mapWithConcurrency([3, 1, 2], 2, async (item) => {
-            await new Promise((resolve) => setTimeout(resolve, item))
-            return item * 10
-        })
-
-        expect(results).toEqual([30, 10, 20])
-    })
-})
-
 describe('upgradeExtension', () => {
     let root: string
     let extensionsDir: string
@@ -137,7 +107,13 @@ describe('upgradeExtension', () => {
         const workspace = join(root, 'code')
         await mkdir(workspace, { recursive: true })
         const target = await writeFixtureExtension(workspace, 'scratch')
-        await symlink(target, join(extensionsDir, 'td-scratch'), 'dir')
+        // Matching installLocal, which writes a path file on Windows because
+        // symlinks there need rights the test runner will not have.
+        if (process.platform === 'win32') {
+            await writeFile(join(extensionsDir, 'td-scratch'), target, 'utf8')
+        } else {
+            await symlink(target, join(extensionsDir, 'td-scratch'), 'dir')
+        }
 
         const result = await upgradeExtension(
             await find('scratch'),
@@ -164,7 +140,7 @@ describe('upgradeExtension', () => {
         expect(result).toMatchObject({ outcome: 'skipped', detail: 'pinned to v1.0.0' })
     })
 
-    it('upgrades past a pin only when forced', async () => {
+    it('upgrades past a pin only when forced, and clears the pin it moved off', async () => {
         await writeFixtureExtension(extensionsDir, 'goals', {
             installedManifest: manifestFor('v1.0.0'),
         })
@@ -177,6 +153,16 @@ describe('upgradeExtension', () => {
         )
 
         expect(result).toMatchObject({ outcome: 'upgraded', from: 'v1.0.0', to: 'v2.0.0' })
+
+        // A pin left behind would make every later upgrade skip this
+        // extension, forever.
+        await expect(readState(stateDir, 'td-goals')).resolves.not.toHaveProperty('pinned')
+        const next = await upgradeExtension(
+            await find('goals'),
+            {},
+            contextFor(stubGitHub('v3.0.0')),
+        )
+        expect(next.outcome).not.toBe('skipped')
     })
 
     it('reports an up-to-date binary without downloading anything', async () => {
@@ -342,12 +328,23 @@ describe.skipIf(!HAS_GIT)('upgradeExtension for git clones', () => {
         expect(executable).toContain('echo v2')
     })
 
-    it('prints the trust warning before pulling new code', async () => {
-        await advanceOrigin()
+    it('prints the trust warning before it runs any of the new code', async () => {
+        await advanceOrigin({ 'package.json': JSON.stringify({ name: 'td-cloned' }) })
+        const order: string[] = []
+        const context = contextFor()
+        context.warn = (message) => {
+            order.push(`warn:${message}`)
+            warnings.push(message)
+        }
+        vi.mocked(installDependencies).mockImplementation(async () => {
+            order.push('install-dependencies')
+        })
 
-        await upgradeExtension(await find('cloned'), {}, contextFor())
+        await upgradeExtension(await find('cloned'), {}, context)
 
-        expect(warnings).toEqual(['trust warning'])
+        // Dependency installation runs the repository's own lifecycle scripts,
+        // so the warning has to come first, not merely be present.
+        expect(order).toEqual(['warn:trust warning', 'install-dependencies'])
     })
 
     it('reports what a dry run would do without moving the clone', async () => {
@@ -391,5 +388,102 @@ describe.skipIf(!HAS_GIT)('upgradeExtension for git clones', () => {
         await expect(readState(stateDir, 'td-cloned')).resolves.not.toHaveProperty('pinned')
         const afterClearing = await upgradeExtension(await find('cloned'), {}, contextFor())
         expect(afterClearing.outcome).not.toBe('skipped')
+    })
+})
+
+describe.skipIf(!HAS_GIT)('upgradeExtension failure handling', () => {
+    let root: string
+    let extensionsDir: string
+    let stateDir: string
+    let origin: string
+    let warnings: string[]
+
+    function contextFor(): InstallContext {
+        return {
+            binName: 'td',
+            extensionsDir,
+            stateDir,
+            officialSource: OFFICIAL,
+            client: createGitHubClient(stubGitHub('v1')),
+            reservedNames: () => [],
+            log: () => undefined,
+            warn: (message) => warnings.push(message),
+            trustWarning: 'trust warning',
+        }
+    }
+
+    const commit = async (dir: string, message: string) => {
+        await run('git', ['add', '.'], { cwd: dir })
+        await run(
+            'git',
+            [
+                '-c',
+                'user.email=t@example.com',
+                '-c',
+                'user.name=T',
+                'commit',
+                '--quiet',
+                '-m',
+                message,
+            ],
+            { cwd: dir },
+        )
+    }
+
+    const find = async (name: string) => {
+        const found = await discoverExtensions({
+            extensionsDir,
+            stateDir,
+            binName: 'td',
+            officialSource: OFFICIAL,
+        })
+        const extension = found.find((candidate) => candidate.name === name)
+        if (!extension) throw new Error(`fixture ${name} not discovered`)
+        return extension
+    }
+
+    beforeEach(async () => {
+        warnings = []
+        root = await mkdtemp(join(tmpdir(), 'td-ext-upgrade-fail-'))
+        extensionsDir = join(root, 'extensions')
+        stateDir = join(root, 'state')
+        await mkdir(extensionsDir, { recursive: true })
+
+        origin = join(root, 'origin', 'td-cloned')
+        await mkdir(origin, { recursive: true })
+        await writeFile(join(origin, 'td-cloned'), '#!/bin/sh\necho v1\n', { mode: 0o755 })
+        await run('git', ['init', '--quiet', '--initial-branch=main'], { cwd: origin })
+        await commit(origin, 'first')
+        await run('git', ['clone', '--quiet', `file://${origin}`, join(extensionsDir, 'td-cloned')])
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('puts the clone back when installing dependencies fails', async () => {
+        const before = await headSha(join(extensionsDir, 'td-cloned'))
+        await writeFile(join(origin, 'package.json'), JSON.stringify({ name: 'td-cloned' }))
+        await commit(origin, 'add dependencies')
+        vi.mocked(installDependencies).mockRejectedValueOnce(new Error('npm exploded'))
+
+        await expect(upgradeExtension(await find('cloned'), {}, contextFor())).rejects.toThrow(
+            'npm exploded',
+        )
+
+        // Left at the new commit, the next upgrade would see nothing to do and
+        // never retry the dependencies its code now needs.
+        await expect(headSha(join(extensionsDir, 'td-cloned'))).resolves.toBe(before)
+    })
+
+    it('reports that it could not check, rather than claiming up to date', async () => {
+        await run('git', ['remote', 'set-url', 'origin', 'file:///nonexistent/repo.git'], {
+            cwd: join(extensionsDir, 'td-cloned'),
+        })
+
+        const result = await upgradeExtension(await find('cloned'), { dryRun: true }, contextFor())
+
+        expect(result.outcome).toBe('skipped')
+        expect(result.detail).toMatch(/could not reach the remote/)
     })
 })

--- a/src/lib/extensions/upgrade.test.ts
+++ b/src/lib/extensions/upgrade.test.ts
@@ -1,0 +1,395 @@
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { writeFixtureExtension } from '../../test-support/extension-fixture.js'
+import { discoverExtensions } from './discover.js'
+import { headSha } from './git.js'
+import { createGitHubClient } from './github.js'
+import type { InstallContext } from './install.js'
+import { installDependencies } from './npm.js'
+import { run } from './run.js'
+import { readState, writeState } from './state.js'
+import { mapWithConcurrency, upgradeExtension } from './upgrade.js'
+
+// Dependency installation is a real npm run; the upgrade tests only care that
+// it is triggered by the right change, so stand in for it here.
+vi.mock('./npm.js', () => ({
+    installDependencies: vi.fn(async () => undefined),
+    hasPackageJson: vi.fn(async () => true),
+}))
+
+const HAS_GIT = (await run('git', ['--version'])).code === 0
+
+const OFFICIAL = { host: 'github.com', owner: 'Doist' }
+const PLATFORM_SUFFIX = `${process.platform}-${process.arch}`
+const BINARY = Buffer.from('#!/bin/sh\necho new\n')
+
+function manifestFor(tag: string) {
+    return {
+        owner: 'Doist',
+        name: 'td-goals',
+        host: 'github.com',
+        tag,
+        pinned: false,
+        asset: `td-goals_${tag}_${PLATFORM_SUFFIX}`,
+        installedAt: '2026-09-01T00:00:00Z',
+    }
+}
+
+function stubGitHub(latestTag: string) {
+    return vi.fn(async (input: string | URL | Request) => {
+        const url = String(input)
+        if (url.includes('/releases/latest')) {
+            return new Response(
+                JSON.stringify({
+                    tag_name: latestTag,
+                    assets: [
+                        {
+                            name: `td-goals_${latestTag}_${PLATFORM_SUFFIX}`,
+                            url: 'https://api.github.com/assets/bin',
+                            size: BINARY.length,
+                        },
+                    ],
+                }),
+                { status: 200 },
+            )
+        }
+        if (url.endsWith('/assets/bin'))
+            return new Response(new Uint8Array(BINARY), { status: 200 })
+        return new Response('', { status: 404 })
+    }) as unknown as typeof fetch
+}
+
+describe('mapWithConcurrency', () => {
+    it('never runs more than the limit at once', async () => {
+        let active = 0
+        let peak = 0
+
+        await mapWithConcurrency(
+            Array.from({ length: 12 }, (_, i) => i),
+            4,
+            async (item) => {
+                active += 1
+                peak = Math.max(peak, active)
+                await new Promise((resolve) => setTimeout(resolve, 5))
+                active -= 1
+                return item
+            },
+        )
+
+        expect(peak).toBeLessThanOrEqual(4)
+    })
+
+    it('keeps results in the order of the input', async () => {
+        const results = await mapWithConcurrency([3, 1, 2], 2, async (item) => {
+            await new Promise((resolve) => setTimeout(resolve, item))
+            return item * 10
+        })
+
+        expect(results).toEqual([30, 10, 20])
+    })
+})
+
+describe('upgradeExtension', () => {
+    let root: string
+    let extensionsDir: string
+    let stateDir: string
+
+    function contextFor(fetchImpl: typeof fetch): InstallContext {
+        return {
+            binName: 'td',
+            extensionsDir,
+            stateDir,
+            officialSource: OFFICIAL,
+            client: createGitHubClient(fetchImpl),
+            reservedNames: () => [],
+            log: () => undefined,
+            warn: () => undefined,
+            trustWarning: 'trust warning',
+        }
+    }
+
+    const find = async (name: string) => {
+        const found = await discoverExtensions({
+            extensionsDir,
+            stateDir,
+            binName: 'td',
+            officialSource: OFFICIAL,
+        })
+        const extension = found.find((candidate) => candidate.name === name)
+        if (!extension) throw new Error(`fixture ${name} not discovered`)
+        return extension
+    }
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-upgrade-'))
+        extensionsDir = join(root, 'extensions')
+        stateDir = join(root, 'state')
+        await mkdir(extensionsDir, { recursive: true })
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('leaves a local install alone', async () => {
+        const workspace = join(root, 'code')
+        await mkdir(workspace, { recursive: true })
+        const target = await writeFixtureExtension(workspace, 'scratch')
+        await symlink(target, join(extensionsDir, 'td-scratch'), 'dir')
+
+        const result = await upgradeExtension(
+            await find('scratch'),
+            {},
+            contextFor(stubGitHub('v2')),
+        )
+
+        expect(result).toMatchObject({ outcome: 'skipped' })
+        expect(result.detail).toMatch(/local installs/)
+    })
+
+    it('skips a pinned extension and says what it is pinned to', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: manifestFor('v1.0.0'),
+        })
+        await writeState(stateDir, 'td-goals', { pinned: 'v1.0.0' })
+
+        const result = await upgradeExtension(
+            await find('goals'),
+            {},
+            contextFor(stubGitHub('v2.0.0')),
+        )
+
+        expect(result).toMatchObject({ outcome: 'skipped', detail: 'pinned to v1.0.0' })
+    })
+
+    it('upgrades past a pin only when forced', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: manifestFor('v1.0.0'),
+        })
+        await writeState(stateDir, 'td-goals', { pinned: 'v1.0.0' })
+
+        const result = await upgradeExtension(
+            await find('goals'),
+            { force: true },
+            contextFor(stubGitHub('v2.0.0')),
+        )
+
+        expect(result).toMatchObject({ outcome: 'upgraded', from: 'v1.0.0', to: 'v2.0.0' })
+    })
+
+    it('reports an up-to-date binary without downloading anything', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: manifestFor('v1.0.0'),
+        })
+        const fetchImpl = stubGitHub('v1.0.0')
+
+        const result = await upgradeExtension(await find('goals'), {}, contextFor(fetchImpl))
+
+        expect(result).toMatchObject({ outcome: 'up-to-date' })
+        expect(
+            vi.mocked(fetchImpl).mock.calls.some(([url]) => String(url).includes('assets')),
+        ).toBe(false)
+    })
+
+    it('reports what a dry run would do without touching the install', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: manifestFor('v1.0.0'),
+        })
+
+        const result = await upgradeExtension(
+            await find('goals'),
+            { dryRun: true },
+            contextFor(stubGitHub('v2.0.0')),
+        )
+
+        expect(result).toMatchObject({ outcome: 'would-upgrade', from: 'v1.0.0', to: 'v2.0.0' })
+        const manifest = JSON.parse(
+            await readFile(join(extensionsDir, 'td-goals', '.td-manifest.json'), 'utf8'),
+        )
+        expect(manifest.tag).toBe('v1.0.0')
+    })
+
+    it('downloads and replaces a binary when the tag has moved', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: manifestFor('v1.0.0'),
+        })
+
+        const result = await upgradeExtension(
+            await find('goals'),
+            {},
+            contextFor(stubGitHub('v2.0.0')),
+        )
+
+        expect(result).toMatchObject({ outcome: 'upgraded', from: 'v1.0.0', to: 'v2.0.0' })
+        const executable = await readFile(join(extensionsDir, 'td-goals', 'td-goals'))
+        expect(executable.equals(BINARY)).toBe(true)
+        const manifest = JSON.parse(
+            await readFile(join(extensionsDir, 'td-goals', '.td-manifest.json'), 'utf8'),
+        )
+        expect(manifest.tag).toBe('v2.0.0')
+    })
+
+    it('skips a binary install that has no manifest to compare against', async () => {
+        await writeFixtureExtension(extensionsDir, 'orphan')
+
+        const result = await upgradeExtension(
+            await find('orphan'),
+            {},
+            contextFor(stubGitHub('v2.0.0')),
+        )
+
+        expect(result).toMatchObject({ outcome: 'skipped' })
+        expect(result.detail).toMatch(/no manifest/)
+    })
+})
+
+describe.skipIf(!HAS_GIT)('upgradeExtension for git clones', () => {
+    let root: string
+    let extensionsDir: string
+    let stateDir: string
+    let origin: string
+
+    function contextFor(): InstallContext {
+        return {
+            binName: 'td',
+            extensionsDir,
+            stateDir,
+            officialSource: OFFICIAL,
+            client: createGitHubClient(stubGitHub('v1')),
+            reservedNames: () => [],
+            log: () => undefined,
+            warn: (message) => warnings.push(message),
+            trustWarning: 'trust warning',
+        }
+    }
+
+    let warnings: string[]
+
+    const commit = async (dir: string, message: string) => {
+        await run('git', ['add', '.'], { cwd: dir })
+        await run(
+            'git',
+            [
+                '-c',
+                'user.email=t@example.com',
+                '-c',
+                'user.name=T',
+                'commit',
+                '--quiet',
+                '-m',
+                message,
+            ],
+            { cwd: dir },
+        )
+    }
+
+    const find = async (name: string) => {
+        const found = await discoverExtensions({
+            extensionsDir,
+            stateDir,
+            binName: 'td',
+            officialSource: OFFICIAL,
+        })
+        const extension = found.find((candidate) => candidate.name === name)
+        if (!extension) throw new Error(`fixture ${name} not discovered`)
+        return extension
+    }
+
+    beforeEach(async () => {
+        warnings = []
+        root = await mkdtemp(join(tmpdir(), 'td-ext-upgrade-git-'))
+        extensionsDir = join(root, 'extensions')
+        stateDir = join(root, 'state')
+        await mkdir(extensionsDir, { recursive: true })
+
+        origin = join(root, 'origin', 'td-cloned')
+        await mkdir(origin, { recursive: true })
+        await writeFile(join(origin, 'td-cloned'), '#!/bin/sh\necho v1\n', { mode: 0o755 })
+        await run('git', ['init', '--quiet', '--initial-branch=main'], { cwd: origin })
+        await commit(origin, 'first')
+
+        await run('git', ['clone', '--quiet', `file://${origin}`, join(extensionsDir, 'td-cloned')])
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    async function advanceOrigin(files: Record<string, string> = {}): Promise<void> {
+        await writeFile(join(origin, 'td-cloned'), '#!/bin/sh\necho v2\n', { mode: 0o755 })
+        for (const [name, contents] of Object.entries(files)) {
+            await writeFile(join(origin, name), contents)
+        }
+        await commit(origin, 'second')
+    }
+
+    it('reports up-to-date when the remote has not moved', async () => {
+        const result = await upgradeExtension(await find('cloned'), {}, contextFor())
+
+        expect(result).toMatchObject({ outcome: 'up-to-date' })
+    })
+
+    it('fast-forwards when the remote has new commits', async () => {
+        await advanceOrigin()
+
+        const result = await upgradeExtension(await find('cloned'), {}, contextFor())
+
+        expect(result.outcome).toBe('upgraded')
+        expect(result.from).not.toBe(result.to)
+        const executable = await readFile(join(extensionsDir, 'td-cloned', 'td-cloned'), 'utf8')
+        expect(executable).toContain('echo v2')
+    })
+
+    it('prints the trust warning before pulling new code', async () => {
+        await advanceOrigin()
+
+        await upgradeExtension(await find('cloned'), {}, contextFor())
+
+        expect(warnings).toEqual(['trust warning'])
+    })
+
+    it('reports what a dry run would do without moving the clone', async () => {
+        await advanceOrigin()
+        const before = await headSha(join(extensionsDir, 'td-cloned'))
+
+        const result = await upgradeExtension(await find('cloned'), { dryRun: true }, contextFor())
+
+        expect(result.outcome).toBe('would-upgrade')
+        await expect(headSha(join(extensionsDir, 'td-cloned'))).resolves.toBe(before)
+        expect(warnings).toEqual([])
+    })
+
+    it('reinstalls dependencies when package.json changed', async () => {
+        await advanceOrigin({ 'package.json': JSON.stringify({ name: 'td-cloned' }) })
+
+        await upgradeExtension(await find('cloned'), {}, contextFor())
+
+        expect(vi.mocked(installDependencies)).toHaveBeenCalledWith(
+            join(extensionsDir, 'td-cloned'),
+        )
+    })
+
+    it('leaves dependencies alone when nothing about them changed', async () => {
+        await advanceOrigin()
+
+        await upgradeExtension(await find('cloned'), {}, contextFor())
+
+        expect(vi.mocked(installDependencies)).not.toHaveBeenCalled()
+    })
+
+    it('clears the pin when a forced upgrade moves the clone off it', async () => {
+        await advanceOrigin()
+        await writeState(stateDir, 'td-cloned', { pinned: 'abc1234' })
+
+        const skipped = await upgradeExtension(await find('cloned'), {}, contextFor())
+        expect(skipped).toMatchObject({ outcome: 'skipped', detail: 'pinned to abc1234' })
+
+        await upgradeExtension(await find('cloned'), { force: true }, contextFor())
+
+        await expect(readState(stateDir, 'td-cloned')).resolves.not.toHaveProperty('pinned')
+        const afterClearing = await upgradeExtension(await find('cloned'), {}, contextFor())
+        expect(afterClearing.outcome).not.toBe('skipped')
+    })
+})

--- a/src/lib/extensions/upgrade.ts
+++ b/src/lib/extensions/upgrade.ts
@@ -1,0 +1,206 @@
+/**
+ * Upgrading installed extensions.
+ *
+ * Git clones fast-forward, release binaries are re-downloaded when the tag has
+ * moved, and local installs are left alone because the user's own working
+ * directory is already the source of truth. A pin is honoured unless the user
+ * explicitly forces past it.
+ */
+
+import { changedFiles, headSha, pull, remoteHeadSha, resetToRemote } from './git.js'
+import { assetSuffixes, pickAsset } from './github.js'
+import { installBinary, type InstallContext } from './install.js'
+import { installDependencies } from './npm.js'
+import { readState, writeState } from './state.js'
+import type { Extension, UpgradeOptions, UpgradeResult } from './types.js'
+
+/** Files whose change means the extension's dependencies must be reinstalled. */
+const DEPENDENCY_FILES = new Set(['package.json', 'package-lock.json'])
+
+/**
+ * The trust warning belongs on upgrades as much as installs — an upgrade
+ * fetches new code and can run it, through lifecycle scripts. One warning
+ * covers a whole run, so `upgrade --all` does not repeat itself once per
+ * extension.
+ */
+export function createTrustWarner(context: InstallContext): () => void {
+    let warned = false
+    return () => {
+        if (warned) return
+        warned = true
+        context.warn(context.trustWarning)
+    }
+}
+
+/**
+ * Run `worker` over every item, at most `limit` at a time. Upgrades hit the
+ * GitHub API once per extension, and firing all of them at once is what
+ * triggers secondary rate limits.
+ */
+export async function mapWithConcurrency<T, R>(
+    items: T[],
+    limit: number,
+    worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+    const results = Array.from<R>({ length: items.length })
+    let next = 0
+
+    const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+        while (next < items.length) {
+            const index = next++
+            results[index] = await worker(items[index])
+        }
+    })
+
+    await Promise.all(runners)
+    return results
+}
+
+async function upgradeGit(
+    extension: Extension,
+    options: UpgradeOptions,
+    context: InstallContext,
+    warnTrust: () => void,
+): Promise<UpgradeResult> {
+    if (options.dryRun) {
+        const [before, remote] = await Promise.all([
+            headSha(extension.dir),
+            remoteHeadSha(extension.dir),
+        ])
+        if (!remote || !before || remote === before) {
+            return { name: extension.name, outcome: 'up-to-date' }
+        }
+        return {
+            name: extension.name,
+            outcome: 'would-upgrade',
+            from: before.slice(0, 8),
+            to: remote.slice(0, 8),
+        }
+    }
+
+    warnTrust()
+    const result = options.force ? await resetToRemote(extension.dir) : await pull(extension.dir)
+
+    if (options.force && extension.pinned) {
+        // A forced upgrade moved the clone off the pinned commit, so the pin no
+        // longer describes anything. Leaving it would make every later upgrade
+        // skip this extension.
+        const state = await readState(context.stateDir, extension.dirName)
+        await writeState(context.stateDir, extension.dirName, { ...state, pinned: undefined })
+    }
+
+    if (result.error) {
+        return { name: extension.name, outcome: 'skipped', detail: result.error }
+    }
+    if (!result.changed) {
+        return { name: extension.name, outcome: 'up-to-date' }
+    }
+
+    if (result.from && result.to) {
+        const changed = await changedFiles(extension.dir, result.from, result.to)
+        if (changed.some((file) => DEPENDENCY_FILES.has(file))) {
+            await installDependencies(extension.dir)
+        }
+    }
+
+    return {
+        name: extension.name,
+        outcome: 'upgraded',
+        from: result.from?.slice(0, 8),
+        to: result.to?.slice(0, 8),
+    }
+}
+
+async function upgradeBinary(
+    extension: Extension,
+    options: UpgradeOptions,
+    context: InstallContext,
+    warnTrust: () => void,
+): Promise<UpgradeResult> {
+    const manifest = extension.manifest
+    if (!manifest) {
+        return {
+            name: extension.name,
+            outcome: 'skipped',
+            detail: 'no manifest, so there is nothing to compare against',
+        }
+    }
+
+    const release = await context.client.fetchRelease(manifest.owner, manifest.name)
+    if (!release) {
+        return { name: extension.name, outcome: 'skipped', detail: 'no releases found' }
+    }
+    if (release.tag === manifest.tag) {
+        return { name: extension.name, outcome: 'up-to-date' }
+    }
+
+    const asset = pickAsset(release.assets, assetSuffixes())
+    if (!asset) {
+        return {
+            name: extension.name,
+            outcome: 'skipped',
+            detail: `release ${release.tag} has no asset for ${process.platform}-${process.arch}`,
+        }
+    }
+
+    if (options.dryRun) {
+        return {
+            name: extension.name,
+            outcome: 'would-upgrade',
+            from: manifest.tag,
+            to: release.tag,
+        }
+    }
+
+    warnTrust()
+    await installBinary(
+        { host: manifest.host, owner: manifest.owner, repo: manifest.name },
+        release,
+        asset,
+        {},
+        context,
+        extension,
+    )
+
+    return { name: extension.name, outcome: 'upgraded', from: manifest.tag, to: release.tag }
+}
+
+export async function upgradeExtension(
+    extension: Extension,
+    options: UpgradeOptions,
+    context: InstallContext,
+    warnTrust: () => void = createTrustWarner(context),
+): Promise<UpgradeResult> {
+    if (extension.kind === 'local') {
+        return {
+            name: extension.name,
+            outcome: 'skipped',
+            detail: 'local installs always run whatever is in their directory',
+        }
+    }
+
+    if (extension.pinned && !options.force) {
+        const state = await readState(context.stateDir, extension.dirName)
+        return {
+            name: extension.name,
+            outcome: 'skipped',
+            detail: `pinned to ${state.pinned ?? extension.manifest?.tag ?? 'a fixed version'}`,
+        }
+    }
+
+    return extension.kind === 'git'
+        ? upgradeGit(extension, options, context, warnTrust)
+        : upgradeBinary(extension, options, context, warnTrust)
+}
+
+/** Upgrade many extensions, bounding how many talk to GitHub at once. */
+export async function upgradeExtensions(
+    extensions: Extension[],
+    options: UpgradeOptions,
+    context: InstallContext,
+): Promise<UpgradeResult[]> {
+    const warnTrust = createTrustWarner(context)
+    return mapWithConcurrency(extensions, 4, (extension) =>
+        upgradeExtension(extension, options, context, warnTrust),
+    )
+}

--- a/src/lib/extensions/upgrade.ts
+++ b/src/lib/extensions/upgrade.ts
@@ -7,15 +7,17 @@
  * explicitly forces past it.
  */
 
-import { changedFiles, headSha, pull, remoteHeadSha, resetToRemote } from './git.js'
+import { mapWithConcurrency } from './concurrency.js'
+import { headSha, pathsChanged, pull, remoteHeadSha, resetToRemote } from './git.js'
 import { assetSuffixes, pickAsset } from './github.js'
 import { installBinary, type InstallContext } from './install.js'
 import { installDependencies } from './npm.js'
+import { run } from './run.js'
 import { readState, writeState } from './state.js'
 import type { Extension, UpgradeOptions, UpgradeResult } from './types.js'
 
 /** Files whose change means the extension's dependencies must be reinstalled. */
-const DEPENDENCY_FILES = new Set(['package.json', 'package-lock.json'])
+const DEPENDENCY_FILES = ['package.json', 'package-lock.json']
 
 /**
  * The trust warning belongs on upgrades as much as installs — an upgrade
@@ -32,30 +34,6 @@ export function createTrustWarner(context: InstallContext): () => void {
     }
 }
 
-/**
- * Run `worker` over every item, at most `limit` at a time. Upgrades hit the
- * GitHub API once per extension, and firing all of them at once is what
- * triggers secondary rate limits.
- */
-export async function mapWithConcurrency<T, R>(
-    items: T[],
-    limit: number,
-    worker: (item: T) => Promise<R>,
-): Promise<R[]> {
-    const results = Array.from<R>({ length: items.length })
-    let next = 0
-
-    const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
-        while (next < items.length) {
-            const index = next++
-            results[index] = await worker(items[index])
-        }
-    })
-
-    await Promise.all(runners)
-    return results
-}
-
 async function upgradeGit(
     extension: Extension,
     options: UpgradeOptions,
@@ -67,7 +45,16 @@ async function upgradeGit(
             headSha(extension.dir),
             remoteHeadSha(extension.dir),
         ])
-        if (!remote || !before || remote === before) {
+        if (!remote) {
+            // Offline, or the remote refused: reporting "up to date" would
+            // claim something this run never established.
+            return {
+                name: extension.name,
+                outcome: 'skipped',
+                detail: 'could not reach the remote to check for updates',
+            }
+        }
+        if (!before || remote === before) {
             return { name: extension.name, outcome: 'up-to-date' }
         }
         return {
@@ -81,14 +68,6 @@ async function upgradeGit(
     warnTrust()
     const result = options.force ? await resetToRemote(extension.dir) : await pull(extension.dir)
 
-    if (options.force && extension.pinned) {
-        // A forced upgrade moved the clone off the pinned commit, so the pin no
-        // longer describes anything. Leaving it would make every later upgrade
-        // skip this extension.
-        const state = await readState(context.stateDir, extension.dirName)
-        await writeState(context.stateDir, extension.dirName, { ...state, pinned: undefined })
-    }
-
     if (result.error) {
         return { name: extension.name, outcome: 'skipped', detail: result.error }
     }
@@ -96,10 +75,29 @@ async function upgradeGit(
         return { name: extension.name, outcome: 'up-to-date' }
     }
 
+    if (options.force && extension.pinned) {
+        // Only now that the clone has actually moved: clearing the pin after a
+        // reset that failed or did nothing would quietly unpin the extension.
+        const state = await readState(context.stateDir, extension.dirName)
+        await writeState(context.stateDir, extension.dirName, { ...state, pinned: undefined })
+    }
+
     if (result.from && result.to) {
-        const changed = await changedFiles(extension.dir, result.from, result.to)
-        if (changed.some((file) => DEPENDENCY_FILES.has(file))) {
-            await installDependencies(extension.dir)
+        const changed = await pathsChanged(extension.dir, result.from, result.to, DEPENDENCY_FILES)
+        // "Could not tell" reinstalls: a slow upgrade costs less than an
+        // extension left with dependencies that no longer match its code.
+        if (changed !== false) {
+            try {
+                await installDependencies(extension.dir)
+            } catch (error) {
+                // The clone has already moved, and a later upgrade would find
+                // it up to date and never retry, so put it back where its
+                // dependencies still match its code.
+                await run('git', ['reset', '--quiet', '--hard', result.from], {
+                    cwd: extension.dir,
+                })
+                throw error
+            }
         }
     }
 


### PR DESCRIPTION
Slice 6 of 7, on top of slice 5.

Clones fast-forward, release binaries are re-downloaded when the tag moves, and local installs are left alone because the user's own directory is already the source of truth.

Pins are honoured unless forced, and a forced upgrade clears the pin it just moved past rather than leaving a stale one to skip every later upgrade. Dependencies are reinstalled only when `package.json` or the lockfile changed. Upgrading many extensions bounds how many talk to GitHub at once, and warns about trust once for the whole run rather than once per extension.

**Stack:** #521 core · #522 discovery · #523 dispatch · #524 tools · #525 install · #526 upgrade · #527 manager