### PR TITLE
refactor(cli): resolve the command token before scanning argv

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { stripUserFlag } from '@doist/cli-core'
 import { type Command, program } from 'commander'
 import packageJson from '../package.json' with { type: 'json' }
 import { ACCOUNT_COMMAND_ALIASES } from './commands/user/aliases.js'
+import { findCommandToken } from './lib/command-token.js'
 import { BaseCliError, CliError } from './lib/errors.js'
 import {
     getRequestedUserRef,
@@ -200,6 +201,15 @@ for (const [name, [, , aliases]] of Object.entries(commands)) {
     for (const alias of aliases ?? []) commandAliases[alias] = name
 }
 
+/**
+ * The canonical command a token names, or undefined. `Object.hasOwn` rather
+ * than `in`, so a token like `constructor` cannot resolve through the
+ * prototype chain to something that is not a command.
+ */
+function resolveCommandName(token: string): string | undefined {
+    return Object.hasOwn(commandAliases, token) ? commandAliases[token] : undefined
+}
+
 // Register placeholders so --help lists all commands
 for (const [name, [description, , aliases]] of Object.entries(commands)) {
     const placeholder = program.command(name).description(description)
@@ -248,8 +258,8 @@ program.hook('preAction', (_thisCommand, actionCommand) => {
 if (process.argv[2] === 'completion-server') {
     const { parseCompLine } = await import('./lib/completion.js')
     const compWords = parseCompLine(process.env.COMP_LINE ?? '')
-    const compToken = compWords.find((w) => !w.startsWith('-') && w in commandAliases)
-    const compCmd = compToken ? commandAliases[compToken] : undefined
+    const compToken = findCommandToken(compWords).token
+    const compCmd = compToken ? resolveCommandName(compToken) : undefined
 
     const toLoad = ['completion', ...(compCmd && compCmd !== 'completion' ? [compCmd] : [])]
     for (const name of toLoad) {
@@ -263,12 +273,12 @@ if (process.argv[2] === 'completion-server') {
         }),
     )
 } else {
-    // Find which command (if any) is being invoked — match only known command names
-    // to avoid treating option values (e.g. --progress-jsonl /tmp/out) as commands
-    const commandToken = process.argv
-        .slice(2)
-        .find((a) => !a.startsWith('-') && a in commandAliases)
-    const commandName = commandToken ? commandAliases[commandToken] : undefined
+    // Find which command (if any) is being invoked. Only the first argument
+    // that is neither a global flag nor a flag's value can name one, and
+    // nothing after it is inspected — `td --progress-jsonl out today` runs
+    // `today`, not the `task` that an all-of-argv scan would have found.
+    const commandToken = findCommandToken(process.argv.slice(2)).token
+    const commandName = commandToken ? resolveCommandName(commandToken) : undefined
 
     if (commandName && commands[commandName]) {
         // Remove placeholder, load real command module, register it

--- a/src/lib/command-token.test.ts
+++ b/src/lib/command-token.test.ts
@@ -1,0 +1,178 @@
+import { Command } from 'commander'
+import { describe, expect, it } from 'vitest'
+import { findCommandToken } from './command-token.js'
+
+describe('findCommandToken', () => {
+    it('returns nothing when there are no arguments', () => {
+        expect(findCommandToken([])).toEqual({ token: undefined, index: 0 })
+    })
+
+    it('returns the first positional argument and its index', () => {
+        expect(findCommandToken(['task', 'list'])).toEqual({ token: 'task', index: 0 })
+        expect(findCommandToken(['--accessible', 'task'])).toEqual({ token: 'task', index: 1 })
+    })
+
+    it('does not inspect anything after the token', () => {
+        // `task` here belongs to the extension, not to td.
+        expect(findCommandToken(['goals', 'task', 'list'])).toEqual({ token: 'goals', index: 0 })
+    })
+
+    it('steps over the value of an option that takes one', () => {
+        expect(findCommandToken(['--user', 'alice', 'task'])).toEqual({ token: 'task', index: 2 })
+        expect(findCommandToken(['--progress-jsonl', '/tmp/out', 'task'])).toEqual({
+            token: 'task',
+            index: 2,
+        })
+    })
+
+    it('steps over nothing for the inline form, which carries its own value', () => {
+        expect(findCommandToken(['--user=alice', 'task'])).toEqual({ token: 'task', index: 1 })
+    })
+
+    it('leaves a forgotten value alone rather than hiding the token behind it', () => {
+        // `--json` is not a value, it is the next flag. Commander reports the
+        // missing value itself; swallowing it here would lose `today`.
+        expect(findCommandToken(['--user', '--json', 'today'])).toEqual({
+            token: 'today',
+            index: 2,
+        })
+    })
+
+    it('never treats a boolean option as taking a value', () => {
+        expect(findCommandToken(['--accessible', 'task'])).toEqual({ token: 'task', index: 1 })
+        expect(findCommandToken(['--no-spinner', 'task'])).toEqual({ token: 'task', index: 1 })
+    })
+
+    it.each([['-v'], ['-q'], ['-vvv'], ['-vq']])('skips the short option %s', (flag) => {
+        expect(findCommandToken([flag, 'task'])).toEqual({ token: 'task', index: 1 })
+    })
+
+    it('reads the entry after `--` as the command, dash or not', () => {
+        expect(findCommandToken(['--', 'task'])).toEqual({ token: 'task', index: 1 })
+        expect(findCommandToken(['--', '--json'])).toEqual({ token: '--json', index: 1 })
+    })
+
+    it('returns nothing for a trailing `--`', () => {
+        expect(findCommandToken(['--user', 'alice', '--'])).toEqual({
+            token: undefined,
+            index: 3,
+        })
+    })
+
+    it('treats a bare dash as a token, since it is the stdin placeholder', () => {
+        expect(findCommandToken(['-'])).toEqual({ token: '-', index: 0 })
+    })
+
+    it('treats an empty argument as a token', () => {
+        expect(findCommandToken(['', 'task'])).toEqual({ token: '', index: 0 })
+    })
+
+    it('returns an unknown token rather than looking past it', () => {
+        // Whether the token names anything is the caller's question.
+        expect(findCommandToken(['nonsense', 'task'])).toEqual({ token: 'nonsense', index: 0 })
+    })
+
+    it('accepts a caller-supplied set of value-taking options', () => {
+        expect(findCommandToken(['--ref', 'v1', 'task'], new Set(['--ref']))).toEqual({
+            token: 'task',
+            index: 2,
+        })
+        expect(findCommandToken(['--user', 'alice'], new Set())).toEqual({
+            token: 'alice',
+            index: 1,
+        })
+    })
+})
+
+/**
+ * The scan only earns its keep if it agrees with commander. These cases run
+ * both and compare, so that adding a root option to `index.ts` without adding
+ * it to `VALUE_FLAGS` fails here rather than misrouting at runtime.
+ */
+describe('agreement with commander', () => {
+    const KNOWN = new Set(['task', 'today', 'doctor'])
+
+    /** The top-level command commander actually dispatches, if any. */
+    function commanderDispatch(argv: string[]): string | undefined {
+        let dispatched: string | undefined
+        const program = new Command()
+        program
+            .name('td')
+            .exitOverride()
+            .configureOutput({ writeOut: () => {}, writeErr: () => {} })
+            // Mirrors the root options declared in `index.ts`.
+            .option('--no-spinner')
+            .option('--progress-jsonl [path]')
+            .option('-v, --verbose')
+            .option('--accessible')
+            .option('-q, --quiet')
+            .option('--user <ref>')
+
+        const task = program.command('task').action(() => {
+            dispatched = 'task'
+        })
+        task.command('list')
+            .option('--json')
+            .action(() => {
+                dispatched = 'task'
+            })
+        program.command('today').action(() => {
+            dispatched = 'today'
+        })
+        program
+            .command('doctor')
+            .option('--offline')
+            .action(() => {
+                dispatched = 'doctor'
+            })
+
+        try {
+            program.parse(argv, { from: 'user' })
+        } catch {
+            // Usage errors mean nothing was dispatched, which is the answer.
+        }
+        return dispatched
+    }
+
+    const cases: string[][] = [
+        [],
+        ['task'],
+        ['task', 'list'],
+        ['task', 'list', '--json'],
+        ['today'],
+        ['--accessible', 'task', 'list'],
+        ['-v', 'today'],
+        ['-vvv', 'today'],
+        ['-vq', 'today'],
+        ['-q', 'doctor', '--offline'],
+        ['--user', 'alice', 'today'],
+        ['--user=alice', 'today'],
+        ['--user', '--quiet', 'today'],
+        ['--progress-jsonl', '/tmp/out', 'today'],
+        ['--progress-jsonl', 'today'],
+        ['--progress-jsonl=/tmp/out', 'today'],
+        ['--no-spinner', 'today'],
+        ['--', 'today'],
+        ['--', '--json'],
+        ['nonsense'],
+        ['-'],
+        ['--accessible'],
+    ]
+
+    it.each(cases.map((argv) => [argv.join(' ') || '(no arguments)', argv]))(
+        'resolves `td %s` the same way commander does',
+        (_label, argv) => {
+            const { token } = findCommandToken(argv)
+            const ours = token !== undefined && KNOWN.has(token) ? token : undefined
+            expect(ours).toBe(commanderDispatch(argv))
+        },
+    )
+
+    it('no longer mistakes an option value for the command', () => {
+        // The old all-of-argv scan found `task` here and imported its module,
+        // started the spinner, and only then let commander run `today`.
+        const argv = ['--progress-jsonl', 'task', 'today']
+        expect(findCommandToken(argv).token).toBe('today')
+        expect(commanderDispatch(argv)).toBe('today')
+    })
+})

--- a/src/lib/command-token.ts
+++ b/src/lib/command-token.ts
@@ -1,0 +1,70 @@
+/**
+ * Working out which argument names the command, without parsing the rest.
+ *
+ * The answer has to match what commander will go on to dispatch, because the
+ * lazy loader in `index.ts` uses it to decide which module to import and
+ * whether to start the early spinner. Scanning all of argv for the first
+ * recognised name gets that wrong twice over: `td --progress-jsonl task today`
+ * loads the task module while commander runs `today`, and once extensions
+ * exist `td goals task list` would load the task module on its way to an
+ * extension that never wanted it.
+ *
+ * Everything after the command token is the command's own business and is not
+ * inspected here.
+ */
+
+/**
+ * Root options that consume the next entry as their value, so the scan has to
+ * step over it. Every other root option is boolean, and the `--flag=value`
+ * form carries its own value, so neither can hide the command name.
+ *
+ * `--progress-jsonl` declares its value optional, but commander still takes a
+ * following non-flag token for it, so this has to as well.
+ *
+ * Kept in step with the `program.option(...)` calls in `index.ts`; the tests
+ * check the two agree by running commander itself.
+ */
+const VALUE_FLAGS: ReadonlySet<string> = new Set(['--user', '--progress-jsonl'])
+
+export type CommandToken = {
+    /** The first entry that is neither a root option nor an option's value. */
+    token: string | undefined
+    /** Its index in the scanned array, or the array's length when there is none. */
+    index: number
+}
+
+export function findCommandToken(
+    argv: string[],
+    valueFlags: ReadonlySet<string> = VALUE_FLAGS,
+): CommandToken {
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i]
+
+        // `--` ends option parsing but not subcommand dispatch: commander
+        // reads the next entry as the command name even when it starts with a
+        // dash, and reports it as an unknown command if it is not one.
+        if (arg === '--') {
+            return i + 1 < argv.length
+                ? { token: argv[i + 1], index: i + 1 }
+                : { token: undefined, index: argv.length }
+        }
+
+        // A bare `-` is the conventional stdin placeholder, not an option.
+        if (arg.length > 1 && arg.startsWith('-')) {
+            const takesValue =
+                !arg.includes('=') &&
+                valueFlags.has(arg) &&
+                i + 1 < argv.length &&
+                // A flag where the value should be means the value was
+                // forgotten. Commander reports that itself; stepping over the
+                // flag here would hide the command token behind it.
+                !argv[i + 1].startsWith('-')
+            if (takesValue) i++
+            continue
+        }
+
+        return { token: arg, index: i }
+    }
+
+    return { token: undefined, index: argv.length }
+}


### PR DESCRIPTION
The lazy loader found the command to import by scanning the whole of argv for the first token matching a known command name. That reads arguments that belong to something else: `td --progress-jsonl task today` found `task`, imported its module and started the early spinner, while commander went on to run `today`.

Walk argv from the start instead, stepping over global flags and the values of the two that take one, and stop at the first remaining token. Nothing after it is inspected. The tests run commander itself over the same arguments and compare, so a root option added without a matching entry in `VALUE_FLAGS` fails there rather than misrouting at runtime.

Resolving a token to a command now uses `Object.hasOwn` rather than `in`, so a token like `constructor` cannot reach through the prototype chain to something that is not a command.

> **Trying it out:** nothing in this stack is usable on its own — `td extension` and extension dispatch only exist once every PR is applied. Check out `feat/ext-cmd-9-docs` (#539), the top of the stack, which carries the instructions.
