### PR TITLE
feat(paths): resolve the per-user data and state directories

### DIFF
--- a/src/lib/app-name.ts
+++ b/src/lib/app-name.ts
@@ -1,0 +1,7 @@
+/**
+ * The directory name this CLI owns under the config, data and state roots.
+ *
+ * One constant rather than one per module, so that a rename cannot move the
+ * config without moving the extensions with it.
+ */
+export const APP_NAME = 'todoist-cli'

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -10,7 +10,7 @@ vi.mock('@doist/cli-core', async () => {
 })
 
 import { readConfigStrict as readConfigStrictCore } from '@doist/cli-core'
-import { readConfigStrict } from './config.js'
+import { getConfigDir, getConfigPath, readConfigStrict } from './config.js'
 
 const mockReadConfigStrictCore = vi.mocked(readConfigStrictCore)
 
@@ -69,5 +69,15 @@ describe('readConfigStrict wrapper', () => {
                 'Fix the JSON by hand, or delete the file and re-authenticate with `td auth login`',
             ],
         })
+    })
+})
+
+describe('getConfigDir', () => {
+    it('is the directory holding the config file', () => {
+        expect(getConfigDir()).toBe('/tmp/cli-core-test')
+    })
+
+    it('never disagrees with getConfigPath about where the config lives', () => {
+        expect(getConfigPath().startsWith(`${getConfigDir()}/`)).toBe(true)
     })
 })

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,3 +1,4 @@
+import { dirname } from 'node:path'
 import {
     getConfigPath as getConfigPathCore,
     readConfig as readConfigCore,
@@ -17,6 +18,15 @@ const APP_NAME = 'todoist-cli'
  */
 export function getConfigPath(): string {
     return getConfigPathCore(APP_NAME)
+}
+
+/**
+ * The directory holding the config file. Derived from the path rather than
+ * rebuilt from the same environment variables, so the two can never disagree
+ * about where the config lives.
+ */
+export function getConfigDir(): string {
+    return dirname(getConfigPath())
 }
 
 export type AuthMode = 'read-only' | 'read-write' | 'unknown'

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -5,10 +5,9 @@ import {
     readConfigStrict as readConfigStrictCore,
     writeConfig as writeConfigCore,
 } from '@doist/cli-core'
+import { APP_NAME } from './app-name.js'
 import { CliError } from './errors.js'
 import { normalizeHelpCenterLocale } from './help-center.js'
-
-const APP_NAME = 'todoist-cli'
 
 /**
  * Resolve the canonical config path lazily. Computing on each call (instead of

--- a/src/lib/paths.test.ts
+++ b/src/lib/paths.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const REAL_PLATFORM = process.platform
+const HOME = '/home/tester'
+
+/**
+ * Load the module with `homedir()` pointed somewhere predictable. `paths.ts`
+ * imports `node:os` directly, so mocking the module reaches it — unlike the
+ * config path, which is resolved inside cli-core's compiled output.
+ */
+async function loadPaths(home = HOME) {
+    vi.resetModules()
+    vi.doMock('node:os', () => ({ homedir: () => home }))
+    return import('./paths.js')
+}
+
+function setPlatform(platform: NodeJS.Platform) {
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+}
+
+/** The XDG variables are read from the real environment, so clear them first. */
+function clearEnv() {
+    for (const name of ['XDG_DATA_HOME', 'XDG_STATE_HOME', 'LOCALAPPDATA']) {
+        vi.stubEnv(name, undefined)
+    }
+}
+
+afterEach(() => {
+    setPlatform(REAL_PLATFORM)
+    vi.unstubAllEnvs()
+    vi.doUnmock('node:os')
+    vi.resetModules()
+})
+
+describe('getDataDir', () => {
+    it.each(['linux', 'darwin'] as const)('uses the XDG layout on %s', async (platform) => {
+        clearEnv()
+        setPlatform(platform)
+        const { getDataDir } = await loadPaths()
+        expect(getDataDir()).toBe('/home/tester/.local/share/todoist-cli')
+    })
+
+    it('prefers XDG_DATA_HOME when it is set', async () => {
+        clearEnv()
+        setPlatform('linux')
+        vi.stubEnv('XDG_DATA_HOME', '/elsewhere/data')
+        const { getDataDir } = await loadPaths()
+        expect(getDataDir()).toBe('/elsewhere/data/todoist-cli')
+    })
+
+    it('uses LOCALAPPDATA on Windows', async () => {
+        clearEnv()
+        setPlatform('win32')
+        vi.stubEnv('LOCALAPPDATA', 'C:\\Users\\tester\\AppData\\Local')
+        const { getDataDir } = await loadPaths()
+        expect(getDataDir()).toBe('C:\\Users\\tester\\AppData\\Local/todoist-cli')
+    })
+
+    it('falls back to the documented location when LOCALAPPDATA is missing', async () => {
+        clearEnv()
+        setPlatform('win32')
+        const { getDataDir } = await loadPaths('C:\\Users\\tester')
+        expect(getDataDir()).toBe('C:\\Users\\tester/AppData/Local/todoist-cli')
+    })
+
+    it('lets XDG_DATA_HOME win on Windows too', async () => {
+        clearEnv()
+        setPlatform('win32')
+        vi.stubEnv('LOCALAPPDATA', 'C:\\Users\\tester\\AppData\\Local')
+        vi.stubEnv('XDG_DATA_HOME', '/elsewhere/data')
+        const { getDataDir } = await loadPaths()
+        expect(getDataDir()).toBe('/elsewhere/data/todoist-cli')
+    })
+})
+
+describe('getStateDir', () => {
+    it.each(['linux', 'darwin'] as const)('uses the XDG layout on %s', async (platform) => {
+        clearEnv()
+        setPlatform(platform)
+        const { getStateDir } = await loadPaths()
+        expect(getStateDir()).toBe('/home/tester/.local/state/todoist-cli')
+    })
+
+    it('prefers XDG_STATE_HOME when it is set', async () => {
+        clearEnv()
+        setPlatform('linux')
+        vi.stubEnv('XDG_STATE_HOME', '/elsewhere/state')
+        const { getStateDir } = await loadPaths()
+        expect(getStateDir()).toBe('/elsewhere/state/todoist-cli')
+    })
+
+    it('nests under the data root on Windows, which has no state root', async () => {
+        clearEnv()
+        setPlatform('win32')
+        vi.stubEnv('LOCALAPPDATA', 'C:\\Users\\tester\\AppData\\Local')
+        const { getDataDir, getStateDir } = await loadPaths()
+        expect(getStateDir()).toBe('C:\\Users\\tester\\AppData\\Local/todoist-cli/state')
+        // The extensions directory is a sibling of `state`, so the two cannot
+        // collide however the data root is spelled.
+        expect(getStateDir().startsWith(`${getDataDir()}/`)).toBe(true)
+    })
+})
+
+describe('the two directories', () => {
+    it('stay distinct on every platform', async () => {
+        for (const platform of ['linux', 'darwin', 'win32'] as const) {
+            clearEnv()
+            setPlatform(platform)
+            const { getDataDir, getStateDir } = await loadPaths()
+            expect(getDataDir()).not.toBe(getStateDir())
+        }
+    })
+})

--- a/src/lib/paths.test.ts
+++ b/src/lib/paths.test.ts
@@ -1,7 +1,9 @@
+import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const REAL_PLATFORM = process.platform
-const HOME = '/home/tester'
+const HOME = join('/home', 'tester')
+const WINDOWS_LOCAL_APPDATA = 'C:\\Users\\tester\\AppData\\Local'
 
 /**
  * Load the module with `homedir()` pointed somewhere predictable. `paths.ts`
@@ -37,39 +39,41 @@ describe('getDataDir', () => {
         clearEnv()
         setPlatform(platform)
         const { getDataDir } = await loadPaths()
-        expect(getDataDir()).toBe('/home/tester/.local/share/todoist-cli')
+        expect(getDataDir()).toBe(join(HOME, '.local', 'share', 'todoist-cli'))
     })
 
     it('prefers XDG_DATA_HOME when it is set', async () => {
         clearEnv()
         setPlatform('linux')
-        vi.stubEnv('XDG_DATA_HOME', '/elsewhere/data')
+        vi.stubEnv('XDG_DATA_HOME', join('/elsewhere', 'data'))
         const { getDataDir } = await loadPaths()
-        expect(getDataDir()).toBe('/elsewhere/data/todoist-cli')
+        expect(getDataDir()).toBe(join('/elsewhere', 'data', 'todoist-cli'))
     })
 
     it('uses LOCALAPPDATA on Windows', async () => {
         clearEnv()
         setPlatform('win32')
-        vi.stubEnv('LOCALAPPDATA', 'C:\\Users\\tester\\AppData\\Local')
+        vi.stubEnv('LOCALAPPDATA', WINDOWS_LOCAL_APPDATA)
         const { getDataDir } = await loadPaths()
-        expect(getDataDir()).toBe('C:\\Users\\tester\\AppData\\Local/todoist-cli')
+        // Joined rather than spelled out: `node:path` uses the separator of
+        // whichever host runs the suite, not of the platform being faked.
+        expect(getDataDir()).toBe(join(WINDOWS_LOCAL_APPDATA, 'todoist-cli'))
     })
 
     it('falls back to the documented location when LOCALAPPDATA is missing', async () => {
         clearEnv()
         setPlatform('win32')
         const { getDataDir } = await loadPaths('C:\\Users\\tester')
-        expect(getDataDir()).toBe('C:\\Users\\tester/AppData/Local/todoist-cli')
+        expect(getDataDir()).toBe(join('C:\\Users\\tester', 'AppData', 'Local', 'todoist-cli'))
     })
 
     it('lets XDG_DATA_HOME win on Windows too', async () => {
         clearEnv()
         setPlatform('win32')
-        vi.stubEnv('LOCALAPPDATA', 'C:\\Users\\tester\\AppData\\Local')
-        vi.stubEnv('XDG_DATA_HOME', '/elsewhere/data')
+        vi.stubEnv('LOCALAPPDATA', WINDOWS_LOCAL_APPDATA)
+        vi.stubEnv('XDG_DATA_HOME', join('/elsewhere', 'data'))
         const { getDataDir } = await loadPaths()
-        expect(getDataDir()).toBe('/elsewhere/data/todoist-cli')
+        expect(getDataDir()).toBe(join('/elsewhere', 'data', 'todoist-cli'))
     })
 })
 
@@ -78,26 +82,55 @@ describe('getStateDir', () => {
         clearEnv()
         setPlatform(platform)
         const { getStateDir } = await loadPaths()
-        expect(getStateDir()).toBe('/home/tester/.local/state/todoist-cli')
+        expect(getStateDir()).toBe(join(HOME, '.local', 'state', 'todoist-cli'))
     })
 
     it('prefers XDG_STATE_HOME when it is set', async () => {
         clearEnv()
         setPlatform('linux')
-        vi.stubEnv('XDG_STATE_HOME', '/elsewhere/state')
+        vi.stubEnv('XDG_STATE_HOME', join('/elsewhere', 'state'))
         const { getStateDir } = await loadPaths()
-        expect(getStateDir()).toBe('/elsewhere/state/todoist-cli')
+        expect(getStateDir()).toBe(join('/elsewhere', 'state', 'todoist-cli'))
     })
 
     it('nests under the data root on Windows, which has no state root', async () => {
         clearEnv()
         setPlatform('win32')
-        vi.stubEnv('LOCALAPPDATA', 'C:\\Users\\tester\\AppData\\Local')
+        vi.stubEnv('LOCALAPPDATA', WINDOWS_LOCAL_APPDATA)
         const { getDataDir, getStateDir } = await loadPaths()
-        expect(getStateDir()).toBe('C:\\Users\\tester\\AppData\\Local/todoist-cli/state')
-        // The extensions directory is a sibling of `state`, so the two cannot
-        // collide however the data root is spelled.
-        expect(getStateDir().startsWith(`${getDataDir()}/`)).toBe(true)
+        expect(getStateDir()).toBe(join(getDataDir(), 'state'))
+    })
+})
+
+describe('a relative XDG value', () => {
+    // The spec says these must be absolute and that a relative value is to be
+    // ignored. Honouring one would tie the directory to the shell's cwd.
+    it.each([
+        ['XDG_DATA_HOME', 'cache'],
+        ['XDG_DATA_HOME', './cache'],
+        ['XDG_DATA_HOME', '../cache'],
+    ])('is ignored for %s=%s', async (name, value) => {
+        clearEnv()
+        setPlatform('linux')
+        vi.stubEnv(name, value)
+        const { getDataDir } = await loadPaths()
+        expect(getDataDir()).toBe(join(HOME, '.local', 'share', 'todoist-cli'))
+    })
+
+    it('is ignored for XDG_STATE_HOME', async () => {
+        clearEnv()
+        setPlatform('linux')
+        vi.stubEnv('XDG_STATE_HOME', 'state')
+        const { getStateDir } = await loadPaths()
+        expect(getStateDir()).toBe(join(HOME, '.local', 'state', 'todoist-cli'))
+    })
+
+    it('is ignored for an empty value', async () => {
+        clearEnv()
+        setPlatform('linux')
+        vi.stubEnv('XDG_DATA_HOME', '')
+        const { getDataDir } = await loadPaths()
+        expect(getDataDir()).toBe(join(HOME, '.local', 'share', 'todoist-cli'))
     })
 })
 

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -12,9 +12,8 @@
  */
 
 import { homedir } from 'node:os'
-import { join } from 'node:path'
-
-const APP_NAME = 'todoist-cli'
+import { isAbsolute, join } from 'node:path'
+import { APP_NAME } from './app-name.js'
 
 /**
  * Windows has no XDG equivalent. `LOCALAPPDATA` is set on every supported
@@ -26,6 +25,17 @@ function windowsBase(): string {
 }
 
 /**
+ * The XDG spec requires these variables to hold absolute paths and says a
+ * relative one must be ignored. Honouring a relative value would tie the
+ * extensions directory to whichever directory `td` happened to be started
+ * from, so an extension installed in one place would be invisible from
+ * another.
+ */
+function xdgBase(value: string | undefined): string | undefined {
+    return value && isAbsolute(value) ? value : undefined
+}
+
+/**
  * Where installed extensions live, under an `extensions` subdirectory.
  *
  * macOS gets the XDG layout rather than `~/Library/Application Support`,
@@ -33,7 +43,8 @@ function windowsBase(): string {
  * the two would leave a user's files in two unrelated places.
  */
 export function getDataDir(): string {
-    if (process.env.XDG_DATA_HOME) return join(process.env.XDG_DATA_HOME, APP_NAME)
+    const xdg = xdgBase(process.env.XDG_DATA_HOME)
+    if (xdg) return join(xdg, APP_NAME)
     if (process.platform === 'win32') return join(windowsBase(), APP_NAME)
     return join(homedir(), '.local', 'share', APP_NAME)
 }
@@ -46,7 +57,8 @@ export function getDataDir(): string {
  * cannot collide with the extensions directory, which is a sibling.
  */
 export function getStateDir(): string {
-    if (process.env.XDG_STATE_HOME) return join(process.env.XDG_STATE_HOME, APP_NAME)
+    const xdg = xdgBase(process.env.XDG_STATE_HOME)
+    if (xdg) return join(xdg, APP_NAME)
     if (process.platform === 'win32') return join(windowsBase(), APP_NAME, 'state')
     return join(homedir(), '.local', 'state', APP_NAME)
 }

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,0 +1,52 @@
+/**
+ * Per-user directories that are not the config directory.
+ *
+ * `@doist/cli-core` owns `getConfigPath`, but has no equivalent for data or
+ * state, so they are resolved here in the same shape: the XDG variable first,
+ * the platform default second.
+ *
+ * Everything is computed on each call rather than cached at module load, for
+ * the same reason `getConfigPath` is (see `config.ts`): a cached value freezes
+ * the home directory before a test has had a chance to point it somewhere
+ * harmless.
+ */
+
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+const APP_NAME = 'todoist-cli'
+
+/**
+ * Windows has no XDG equivalent. `LOCALAPPDATA` is set on every supported
+ * version, but it is an ordinary environment variable and can be missing from
+ * a stripped-down service environment, so the documented default stands in.
+ */
+function windowsBase(): string {
+    return process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local')
+}
+
+/**
+ * Where installed extensions live, under an `extensions` subdirectory.
+ *
+ * macOS gets the XDG layout rather than `~/Library/Application Support`,
+ * because cli-core already puts the config at `~/.config` there and splitting
+ * the two would leave a user's files in two unrelated places.
+ */
+export function getDataDir(): string {
+    if (process.env.XDG_DATA_HOME) return join(process.env.XDG_DATA_HOME, APP_NAME)
+    if (process.platform === 'win32') return join(windowsBase(), APP_NAME)
+    return join(homedir(), '.local', 'share', APP_NAME)
+}
+
+/**
+ * Bookkeeping the CLI can regenerate: pins, update checks. Separate from the
+ * data directory so that deleting it loses nothing a user authored.
+ *
+ * Windows has no state root distinct from its data root, so it nests. That
+ * cannot collide with the extensions directory, which is a sibling.
+ */
+export function getStateDir(): string {
+    if (process.env.XDG_STATE_HOME) return join(process.env.XDG_STATE_HOME, APP_NAME)
+    if (process.platform === 'win32') return join(windowsBase(), APP_NAME, 'state')
+    return join(homedir(), '.local', 'state', APP_NAME)
+}


### PR DESCRIPTION
cli-core owns `getConfigPath` but has no equivalent for the data and state directories, which the extension system needs: installed extensions live under the data directory, and their pins and update bookkeeping under the state directory.

Resolve both in the same shape cli-core uses for the config path — the XDG variable first, the platform default second — with Windows falling back to `%LOCALAPPDATA%`. macOS gets the XDG layout rather than `~/Library/Application Support`, because cli-core already puts the config at `~/.config` there and splitting the two would leave a user's files in two unrelated places.

`getConfigDir` joins `getConfigPath` in config.ts, derived from the path rather than rebuilt from the same environment variables so the two can never disagree.

> **Trying it out:** nothing in this stack is usable on its own — `td extension` and extension dispatch only exist once every PR is applied. Check out `feat/ext-cmd-9-docs` (#539), the top of the stack, which carries the instructions.
