### PR TITLE
feat(extensions): the extension manager facade

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -130,6 +130,15 @@ New subcommand? Copy a sibling in the target group, wire it in that group's
   pointer) and `getEffectiveDefaultUserId` (pinned-else-sole-account, used for
   the `(default)` marker in `accounts list`/`current`, `auth status`,
   `config view`).
+- **`extensions/`** — the extension system: `manager.ts`
+  (`createExtensionManager`, the only entry point a host needs), plus
+  `discover`, `install`, `upgrade`, `remove`, `dispatch`, `github`, `git`,
+  `npm`, `manifest`, `state`, `source`, `version-range`, `run`, `fs-utils`.
+  Host-agnostic by design: the binary name, directories, version, reserved
+  command names and first-party source all arrive through the manager's
+  options, and nothing in the directory imports from the rest of the repo, so
+  it can move to `@doist/cli-core` as a file move. See
+  `docs/specs/extensions.md`.
 - **`auth-flags.ts`** — `buildReloginCommand()` (rebuilds `td auth login`
   with `--read-only` / `--additional-scopes=...` preserved)
 - **`config.ts`** — `~/.config/todoist-cli/config.json` read/write,

--- a/src/lib/extensions/manager.test.ts
+++ b/src/lib/extensions/manager.test.ts
@@ -71,7 +71,25 @@ describe('createExtensionManager', () => {
     it('throws a not-found error that points at the list command', async () => {
         await expect(makeManager().require('ghost')).rejects.toMatchObject({
             code: 'EXTENSION_NOT_FOUND',
+            hints: [expect.stringContaining('extension list')],
         })
+    })
+
+    it('reports an unknown selector the same way when upgrading', async () => {
+        await expect(makeManager().upgrade(['ghost'])).rejects.toMatchObject({
+            code: 'EXTENSION_NOT_FOUND',
+            hints: [expect.stringContaining('extension list')],
+        })
+    })
+
+    it('upgrades an extension once however many names it was given by', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals')
+
+        const results = await makeManager().upgrade(['goals', 'td-goals', 'Doist/td-goals'])
+
+        // Two upgrades of one directory at once would write over each other.
+        expect(results).toHaveLength(1)
+        expect(results[0].name).toBe('goals')
     })
 
     it('flags an extension whose name a built-in command owns', async () => {

--- a/src/lib/extensions/manager.test.ts
+++ b/src/lib/extensions/manager.test.ts
@@ -112,6 +112,31 @@ describe('createExtensionManager', () => {
         expect(listing.find((entry) => entry.name === 'unbuilt')?.executable).toBe(false)
     })
 
+    it('flags an extension whose manifest format is newer than this CLI knows', async () => {
+        await writeFixtureExtension(extensionsDir, 'future', {
+            authoredManifest: { manifestVersion: 99, description: 'still described' },
+        })
+        await writeFixtureExtension(extensionsDir, 'ordinary', {
+            authoredManifest: { description: 'ordinary' },
+        })
+
+        const listing = await makeManager().list()
+
+        expect(listing.find((e) => e.name === 'future')?.manifestFromNewerFormat).toBe(true)
+        expect(listing.find((e) => e.name === 'ordinary')?.manifestFromNewerFormat).toBe(false)
+        // Still described, and still runnable: only the fields this version
+        // does not understand are lost.
+        expect(listing.find((e) => e.name === 'future')?.description).toBe('still described')
+    })
+
+    it('runs an extension whose manifest format is newer than this CLI knows', async () => {
+        await writeFixtureExtension(extensionsDir, 'future', {
+            authoredManifest: { manifestVersion: 99 },
+        })
+
+        await expect(makeManager().dispatch('future', [], { env: quiet() })).resolves.toBe(0)
+    })
+
     it('reports the release tag as the version of a binary install', async () => {
         await writeFixtureExtension(extensionsDir, 'goals', {
             installedManifest: {

--- a/src/lib/extensions/manager.test.ts
+++ b/src/lib/extensions/manager.test.ts
@@ -1,0 +1,149 @@
+import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { writeFixtureExtension } from '../../test-support/extension-fixture.js'
+import { createExtensionManager, type ExtensionManager } from './manager.js'
+
+describe('createExtensionManager', () => {
+    let root: string
+    let dataDir: string
+    let extensionsDir: string
+    let warnings: string[]
+
+    function makeManager(reserved: string[] = []): ExtensionManager {
+        return createExtensionManager({
+            binName: 'td',
+            envPrefix: 'TD',
+            version: '5.3.1',
+            dataDir,
+            stateDir: join(root, 'state'),
+            configDir: join(root, 'config'),
+            hostPath: '/host/dist/index.js',
+            reservedNames: () => reserved,
+            officialSource: { host: 'github.com', owner: 'Doist' },
+            officialLabel: 'Todoist',
+            warn: (message) => warnings.push(message),
+            log: () => undefined,
+        })
+    }
+
+    /** Send the fixture's report to a file so it does not print during tests. */
+    const quiet = () => ({ XX_REPORT: join(root, 'report.json') })
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-manager-'))
+        dataDir = join(root, 'todoist-cli')
+        extensionsDir = join(dataDir, 'extensions')
+        warnings = []
+        await mkdir(extensionsDir, { recursive: true })
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('puts extensions under <dataDir>/extensions', () => {
+        expect(makeManager().extensionsDir).toBe(extensionsDir)
+    })
+
+    it('reports an empty install, and stops reporting one once something is installed', async () => {
+        const manager = makeManager()
+        await expect(manager.isEmpty()).resolves.toBe(true)
+
+        await writeFixtureExtension(extensionsDir, 'goals')
+        await expect(manager.isEmpty()).resolves.toBe(false)
+    })
+
+    it('builds a trust warning that names the CLI’s owner', () => {
+        expect(makeManager().trustWarning).toContain('endorsed by Todoist')
+    })
+
+    it('resolves a loose selector to an installed extension', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals')
+        const manager = makeManager()
+
+        for (const selector of ['goals', 'td-goals', 'Doist/td-goals']) {
+            await expect(manager.find(selector)).resolves.toMatchObject({ name: 'goals' })
+        }
+    })
+
+    it('throws a not-found error that points at the list command', async () => {
+        await expect(makeManager().require('ghost')).rejects.toMatchObject({
+            code: 'EXTENSION_NOT_FOUND',
+        })
+    })
+
+    it('flags an extension whose name a built-in command owns', async () => {
+        await writeFixtureExtension(extensionsDir, 'task')
+        await writeFixtureExtension(extensionsDir, 'goals')
+
+        const listing = await makeManager(['task']).list()
+
+        expect(listing.find((entry) => entry.name === 'task')?.shadowed).toBe(true)
+        expect(listing.find((entry) => entry.name === 'goals')?.shadowed).toBe(false)
+    })
+
+    it('reports an executable that has not been built', async () => {
+        await writeFixtureExtension(extensionsDir, 'built')
+        await writeFixtureExtension(extensionsDir, 'unbuilt', { notExecutable: true })
+
+        const listing = await makeManager().list()
+
+        expect(listing.find((entry) => entry.name === 'built')?.executable).toBe(true)
+        expect(listing.find((entry) => entry.name === 'unbuilt')?.executable).toBe(false)
+    })
+
+    it('reports the release tag as the version of a binary install', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            installedManifest: {
+                owner: 'Doist',
+                name: 'td-goals',
+                host: 'github.com',
+                tag: 'v0.3.0',
+                pinned: false,
+                asset: 'a',
+                installedAt: 'now',
+            },
+        })
+
+        const [entry] = await makeManager().list()
+        expect(entry).toMatchObject({ version: 'v0.3.0', official: true })
+    })
+
+    it('has no version for a local install', async () => {
+        const workspace = join(root, 'code')
+        await mkdir(workspace, { recursive: true })
+        const target = await writeFixtureExtension(workspace, 'scratch')
+        await symlink(target, join(extensionsDir, 'td-scratch'), 'dir')
+
+        const [entry] = await makeManager().list()
+        expect(entry.version).toBeUndefined()
+    })
+
+    it('runs an extension and returns its exit code', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals')
+
+        await expect(
+            makeManager().dispatch('goals', ['--exit-code', '7'], { env: quiet() }),
+        ).resolves.toBe(7)
+    })
+
+    it('warns, but still runs, when the host is older than the extension requires', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            authoredManifest: { requires: { td: '>=9.0.0' } },
+        })
+
+        await expect(makeManager().dispatch('goals', [], { env: quiet() })).resolves.toBe(0)
+        expect(warnings.some((warning) => warning.includes('expects td >=9.0.0'))).toBe(true)
+    })
+
+    it('says nothing when the host satisfies the required range', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            authoredManifest: { requires: { td: '>=5.0.0' } },
+        })
+
+        await makeManager().dispatch('goals', [], { env: quiet() })
+        expect(warnings).toEqual([])
+    })
+})

--- a/src/lib/extensions/manager.ts
+++ b/src/lib/extensions/manager.ts
@@ -10,7 +10,8 @@
 
 import { join } from 'node:path'
 import { CliError } from '@doist/cli-core'
-import { discoverExtensions } from './discover.js'
+import { mapWithConcurrency } from './concurrency.js'
+import { discoverExtensions, findExtension } from './discover.js'
 import { buildExtensionEnv, dispatchExtension } from './dispatch.js'
 import { isExecutable } from './fs-utils.js'
 import { headSha } from './git.js'
@@ -31,7 +32,7 @@ import type {
     UpgradeOptions,
     UpgradeResult,
 } from './types.js'
-import { mapWithConcurrency, upgradeExtensions } from './upgrade.js'
+import { upgradeExtensions } from './upgrade.js'
 import { satisfiesRange } from './version-range.js'
 
 export type ExtensionManager = {
@@ -111,20 +112,21 @@ export function createExtensionManager(options: ExtensionManagerOptions): Extens
         return discoverExtensions(discoverOptions)
     }
 
+    function notFound(name: string): CliError {
+        return new CliError('EXTENSION_NOT_FOUND', `No extension named "${name}" is installed.`, {
+            hints: [`Run \`${binName} extension list\` to see what is installed.`],
+        })
+    }
+
+    /** Inspect the one entry that could match, rather than describing them all. */
     async function find(selector: string): Promise<Extension | undefined> {
-        const name = normalizeSelector(binName, selector)
-        return (await discover()).find((extension) => extension.name === name)
+        return findExtension(normalizeSelector(binName, selector), discoverOptions)
     }
 
     async function requireExtension(selector: string): Promise<Extension> {
-        const extension = await find(selector)
-        if (!extension) {
-            throw new CliError(
-                'EXTENSION_NOT_FOUND',
-                `No extension named "${normalizeSelector(binName, selector)}" is installed.`,
-                { hints: [`Run \`${binName} extension list\` to see what is installed.`] },
-            )
-        }
+        const name = normalizeSelector(binName, selector)
+        const extension = await find(name)
+        if (!extension) throw notFound(name)
         return extension
     }
 
@@ -178,21 +180,21 @@ export function createExtensionManager(options: ExtensionManagerOptions): Extens
         },
 
         async upgrade(selectors, upgradeOptions = {}) {
-            // One scan for the whole set: resolving each selector separately
-            // would re-read every installed extension once per name.
+            // Deduplicated first: `goals` and `td-goals` name one extension,
+            // and two upgrades of one directory at once would write over each
+            // other.
+            const names = [
+                ...new Set(selectors.map((selector) => normalizeSelector(binName, selector))),
+            ]
+
+            // One scan for the whole set, rather than one per name.
             const installed = await discover()
-            const extensions = selectors.map((selector) => {
-                const name = normalizeSelector(binName, selector)
+            const extensions = names.map((name) => {
                 const extension = installed.find((candidate) => candidate.name === name)
-                if (!extension) {
-                    throw new CliError(
-                        'EXTENSION_NOT_FOUND',
-                        `No extension named "${name}" is installed.`,
-                        { hints: [`Run \`${binName} extension list\` to see what is installed.`] },
-                    )
-                }
+                if (!extension) throw notFound(name)
                 return extension
             })
+
             return upgradeExtensions(extensions, upgradeOptions, installContext)
         },
 
@@ -217,7 +219,7 @@ export function createExtensionManager(options: ExtensionManagerOptions): Extens
                 extension,
                 user: dispatchOptions.user,
                 accessible: isAccessible(),
-                extra: dispatchOptions.env,
+                env: dispatchOptions.env,
             })
 
             return dispatchExtension(extension, args, env)

--- a/src/lib/extensions/manager.ts
+++ b/src/lib/extensions/manager.ts
@@ -1,0 +1,230 @@
+/**
+ * The extension manager: one object holding every operation the CLI needs,
+ * configured entirely through its options.
+ *
+ * Nothing in this directory knows which CLI it is serving. The binary name,
+ * directories, version, reserved command names and first-party source all
+ * arrive here, which is what allows the whole thing to move to
+ * `@doist/cli-core` and be adopted by another CLI with one call.
+ */
+
+import { join } from 'node:path'
+import { CliError } from '@doist/cli-core'
+import { discoverExtensions } from './discover.js'
+import { buildExtensionEnv, dispatchExtension } from './dispatch.js'
+import { isExecutable } from './fs-utils.js'
+import { headSha } from './git.js'
+import { createGitHubClient } from './github.js'
+import { installExtension, type InstallContext, isEmpty } from './install.js'
+import { removeExtension } from './remove.js'
+import { normalizeSelector } from './source.js'
+import type {
+    DispatchOptions,
+    Extension,
+    ExtensionListing,
+    ExtensionManagerOptions,
+    ExtensionTheme,
+    InstallOptions,
+    InstallResult,
+    RemoveOptions,
+    RemoveResult,
+    UpgradeOptions,
+    UpgradeResult,
+} from './types.js'
+import { mapWithConcurrency, upgradeExtensions } from './upgrade.js'
+import { satisfiesRange } from './version-range.js'
+
+export type ExtensionManager = {
+    readonly binName: string
+    readonly envPrefix: string
+    readonly extensionsDir: string
+    readonly officialLabel: string
+    readonly theme: ExtensionTheme
+    readonly trustWarning: string
+    isAccessible(): boolean
+    /** Everything installed, cheaply: no subprocesses, no network. */
+    discover(): Promise<Extension[]>
+    /** Resolve `goals`, `td-goals` or `owner/td-goals` to an installed extension. */
+    find(selector: string): Promise<Extension | undefined>
+    /** Like `find`, but throws the standard not-found error. */
+    require(selector: string): Promise<Extension>
+    /** Everything installed, with the details that cost extra work to learn. */
+    list(): Promise<ExtensionListing[]>
+    install(source: string, options?: InstallOptions): Promise<InstallResult>
+    upgrade(selectors: string[], options?: UpgradeOptions): Promise<UpgradeResult[]>
+    upgradeAll(options?: UpgradeOptions): Promise<UpgradeResult[]>
+    remove(selector: string, options?: RemoveOptions): Promise<RemoveResult>
+    /** Run an extension and resolve with the exit code the host should use. */
+    dispatch(selector: string, args: string[], options?: DispatchOptions): Promise<number>
+    /** True when no extension is installed, used to decide whether to advertise the feature. */
+    isEmpty(): Promise<boolean>
+}
+
+const IDENTITY: ExtensionTheme = {
+    dim: (text) => text,
+    bold: (text) => text,
+    green: (text) => text,
+    yellow: (text) => text,
+}
+
+export function createExtensionManager(options: ExtensionManagerOptions): ExtensionManager {
+    const {
+        binName,
+        envPrefix,
+        version,
+        dataDir,
+        stateDir,
+        configDir,
+        hostPath,
+        reservedNames,
+        officialSource,
+        officialLabel,
+    } = options
+
+    const extensionsDir = join(dataDir, 'extensions')
+    const theme: ExtensionTheme = { ...IDENTITY, ...options.theme }
+    const log = options.log ?? ((message: string) => console.log(message))
+    const warn = options.warn ?? ((message: string) => console.error(message))
+    const isAccessible = options.isAccessible ?? (() => false)
+    const client = createGitHubClient(options.fetchImpl ?? fetch)
+
+    const trustWarning =
+        `Extensions are not reviewed, signed, or endorsed by ${officialLabel}. ` +
+        `Installing one runs code from its publisher with your permissions and your ${officialLabel} credentials. ` +
+        'Review the source before use.'
+
+    const discoverOptions = { extensionsDir, stateDir, binName, officialSource }
+
+    const installContext: InstallContext = {
+        binName,
+        extensionsDir,
+        stateDir,
+        officialSource,
+        client,
+        reservedNames,
+        log,
+        warn,
+        trustWarning,
+    }
+
+    async function discover(): Promise<Extension[]> {
+        return discoverExtensions(discoverOptions)
+    }
+
+    async function find(selector: string): Promise<Extension | undefined> {
+        const name = normalizeSelector(binName, selector)
+        return (await discover()).find((extension) => extension.name === name)
+    }
+
+    async function requireExtension(selector: string): Promise<Extension> {
+        const extension = await find(selector)
+        if (!extension) {
+            throw new CliError(
+                'EXTENSION_NOT_FOUND',
+                `No extension named "${normalizeSelector(binName, selector)}" is installed.`,
+                { hints: [`Run \`${binName} extension list\` to see what is installed.`] },
+            )
+        }
+        return extension
+    }
+
+    async function describeVersion(extension: Extension): Promise<string | undefined> {
+        if (extension.kind === 'binary') return extension.manifest?.tag
+        if (extension.kind === 'git') return (await headSha(extension.dir))?.slice(0, 8)
+        return undefined
+    }
+
+    async function list(): Promise<ExtensionListing[]> {
+        const extensions = await discover()
+        const reserved = new Set(reservedNames())
+
+        return mapWithConcurrency(extensions, 4, async (extension) => ({
+            ...extension,
+            version: await describeVersion(extension),
+            shadowed: reserved.has(extension.name),
+            executable: await isExecutable(extension.executablePath),
+        }))
+    }
+
+    /**
+     * A `requires` range that the running host does not satisfy is a warning,
+     * never a refusal: upgrading the CLI should not silently break an
+     * extension that still works.
+     */
+    function warnIfIncompatible(extension: Extension): void {
+        const range = extension.requires?.[binName]
+        if (range && !satisfiesRange(version, range)) {
+            warn(
+                `Warning: ${extension.name} expects ${binName} ${range}, but this is ${binName} ${version}.`,
+            )
+        }
+    }
+
+    return {
+        binName,
+        envPrefix,
+        extensionsDir,
+        officialLabel,
+        theme,
+        trustWarning,
+        isAccessible,
+        discover,
+        find,
+        require: requireExtension,
+        list,
+
+        async install(source, installOptions = {}) {
+            return installExtension(source, installOptions, installContext)
+        },
+
+        async upgrade(selectors, upgradeOptions = {}) {
+            // One scan for the whole set: resolving each selector separately
+            // would re-read every installed extension once per name.
+            const installed = await discover()
+            const extensions = selectors.map((selector) => {
+                const name = normalizeSelector(binName, selector)
+                const extension = installed.find((candidate) => candidate.name === name)
+                if (!extension) {
+                    throw new CliError(
+                        'EXTENSION_NOT_FOUND',
+                        `No extension named "${name}" is installed.`,
+                        { hints: [`Run \`${binName} extension list\` to see what is installed.`] },
+                    )
+                }
+                return extension
+            })
+            return upgradeExtensions(extensions, upgradeOptions, installContext)
+        },
+
+        async upgradeAll(upgradeOptions = {}) {
+            return upgradeExtensions(await discover(), upgradeOptions, installContext)
+        },
+
+        async remove(selector, removeOptions = {}) {
+            const extension = await requireExtension(selector)
+            return removeExtension(extension, removeOptions, { binName, stateDir })
+        },
+
+        async dispatch(selector, args, dispatchOptions = {}) {
+            const extension = await requireExtension(selector)
+            warnIfIncompatible(extension)
+
+            const env = buildExtensionEnv({
+                envPrefix,
+                version,
+                configDir,
+                hostPath,
+                extension,
+                user: dispatchOptions.user,
+                accessible: isAccessible(),
+                extra: dispatchOptions.env,
+            })
+
+            return dispatchExtension(extension, args, env)
+        },
+
+        async isEmpty() {
+            return isEmpty(extensionsDir)
+        },
+    }
+}

--- a/src/lib/extensions/manager.ts
+++ b/src/lib/extensions/manager.ts
@@ -17,6 +17,8 @@ import { isExecutable } from './fs-utils.js'
 import { headSha } from './git.js'
 import { createGitHubClient } from './github.js'
 import { installExtension, type InstallContext, isEmpty } from './install.js'
+import { isFromNewerFormat } from './manifest-format.js'
+import { readAuthoredManifest } from './manifest.js'
 import { removeExtension } from './remove.js'
 import { normalizeSelector } from './source.js'
 import type {
@@ -145,6 +147,12 @@ export function createExtensionManager(options: ExtensionManagerOptions): Extens
             version: await describeVersion(extension),
             shadowed: reserved.has(extension.name),
             executable: await isExecutable(extension.executablePath),
+            // Read here rather than warned about on every run: an extension
+            // whose metadata is newer still works, and listing is where
+            // someone looks to find out why a description is missing.
+            manifestFromNewerFormat: isFromNewerFormat(
+                await readAuthoredManifest(extension.dir, binName),
+            ),
         }))
     }
 

--- a/src/lib/extensions/types.ts
+++ b/src/lib/extensions/types.ts
@@ -57,6 +57,11 @@ export type ExtensionListing = Extension & {
     shadowed: boolean
     /** False when the executable is missing or lacks the executable bit. */
     executable: boolean
+    /**
+     * True when the extension's manifest declares a format newer than this
+     * CLI understands, so some of its metadata is being ignored.
+     */
+    manifestFromNewerFormat: boolean
 }
 
 export type InstallOptions = {

--- a/src/lib/extensions/version-range.test.ts
+++ b/src/lib/extensions/version-range.test.ts
@@ -21,12 +21,33 @@ describe('satisfiesRange', () => {
         expect(satisfiesRange(version, range)).toBe(expected)
     })
 
-    it('applies caret rules, including the 0.x special case', () => {
+    it('applies caret rules, narrowing as the version approaches zero', () => {
         expect(satisfiesRange('4.9.0', '^4.1.0')).toBe(true)
         expect(satisfiesRange('5.0.0', '^4.1.0')).toBe(false)
         expect(satisfiesRange('4.0.0', '^4.1.0')).toBe(false)
         expect(satisfiesRange('0.2.9', '^0.2.3')).toBe(true)
         expect(satisfiesRange('0.3.0', '^0.2.3')).toBe(false)
+        // ^0.0.3 allows nothing above itself.
+        expect(satisfiesRange('0.0.3', '^0.0.3')).toBe(true)
+        expect(satisfiesRange('0.0.4', '^0.0.3')).toBe(false)
+    })
+
+    it('reads an operator written apart from its version', () => {
+        expect(satisfiesRange('5.3.1', '>= 4.0.0')).toBe(true)
+        expect(satisfiesRange('3.0.0', '>= 4.0.0')).toBe(false)
+        expect(satisfiesRange('4.5.0', '>= 4.0.0 < 5.0.0')).toBe(true)
+    })
+
+    it('does not enforce half of a clause it cannot read in full', () => {
+        // A hyphen range read as two exact matches would warn about a version
+        // that actually sits inside it.
+        expect(satisfiesRange('4.5.0', '4.0.0 - 5.0.0')).toBe(true)
+    })
+
+    it('ignores empty alternatives rather than letting them satisfy the range', () => {
+        expect(satisfiesRange('3.0.0', '>=9.0.0 ||')).toBe(false)
+        expect(satisfiesRange('3.0.0', '|| >=9.0.0')).toBe(false)
+        expect(satisfiesRange('9.1.0', '>=9.0.0 ||')).toBe(true)
     })
 
     it('applies tilde rules', () => {

--- a/src/lib/extensions/version-range.test.ts
+++ b/src/lib/extensions/version-range.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { satisfiesRange } from './version-range.js'
+
+describe('satisfiesRange', () => {
+    it('treats a missing or wildcard range as satisfied', () => {
+        expect(satisfiesRange('5.3.1', undefined)).toBe(true)
+        expect(satisfiesRange('5.3.1', '')).toBe(true)
+        expect(satisfiesRange('5.3.1', '*')).toBe(true)
+    })
+
+    it.each([
+        ['5.3.1', '>=4.0.0', true],
+        ['3.9.0', '>=4.0.0', false],
+        ['4.0.0', '>=4.0.0', true],
+        ['4.0.0', '>4.0.0', false],
+        ['4.0.0', '<5.0.0', true],
+        ['5.0.0', '<5.0.0', false],
+        ['5.3.1', '5.3.1', true],
+        ['5.3.2', '5.3.1', false],
+    ])('%s against %s is %s', (version, range, expected) => {
+        expect(satisfiesRange(version, range)).toBe(expected)
+    })
+
+    it('applies caret rules, including the 0.x special case', () => {
+        expect(satisfiesRange('4.9.0', '^4.1.0')).toBe(true)
+        expect(satisfiesRange('5.0.0', '^4.1.0')).toBe(false)
+        expect(satisfiesRange('4.0.0', '^4.1.0')).toBe(false)
+        expect(satisfiesRange('0.2.9', '^0.2.3')).toBe(true)
+        expect(satisfiesRange('0.3.0', '^0.2.3')).toBe(false)
+    })
+
+    it('applies tilde rules', () => {
+        expect(satisfiesRange('4.1.9', '~4.1.0')).toBe(true)
+        expect(satisfiesRange('4.2.0', '~4.1.0')).toBe(false)
+    })
+
+    it('supports a conjunction and a disjunction', () => {
+        expect(satisfiesRange('4.5.0', '>=4.0.0 <5.0.0')).toBe(true)
+        expect(satisfiesRange('5.1.0', '>=4.0.0 <5.0.0')).toBe(false)
+        expect(satisfiesRange('5.1.0', '^4.0.0 || >=5.0.0')).toBe(true)
+    })
+
+    it('passes ranges it cannot parse, since the check only drives a warning', () => {
+        expect(satisfiesRange('5.3.1', 'next')).toBe(true)
+        expect(satisfiesRange('5.3.1', '>=4.0.0-alpha.x.y.z.what')).toBe(true)
+    })
+})

--- a/src/lib/extensions/version-range.ts
+++ b/src/lib/extensions/version-range.ts
@@ -68,13 +68,27 @@ export function satisfiesRange(version: string, range: string | undefined): bool
     const trimmed = range?.trim()
     if (!trimmed || trimmed === '*' || trimmed === 'x') return true
 
-    return trimmed.split('||').some((clause) => {
-        const comparators = clause.trim().split(/\s+/).filter(Boolean).map(parseComparator)
-        if (comparators.length === 0) return true
-        // An unparseable comparator makes the whole clause pass; see the note
-        // at the top about preferring false positives.
+    // An operator may be written apart from its version, so `>= 4.0.0` is one
+    // comparator rather than two tokens.
+    const clauses = trimmed
+        .split('||')
+        .map((clause) => clause.trim().replace(/(>=|<=|>|<|=|\^|~)\s+/g, '$1'))
+        .filter(Boolean)
+
+    // A range made only of separators asks for nothing, so nothing is unmet.
+    if (clauses.length === 0) return true
+
+    return clauses.some((clause) => {
+        const comparators = clause.split(/\s+/).filter(Boolean).map(parseComparator)
+
+        // A clause this checker cannot read in full counts as satisfied rather
+        // than half-enforced. A hyphen range such as `4.0.0 - 5.0.0` would
+        // otherwise read as two exact-match comparators and warn about a
+        // version that sits inside it.
+        if (comparators.some((comparator) => comparator === undefined)) return true
+
         return comparators.every(
-            (comparator) => comparator === undefined || satisfiesComparator(version, comparator),
+            (comparator) => comparator !== undefined && satisfiesComparator(version, comparator),
         )
     })
 }

--- a/src/lib/extensions/version-range.ts
+++ b/src/lib/extensions/version-range.ts
@@ -1,0 +1,80 @@
+/**
+ * A deliberately small semver range check for an extension's `requires` field.
+ *
+ * Supports the forms an extension author realistically writes: `>=4.1.0`,
+ * `^4.1.0`, `~4.1.0`, `4.1.0`, `*`, a space-separated conjunction
+ * (`>=4.1.0 <5.0.0`) and a `||` disjunction. Anything it cannot parse is
+ * treated as satisfied, because a version range is advisory here: failing it
+ * only prints a warning, so a false negative would be noise while a false
+ * positive costs nothing.
+ */
+
+import { compareVersions, parseVersion } from '@doist/cli-core/commands'
+
+type Comparator = { operator: string; version: string }
+
+const COMPARATOR = /^(>=|<=|>|<|=|\^|~)?\s*v?(\d.*)$/
+
+function parseComparator(raw: string): Comparator | undefined {
+    const match = raw.trim().match(COMPARATOR)
+    if (!match) return undefined
+    const [, operator, version] = match
+    return { operator: operator ?? '=', version }
+}
+
+/** Upper bound (exclusive) for `^` and `~`, following npm's rules. */
+function upperBound(operator: string, version: string): string | undefined {
+    const { major, minor, patch } = parseVersion(version)
+    if (operator === '^') {
+        // Caret narrows as the version approaches zero: ^1.2.3 allows minor
+        // changes, ^0.2.3 allows patch changes, and ^0.0.3 allows nothing above
+        // itself.
+        if (major > 0) return `${major + 1}.0.0`
+        if (minor > 0) return `0.${minor + 1}.0`
+        return `0.0.${patch + 1}`
+    }
+    if (operator === '~') return `${major}.${minor + 1}.0`
+    return undefined
+}
+
+function satisfiesComparator(version: string, comparator: Comparator): boolean {
+    const { operator, version: target } = comparator
+    const compared = compareVersions(version, target)
+
+    switch (operator) {
+        case '>':
+            return compared > 0
+        case '>=':
+            return compared >= 0
+        case '<':
+            return compared < 0
+        case '<=':
+            return compared <= 0
+        case '^':
+        case '~': {
+            const bound = upperBound(operator, target)
+            return compared >= 0 && (bound === undefined || compareVersions(version, bound) < 0)
+        }
+        default:
+            return compared === 0
+    }
+}
+
+/**
+ * True when `version` satisfies `range`, or when the range is empty or in a
+ * form this checker does not understand.
+ */
+export function satisfiesRange(version: string, range: string | undefined): boolean {
+    const trimmed = range?.trim()
+    if (!trimmed || trimmed === '*' || trimmed === 'x') return true
+
+    return trimmed.split('||').some((clause) => {
+        const comparators = clause.trim().split(/\s+/).filter(Boolean).map(parseComparator)
+        if (comparators.length === 0) return true
+        // An unparseable comparator makes the whole clause pass; see the note
+        // at the top about preferring false positives.
+        return comparators.every(
+            (comparator) => comparator === undefined || satisfiesComparator(version, comparator),
+        )
+    })
+}


### PR DESCRIPTION
Slice 7 of 7, on top of slice 6. This completes the library half of phase 1.

Ties the slices together behind `createExtensionManager`, which is the only thing a host CLI needs to call.

Includes the version-range check behind an extension's `requires` field. A range the running CLI does not satisfy is a warning rather than a refusal: upgrading the CLI should not silently break an extension that still works.

Also records the subsystem in `CODEBASE.md`, including why nothing in the directory imports from the rest of the repo.

Next, in a separate PR: the `td extension` command group, the `src/index.ts` wiring, the command-token lookup change, `--user` scoping, doctor checks and `SKILL_CONTENT`.

**Stack:** #521 core · #522 discovery · #523 dispatch · #524 tools · #525 install · #526 upgrade · #527 manager