### PR TITLE
feat(extensions): the extension command group, list and exec

### DIFF
--- a/src/lib/extensions/commands.test.ts
+++ b/src/lib/extensions/commands.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { writeFakeGitRepo, writeFixtureExtension } from '../../test-support/extension-fixture.js'
 import { registerExtensionGroup } from './commands.js'
 import { createExtensionManager, type ExtensionManager } from './manager.js'
+import { run as runProcess } from './run.js'
 
 describe('registerExtensionGroup', () => {
     let root: string
@@ -176,7 +177,35 @@ describe('registerExtensionGroup', () => {
             expect(lines().join('\n')).toContain('manifest needs a newer td')
         })
 
-        it('shows the pin, and the short SHA for a clone', async () => {
+        it('shows the short SHA of a clone', async () => {
+            const dir = await writeFixtureExtension(extensionsDir, 'standup', {})
+            await runProcess('git', ['init', '--quiet', '--initial-branch=main'], { cwd: dir })
+            await runProcess('git', ['add', '.'], { cwd: dir })
+            await runProcess(
+                'git',
+                [
+                    '-c',
+                    'user.email=t@example.com',
+                    '-c',
+                    'user.name=T',
+                    'commit',
+                    '--quiet',
+                    '-m',
+                    'init',
+                ],
+                { cwd: dir },
+            )
+            const head = (
+                await runProcess('git', ['rev-parse', 'HEAD'], { cwd: dir })
+            ).stdout.trim()
+
+            await run(makeManager(), ['extension', 'list'])
+            const row = lines().find((line) => line.startsWith('standup'))
+            expect(row).toContain(head.slice(0, 8))
+            expect(row).toContain('git')
+        })
+
+        it('shows the pin, and the repository a clone came from', async () => {
             const dir = await writeFixtureExtension(extensionsDir, 'standup', {})
             await writeFakeGitRepo(dir, 'https://github.com/example/td-standup.git')
             await writeFixtureExtension(extensionsDir, 'goals', {
@@ -264,6 +293,14 @@ describe('registerExtensionGroup', () => {
                 '--raw',
             ])
             expect((await reported()).args).toEqual(['--json', '-q', '--accessible', '--', '--raw'])
+        })
+
+        it('forwards --help rather than answering it', async () => {
+            // The only way to reach the usage of an extension a built-in
+            // command is hiding, so commander must not take the flag first.
+            await writeFixtureExtension(extensionsDir, 'goals', {})
+            await run(makeManager(), ['extension', 'exec', 'goals', '--help'])
+            expect((await reported()).args).toEqual(['--help'])
         })
 
         it('runs an extension with no arguments at all', async () => {

--- a/src/lib/extensions/commands.test.ts
+++ b/src/lib/extensions/commands.test.ts
@@ -1,0 +1,296 @@
+import { mkdir, mkdtemp, readFile, rm, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { captureConsole, captureStream, createTestProgram } from '@doist/cli-core/testing'
+import type { Command } from 'commander'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { writeFakeGitRepo, writeFixtureExtension } from '../../test-support/extension-fixture.js'
+import { registerExtensionGroup } from './commands.js'
+import { createExtensionManager, type ExtensionManager } from './manager.js'
+
+describe('registerExtensionGroup', () => {
+    let root: string
+    let dataDir: string
+    let extensionsDir: string
+    let warnings: string[]
+    let out: ReturnType<typeof captureConsole>
+
+    function makeManager(
+        options: { reserved?: string[]; accessible?: boolean } = {},
+    ): ExtensionManager {
+        return createExtensionManager({
+            binName: 'td',
+            envPrefix: 'TD',
+            version: '5.3.1',
+            dataDir,
+            stateDir: join(root, 'state'),
+            configDir: join(root, 'config'),
+            hostPath: '/host/dist/index.js',
+            reservedNames: () => options.reserved ?? [],
+            officialSource: { host: 'github.com', owner: 'Doist' },
+            officialLabel: 'Todoist',
+            isAccessible: () => options.accessible ?? false,
+            warn: (message) => warnings.push(message),
+            log: () => undefined,
+        })
+    }
+
+    function makeProgram(manager: ExtensionManager): Command {
+        return createTestProgram((program) => {
+            registerExtensionGroup(program, manager)
+        })
+    }
+
+    /** Run the group the way the CLI would, argv included. */
+    async function run(manager: ExtensionManager, args: string[]): Promise<void> {
+        const argv = ['node', 'td', ...args]
+        vi.spyOn(process, 'argv', 'get').mockReturnValue(argv)
+        await makeProgram(manager).parseAsync(argv)
+    }
+
+    /** Everything written to stdout, as lines. */
+    function lines(): string[] {
+        return out.mock.calls.map((call) => String(call[0]))
+    }
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-commands-'))
+        dataDir = join(root, 'todoist-cli')
+        extensionsDir = join(dataDir, 'extensions')
+        warnings = []
+        await mkdir(extensionsDir, { recursive: true })
+        out = captureConsole('log')
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    describe('the group itself', () => {
+        it('registers under both `extension` and `ext`', () => {
+            const program = makeProgram(makeManager())
+            const group = program.commands.find((command) => command.name() === 'extension')
+            expect(group?.aliases()).toContain('ext')
+        })
+
+        it('puts the trust warning in its help', () => {
+            const manager = makeManager()
+            const program = makeProgram(manager)
+            const group = program.commands.find((command) => command.name() === 'extension')
+            const stdout = captureStream('stdout')
+            group?.outputHelp()
+            expect(stdout.mock.calls.join('')).toContain(manager.trustWarning)
+        })
+    })
+
+    describe('list', () => {
+        it('says nothing is installed, and how to change that', async () => {
+            await run(makeManager(), ['extension', 'list'])
+            expect(lines().join('\n')).toContain(
+                'No extensions installed. Run `td extension install <owner/repo>` to add one.',
+            )
+        })
+
+        it('prints `[]` for --json when nothing is installed', async () => {
+            await run(makeManager(), ['extension', 'list', '--json'])
+            expect(lines()).toEqual(['[]'])
+        })
+
+        it('lines the columns up under their headers', async () => {
+            await writeFixtureExtension(extensionsDir, 'goals', {
+                installedManifest: {
+                    owner: 'Doist',
+                    name: 'td-goals',
+                    host: 'github.com',
+                    tag: 'v0.3.0',
+                    pinned: false,
+                    asset: 'td-goals_v0.3.0_linux-x64',
+                    installedAt: '2026-09-07T10:12:00Z',
+                    description: 'Track quarterly goals',
+                },
+            })
+            await writeFixtureExtension(extensionsDir, 'standup', {})
+
+            await run(makeManager(), ['extension', 'list'])
+            const [header, ...rows] = lines()
+
+            expect(header).toBe('NAME     SOURCE          VERSION  KIND    OFFICIAL')
+            const goals = rows.find((row) => row.startsWith('goals'))
+            expect(goals).toBe('goals    Doist/td-goals  v0.3.0   binary  ✓ Todoist')
+            // A directory with neither a link, a clone, nor a manifest is a
+            // binary install that nothing is known about.
+            expect(rows.find((row) => row.startsWith('standup'))).toBe(
+                'standup  —               —        binary',
+            )
+        })
+
+        it('drops the tick in accessible mode but keeps the label', async () => {
+            await writeFixtureExtension(extensionsDir, 'goals', {
+                installedManifest: {
+                    owner: 'Doist',
+                    name: 'td-goals',
+                    host: 'github.com',
+                    tag: 'v0.3.0',
+                    pinned: false,
+                    asset: 'a',
+                    installedAt: '2026-09-07T10:12:00Z',
+                },
+            })
+
+            await run(makeManager({ accessible: true }), ['extension', 'list'])
+            const row = lines().find((line) => line.startsWith('goals'))
+            expect(row).toContain('Todoist')
+            expect(row).not.toContain('✓')
+        })
+
+        it('does not call a non-Doist host official', async () => {
+            const dir = await writeFixtureExtension(extensionsDir, 'goals', {})
+            await writeFakeGitRepo(dir, 'https://git.example.com/Doist/td-goals.git')
+
+            await run(makeManager(), ['extension', 'list', '--json'])
+            const [entry] = JSON.parse(lines().join(''))
+            expect(entry).toMatchObject({
+                owner: 'Doist',
+                host: 'git.example.com',
+                official: false,
+            })
+        })
+
+        it('notes an extension that cannot be run', async () => {
+            await writeFixtureExtension(extensionsDir, 'goals', { notExecutable: true })
+            await run(makeManager(), ['extension', 'list'])
+            expect(lines().join('\n')).toContain('not executable')
+        })
+
+        it('notes an extension a built-in command hides', async () => {
+            await writeFixtureExtension(extensionsDir, 'task', {})
+            await run(makeManager({ reserved: ['task'] }), ['extension', 'list'])
+            expect(lines().join('\n')).toContain('shadowed by built-in "task"')
+        })
+
+        it('notes a manifest this version cannot fully read', async () => {
+            await writeFixtureExtension(extensionsDir, 'goals', {
+                authoredManifest: { manifestVersion: 99, description: 'From the future' },
+            })
+            await run(makeManager(), ['extension', 'list'])
+            expect(lines().join('\n')).toContain('manifest needs a newer td')
+        })
+
+        it('shows the pin, and the short SHA for a clone', async () => {
+            const dir = await writeFixtureExtension(extensionsDir, 'standup', {})
+            await writeFakeGitRepo(dir, 'https://github.com/example/td-standup.git')
+            await writeFixtureExtension(extensionsDir, 'goals', {
+                installedManifest: {
+                    owner: 'Doist',
+                    name: 'td-goals',
+                    host: 'github.com',
+                    tag: 'v0.3.0',
+                    pinned: true,
+                    asset: 'a',
+                    installedAt: '2026-09-07T10:12:00Z',
+                },
+            })
+
+            await run(makeManager(), ['extension', 'list'])
+            const rendered = lines().join('\n')
+            expect(rendered).toContain('binary (pinned)')
+            expect(rendered).toContain('example/td-standup')
+        })
+
+        it('writes a path under the home directory the short way', async () => {
+            // `os.homedir()` follows $HOME on POSIX, so this needs no mock.
+            vi.stubEnv('HOME', root)
+            await mkdir(join(root, 'code'), { recursive: true })
+            await writeFixtureExtension(join(root, 'code'), 'scratch', {})
+            await symlink(join(root, 'code', 'td-scratch'), join(extensionsDir, 'td-scratch'))
+
+            await run(makeManager(), ['extension', 'list'])
+            expect(lines().find((line) => line.startsWith('scratch'))).toContain(
+                '~/code/td-scratch',
+            )
+            vi.unstubAllEnvs()
+        })
+
+        it('separates where the entry sits from where it points', async () => {
+            const target = join(root, 'code', 'td-scratch')
+            await mkdir(join(root, 'code'), { recursive: true })
+            await writeFixtureExtension(join(root, 'code'), 'scratch', {})
+            await symlink(target, join(extensionsDir, 'td-scratch'))
+
+            await run(makeManager(), ['extension', 'list', '--json'])
+            const [entry] = JSON.parse(lines().join(''))
+            expect(entry.path).toBe(join(extensionsDir, 'td-scratch'))
+            expect(entry.dir).toBe(target)
+            expect(entry.kind).toBe('local')
+        })
+
+        it('leaves absent fields out of the JSON rather than nulling them', async () => {
+            await writeFixtureExtension(extensionsDir, 'goals', {})
+            await run(makeManager(), ['extension', 'list', '--json'])
+            const [entry] = JSON.parse(lines().join(''))
+            expect(entry).not.toHaveProperty('description')
+            expect(entry).not.toHaveProperty('version')
+            expect(entry).toMatchObject({ name: 'goals', executable: true, shadowed: false })
+        })
+    })
+
+    describe('exec', () => {
+        const report = () => join(root, 'report.json')
+
+        async function reported(): Promise<{ args: string[]; env: Record<string, string> }> {
+            return JSON.parse(await readFile(report(), 'utf8'))
+        }
+
+        beforeEach(() => {
+            process.env.XX_REPORT = join(root, 'report.json')
+        })
+
+        afterEach(() => {
+            delete process.env.XX_REPORT
+        })
+
+        it('hands every argument to the extension untouched', async () => {
+            await writeFixtureExtension(extensionsDir, 'goals', {})
+            // `--accessible` and `-q` are td's own flags, and commander would
+            // eat them if the arguments came from it rather than from argv.
+            await run(makeManager(), [
+                'extension',
+                'exec',
+                'goals',
+                '--json',
+                '-q',
+                '--accessible',
+                '--',
+                '--raw',
+            ])
+            expect((await reported()).args).toEqual(['--json', '-q', '--accessible', '--', '--raw'])
+        })
+
+        it('runs an extension with no arguments at all', async () => {
+            await writeFixtureExtension(extensionsDir, 'goals', {})
+            await run(makeManager(), ['extension', 'exec', 'goals'])
+            expect((await reported()).args).toEqual([])
+        })
+
+        it('accepts the directory name and the owner-qualified form', async () => {
+            await writeFixtureExtension(extensionsDir, 'goals', {})
+            await run(makeManager(), ['extension', 'exec', 'td-goals'])
+            expect((await reported()).env.TD_EXTENSION_NAME).toBe('goals')
+        })
+
+        it('exits with the extension exit code', async () => {
+            await writeFixtureExtension(extensionsDir, 'goals', {})
+            const previous = process.exitCode
+            await run(makeManager(), ['extension', 'exec', 'goals', '--exit-code', '3'])
+            expect(process.exitCode).toBe(3)
+            process.exitCode = previous
+        })
+
+        it('reports an unknown name rather than failing to spawn it', async () => {
+            await expect(run(makeManager(), ['extension', 'exec', 'ghost'])).rejects.toMatchObject({
+                code: 'EXTENSION_NOT_FOUND',
+                hints: ['Run `td extension list` to see what is installed.'],
+            })
+        })
+    })
+})

--- a/src/lib/extensions/commands.ts
+++ b/src/lib/extensions/commands.ts
@@ -190,6 +190,9 @@ Examples:
         // so that `--help` describes the shape.
         .allowUnknownOption()
         .allowExcessArguments()
+        // `--help` included: an extension that ships its own usage can only be
+        // asked for it through here when a built-in command hides its name.
+        .helpOption(false)
         .action(async (name: string) => {
             // `require` first, so an unknown name is a clean error rather than
             // a failed spawn.

--- a/src/lib/extensions/commands.ts
+++ b/src/lib/extensions/commands.ts
@@ -1,0 +1,201 @@
+/**
+ * The `<bin> extension` command group.
+ *
+ * Registered against a `Command` the host owns, driven entirely by the manager
+ * it is handed. Like the rest of this directory it knows nothing about which
+ * CLI it is serving: colours come from `manager.theme`, accessible mode from
+ * `manager.isAccessible()`, and every string that names the binary is built
+ * from `manager.binName`.
+ *
+ * That means no chalk, nothing from the host's `lib/`, and `commander` as a
+ * type only — the host passes the program in.
+ */
+
+import { homedir } from 'node:os'
+import { formatJson, printEmpty } from '@doist/cli-core'
+import type { Command } from 'commander'
+import type { ExtensionManager } from './manager.js'
+import type { ExtensionListing } from './types.js'
+
+/** Neither column has a value worth showing, so say so once, the same way. */
+const NOTHING = '—'
+
+/**
+ * The arguments an extension is given, read back off the real argv.
+ *
+ * Commander cannot supply them: it consumes any root option it recognises
+ * before the action runs, so `exec goals --quiet` would reach the extension
+ * with `--quiet` already eaten. `passThroughOptions` is not an answer either —
+ * it requires `enablePositionalOptions` on the parent, which makes ordinary
+ * commands reject the global flags they accept today.
+ *
+ * The search starts after the subcommand token so that a value elsewhere on
+ * the line cannot be mistaken for the name.
+ */
+function argsAfter(marker: string, name: string): string[] {
+    const markerIndex = process.argv.indexOf(marker, 2)
+    if (markerIndex === -1) return []
+    const nameIndex = process.argv.indexOf(name, markerIndex + 1)
+    return nameIndex === -1 ? [] : process.argv.slice(nameIndex + 1)
+}
+
+/** `/home/alice/code/td-x` reads better as `~/code/td-x`, and fits the column. */
+function shorten(path: string): string {
+    const home = homedir()
+    return home && path.startsWith(`${home}/`) ? `~${path.slice(home.length)}` : path
+}
+
+/**
+ * The kind, plus whatever is worth knowing about this particular install.
+ * Everything lands in one column because each note is rare and none of them
+ * deserves a column of its own that is empty for almost every row.
+ */
+function describeKind(entry: ExtensionListing, binName: string): string {
+    const notes: string[] = []
+    if (entry.shadowed) notes.push(`shadowed by built-in "${entry.name}"`)
+    if (!entry.executable) notes.push('not executable')
+    if (entry.manifestFromNewerFormat) notes.push(`manifest needs a newer ${binName}`)
+
+    const pinned = entry.pinned ? ' (pinned)' : ''
+    const suffix = notes.length > 0 ? ` · ${notes.join(' · ')}` : ''
+    return `${entry.kind}${pinned}${suffix}`
+}
+
+/**
+ * An ownership label, not a signature. The tick carries the meaning, so
+ * accessible mode drops it and keeps the word.
+ */
+function describeOfficial(entry: ExtensionListing, manager: ExtensionManager): string {
+    if (!entry.official) return ''
+    return manager.isAccessible()
+        ? manager.officialLabel
+        : manager.theme.green(`✓ ${manager.officialLabel}`)
+}
+
+/**
+ * Pad every column to its widest cell, leaving the last one ragged so a long
+ * final value never drags trailing spaces across the terminal.
+ *
+ * Widths are measured on the text as given. Only the last column is ever
+ * coloured, so no escape sequence is ever counted as width.
+ */
+function alignRows(rows: string[][]): string[] {
+    const widths = rows[0].map((_, column) =>
+        Math.max(...rows.map((row) => row[column]?.length ?? 0)),
+    )
+    return rows.map((row) =>
+        row
+            .map((cell, column) => (column === row.length - 1 ? cell : cell.padEnd(widths[column])))
+            .join('  ')
+            .trimEnd(),
+    )
+}
+
+/** The fields `list --json` promises, with absent ones left out entirely. */
+function toJson(entry: ExtensionListing) {
+    return {
+        name: entry.name,
+        dirName: entry.dirName,
+        kind: entry.kind,
+        // Where the entry sits in the extensions directory, which is what
+        // `remove` acts on. For a local install `dir` is the link target, so
+        // the two differ.
+        path: entry.entryPath,
+        dir: entry.dir,
+        source: entry.source,
+        host: entry.host,
+        owner: entry.owner,
+        version: entry.version,
+        pinned: entry.pinned,
+        pinnedRef: entry.pinnedRef,
+        official: entry.official,
+        executable: entry.executable,
+        shadowed: entry.shadowed,
+        description: entry.description,
+        requires: entry.requires,
+        manifestFromNewerFormat: entry.manifestFromNewerFormat,
+    }
+}
+
+async function listExtensions(
+    manager: ExtensionManager,
+    options: { json?: boolean },
+): Promise<void> {
+    const entries = await manager.list()
+
+    if (options.json) {
+        console.log(formatJson(entries.map(toJson)))
+        return
+    }
+
+    if (entries.length === 0) {
+        printEmpty({
+            options,
+            message: `No extensions installed. Run \`${manager.binName} extension install <owner/repo>\` to add one.`,
+        })
+        return
+    }
+
+    const rows = [
+        ['NAME', 'SOURCE', 'VERSION', 'KIND', 'OFFICIAL'],
+        ...entries.map((entry) => [
+            entry.name,
+            entry.source ? shorten(entry.source) : NOTHING,
+            entry.version ?? NOTHING,
+            describeKind(entry, manager.binName),
+            describeOfficial(entry, manager),
+        ]),
+    ]
+
+    const [header, ...body] = alignRows(rows)
+    console.log(manager.theme.bold(header))
+    for (const line of body) console.log(line)
+}
+
+export function registerExtensionGroup(program: Command, manager: ExtensionManager): Command {
+    const { binName } = manager
+
+    const extension = program
+        .command('extension')
+        .alias('ext')
+        .description(`Manage ${binName} extensions`)
+        .addHelpText(
+            'after',
+            `
+An extension is an executable named \`${binName}-<name>\` that ${binName} runs as
+\`${binName} <name> …\`, passing everything after the name through untouched. It can
+be written in any language.
+
+${manager.trustWarning}
+
+Examples:
+  ${binName} extension install owner/${binName}-goals
+  ${binName} extension install .          # a local directory, for development
+  ${binName} extension list
+  ${binName} extension upgrade --all
+  ${binName} extension remove goals`,
+        )
+
+    extension
+        .command('list')
+        .description('List installed extensions')
+        .option('--json', 'Output as JSON')
+        .action((options) => listExtensions(manager, options))
+
+    extension
+        .command('exec <name> [args...]')
+        .description('Run an extension directly, bypassing the built-in commands')
+        // Whatever follows the name belongs to the extension. The arguments
+        // are taken from argv rather than from these declarations, which exist
+        // so that `--help` describes the shape.
+        .allowUnknownOption()
+        .allowExcessArguments()
+        .action(async (name: string) => {
+            // `require` first, so an unknown name is a clean error rather than
+            // a failed spawn.
+            const target = await manager.require(name)
+            process.exitCode = await manager.dispatch(target.name, argsAfter('exec', name))
+        })
+
+    return extension
+}

--- a/src/lib/extensions/dispatch.test.ts
+++ b/src/lib/extensions/dispatch.test.ts
@@ -275,7 +275,65 @@ describe('buildSpawnPlan on Windows', () => {
         const plan = await buildSpawnPlan(cmd, ['a', 'b'])
 
         expect(plan.command).toMatch(/cmd\.exe$/i)
-        expect(plan.args).toEqual(['/d', '/s', '/c', cmd, 'a', 'b'])
+        expect(plan.args).toEqual(['/d', '/s', '/c', `"${cmd}" "a" "b"`])
+        // The line is written for cmd.exe, so node must not quote it again.
+        expect(plan.verbatim).toBe(true)
+    })
+
+    it('quotes a batch argument that cmd.exe would otherwise read as a command', async () => {
+        const dir = await writeFixtureExtension(root, 'batch')
+        const cmd = join(dir, 'td-batch.cmd')
+        await writeFile(cmd, '@echo off\r\n')
+        await chmod(cmd, 0o755)
+        asWindows()
+
+        // Node quotes an argument only when it contains a space, so `&whoami`
+        // would reach cmd.exe bare and the `&` would start a second command.
+        const plan = await buildSpawnPlan(cmd, ['&whoami', 'a b'])
+
+        expect(plan.args[3]).toBe(`"${cmd}" "&whoami" "a b"`)
+    })
+
+    it('doubles an embedded quote so it cannot end the quoting', async () => {
+        const dir = await writeFixtureExtension(root, 'batch')
+        const cmd = join(dir, 'td-batch.cmd')
+        await writeFile(cmd, '@echo off\r\n')
+        await chmod(cmd, 0o755)
+        asWindows()
+
+        const plan = await buildSpawnPlan(cmd, ['say "hi"'])
+
+        expect(plan.args[3]).toBe(`"${cmd}" "say ""hi"""`)
+    })
+
+    it('refuses a batch argument that quoting cannot contain', async () => {
+        const dir = await writeFixtureExtension(root, 'batch')
+        const cmd = join(dir, 'td-batch.cmd')
+        await writeFile(cmd, '@echo off\r\n')
+        await chmod(cmd, 0o755)
+        asWindows()
+
+        // cmd.exe expands these from inside quotes, so there is no escaping
+        // that holds; refusing is the only honest answer.
+        for (const argument of ['%PATH%', 'a!b', 'one\ntwo']) {
+            await expect(buildSpawnPlan(cmd, [argument])).rejects.toMatchObject({
+                code: 'EXTENSION_NOT_EXECUTABLE',
+            })
+        }
+    })
+
+    it('leaves the other Windows paths taking arguments unchanged', async () => {
+        const dir = await writeFixtureExtension(root, 'compiled')
+        const exe = join(dir, 'td-compiled.exe')
+        await writeFile(exe, 'MZ fake binary')
+        await chmod(exe, 0o755)
+        asWindows()
+
+        // Only the batch path goes through cmd.exe, so only it needs quoting.
+        const plan = await buildSpawnPlan(exe, ['&whoami', '%PATH%'])
+
+        expect(plan.args).toEqual(['&whoami', '%PATH%'])
+        expect(plan.verbatim).toBeUndefined()
     })
 
     it('runs a shell script through sh, keeping arguments as positional parameters', async () => {

--- a/src/lib/extensions/dispatch.ts
+++ b/src/lib/extensions/dispatch.ts
@@ -14,7 +14,16 @@ import { CliError } from '@doist/cli-core'
 import { isExecutable } from './fs-utils.js'
 import type { DispatchOptions, Extension } from './types.js'
 
-export type SpawnPlan = { command: string; args: string[] }
+export type SpawnPlan = {
+    command: string
+    args: string[]
+    /**
+     * Hand `args` to the child exactly as written, without Node's own quoting.
+     * Only the Windows batch path sets it, where the quoting has to be done
+     * for `cmd.exe` rather than for a program's argv.
+     */
+    verbatim?: boolean
+}
 
 type ExecutableHead = {
     /** The shebang line, when there is one. */
@@ -76,6 +85,47 @@ function nodeShebangOptions(shebang: string): string[] | undefined {
  * the host already requires. Everything else runs directly on POSIX, and
  * through `sh` on Windows, where shebangs mean nothing.
  */
+/**
+ * Characters `cmd.exe` expands from inside a quoted string, so quoting is not
+ * enough to make them safe. `%` performs variable substitution, and `!` does
+ * too once delayed expansion is on, which a batch file can turn on for itself.
+ */
+const CMD_UNQUOTABLE = /[%!\r\n]/
+
+/**
+ * Build the single command line `cmd.exe` is given for a batch extension.
+ *
+ * This cannot go through Node's argument handling. Node quotes an argument
+ * only when it contains a space, so `&whoami` would arrive unquoted and
+ * `cmd.exe` would read the `&` as a command separator and run it. Quoting
+ * every argument here, and refusing the two characters quoting cannot contain,
+ * is what keeps an argument an argument.
+ *
+ * Following Rust's standard library, which refuses rather than pretends: there
+ * is no escape for `%` that holds in every context a batch file can create.
+ */
+function buildCmdLine(executablePath: string, args: string[]): string {
+    return [executablePath, ...args].map(quoteForCmd).join(' ')
+}
+
+function quoteForCmd(value: string): string {
+    if (CMD_UNQUOTABLE.test(value)) {
+        throw new CliError(
+            'EXTENSION_NOT_EXECUTABLE',
+            'An argument to a .cmd or .bat extension contains a character the Windows command interpreter would expand.',
+            {
+                hints: [
+                    'Remove any %, ! or newline from the argument.',
+                    'A .exe or a script with a node shebang takes its arguments unchanged.',
+                ],
+            },
+        )
+    }
+    // Backslashes are literal except when they precede the closing quote, where
+    // they would escape it, so those runs are doubled.
+    return `"${value.replace(/(\\*)$/, '$1$1').replace(/"/g, '""')}"`
+}
+
 export async function buildSpawnPlan(executablePath: string, args: string[]): Promise<SpawnPlan> {
     const onWindows = process.platform === 'win32'
     const head = await readExecutableHead(executablePath)
@@ -102,7 +152,8 @@ export async function buildSpawnPlan(executablePath: string, args: string[]): Pr
         // one, and spawning it directly fails on every supported Node version.
         return {
             command: process.env.ComSpec ?? 'cmd.exe',
-            args: ['/d', '/s', '/c', executablePath, ...args],
+            args: ['/d', '/s', '/c', buildCmdLine(executablePath, args)],
+            verbatim: true,
         }
     }
 
@@ -189,6 +240,7 @@ export async function dispatchExtension(
             cwd: process.cwd(),
             env,
             stdio: 'inherit',
+            windowsVerbatimArguments: plan.verbatim,
         })
 
         child.on('error', (error: NodeJS.ErrnoException) => {


### PR DESCRIPTION
Add `registerExtensionGroup`, which puts `extension` (alias `ext`) on a program the host owns, with `list` and `exec` to start with. Everything it needs comes from the manager it is handed — colours, accessible mode, the binary name, the trust warning — so it stays free of host imports and moves to cli-core with the rest of the directory.

`list` renders the five columns from the spec, folding the notes that apply to few installs (pinned, shadowed, not executable, a manifest from a newer format) into the kind column rather than giving each one a column that is empty for almost every row. `--json` reports where the entry sits as well as where it points, which differ for a local install.

`exec` reads its arguments from argv rather than from commander, which consumes any root option it recognises before the action runs. `passThroughOptions` would be the obvious fix and is not usable: it requires `enablePositionalOptions` on the parent, which makes ordinary commands reject global flags they accept today.

> **Trying it out:** nothing in this stack is usable on its own — `td extension` and extension dispatch only exist once every PR is applied. Check out `feat/ext-cmd-9-docs` (#539), the top of the stack, which carries the instructions.
