### PR TITLE
feat(extensions): install, upgrade and remove commands

### DIFF
--- a/src/lib/extensions/commands.test.ts
+++ b/src/lib/extensions/commands.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, symlink } from 'node:fs/promises'
+import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { captureConsole, captureStream, createTestProgram } from '@doist/cli-core/testing'
@@ -260,6 +260,176 @@ describe('registerExtensionGroup', () => {
             expect(entry).not.toHaveProperty('description')
             expect(entry).not.toHaveProperty('version')
             expect(entry).toMatchObject({ name: 'goals', executable: true, shadowed: false })
+        })
+    })
+
+    describe('install', () => {
+        /** A directory the user is developing in, outside the extensions dir. */
+        async function localSource(name: string): Promise<string> {
+            await mkdir(join(root, 'code'), { recursive: true })
+            return writeFixtureExtension(join(root, 'code'), name, {})
+        }
+
+        it('links a local directory and says where the link is', async () => {
+            const target = await localSource('scratch')
+            await run(makeManager(), ['extension', 'install', target])
+
+            const entry = join(extensionsDir, 'td-scratch')
+            expect((await lstat(entry)).isSymbolicLink()).toBe(true)
+            expect(lines().join('\n')).toContain(`Linked td-scratch from ${target} to ${entry}`)
+        })
+
+        it('does not print the trust warning for the user own directory', async () => {
+            await run(makeManager(), ['extension', 'install', await localSource('scratch')])
+            expect(warnings).toEqual([])
+        })
+
+        it('reports the install as JSON', async () => {
+            const target = await localSource('scratch')
+            await run(makeManager(), ['extension', 'install', target, '--json'])
+            expect(JSON.parse(lines().join(''))).toEqual({
+                name: 'scratch',
+                dirName: 'td-scratch',
+                kind: 'local',
+                source: target,
+                dir: target,
+            })
+        })
+
+        it('refuses a name that a built-in command already uses', async () => {
+            const target = await localSource('task')
+            await expect(
+                run(makeManager({ reserved: ['task'] }), ['extension', 'install', target]),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NAME_RESERVED' })
+            expect(await readdir(extensionsDir)).toEqual([])
+        })
+
+        it('links an extension that has not been built yet, with a warning', async () => {
+            await mkdir(join(root, 'code', 'td-compiled'), { recursive: true })
+            await run(makeManager(), ['extension', 'install', join(root, 'code', 'td-compiled')])
+
+            expect((await lstat(join(extensionsDir, 'td-compiled'))).isSymbolicLink()).toBe(true)
+            expect(warnings.join('\n')).toContain('has no executable named "td-compiled" yet')
+        })
+
+        it('refuses a directory that is not there', async () => {
+            await expect(
+                run(makeManager(), ['extension', 'install', join(root, 'code', 'td-missing')]),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NOT_INSTALLABLE' })
+        })
+    })
+
+    describe('upgrade', () => {
+        it('refuses names and --all together', async () => {
+            await expect(
+                run(makeManager(), ['extension', 'upgrade', 'goals', '--all']),
+            ).rejects.toMatchObject({ code: 'CONFLICTING_OPTIONS' })
+        })
+
+        it('shows its usage when given neither a name nor --all', async () => {
+            // Nothing is upgraded on a bare invocation, so nothing reaches the
+            // network by accident.
+            await expect(run(makeManager(), ['extension', 'upgrade'])).rejects.toThrow()
+        })
+
+        it('says so when there is nothing installed', async () => {
+            await run(makeManager(), ['extension', 'upgrade', '--all'])
+            expect(lines().join('\n')).toContain('No extensions installed.')
+        })
+
+        it('leaves a local install alone and says why', async () => {
+            await mkdir(join(root, 'code'), { recursive: true })
+            const target = await writeFixtureExtension(join(root, 'code'), 'scratch', {})
+            await symlink(target, join(extensionsDir, 'td-scratch'))
+
+            await run(makeManager(), ['extension', 'upgrade', '--all'])
+            const row = lines().find((line) => line.startsWith('scratch'))
+            expect(row).toContain('skipped')
+        })
+
+        it('reports a dry run without changing anything', async () => {
+            await mkdir(join(root, 'code'), { recursive: true })
+            const target = await writeFixtureExtension(join(root, 'code'), 'scratch', {})
+            await symlink(target, join(extensionsDir, 'td-scratch'))
+            const before = await readdir(extensionsDir)
+
+            await run(makeManager(), ['extension', 'upgrade', '--all', '--dry-run'])
+            const rendered = lines().join('\n')
+            expect(rendered).toContain('[dry-run] Would upgrade 0 extensions:')
+            expect(rendered).toContain('Run without --dry-run to execute.')
+            expect(await readdir(extensionsDir)).toEqual(before)
+        })
+
+        it('names an extension that is not installed', async () => {
+            await expect(
+                run(makeManager(), ['extension', 'upgrade', 'ghost']),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NOT_FOUND' })
+        })
+
+        it('reports results as JSON', async () => {
+            await mkdir(join(root, 'code'), { recursive: true })
+            const target = await writeFixtureExtension(join(root, 'code'), 'scratch', {})
+            await symlink(target, join(extensionsDir, 'td-scratch'))
+
+            await run(makeManager(), ['extension', 'upgrade', '--all', '--json'])
+            expect(JSON.parse(lines().join(''))).toEqual([
+                { name: 'scratch', outcome: 'skipped', detail: expect.any(String) },
+            ])
+        })
+    })
+
+    describe('remove', () => {
+        it('takes the link and leaves the user directory alone', async () => {
+            await mkdir(join(root, 'code'), { recursive: true })
+            const target = await writeFixtureExtension(join(root, 'code'), 'scratch', {})
+            await symlink(target, join(extensionsDir, 'td-scratch'))
+
+            await run(makeManager(), ['extension', 'remove', 'scratch'])
+
+            expect(await readdir(extensionsDir)).toEqual([])
+            expect(await readdir(target)).toContain('td-scratch')
+            expect(lines().join('\n')).toContain('Its directory was left alone.')
+        })
+
+        it('removes a binary install outright', async () => {
+            await writeFixtureExtension(extensionsDir, 'goals', {})
+            await run(makeManager(), ['extension', 'remove', 'goals'])
+            expect(await readdir(extensionsDir)).toEqual([])
+            expect(lines().join('\n')).toContain('Removed goals from')
+        })
+
+        it('refuses a clone whose state it cannot read', async () => {
+            const dir = await writeFixtureExtension(extensionsDir, 'standup', {})
+            await writeFakeGitRepo(dir, 'https://github.com/example/td-standup.git')
+
+            await expect(
+                run(makeManager(), ['extension', 'remove', 'standup']),
+            ).rejects.toMatchObject({ code: 'EXTENSION_DIRTY' })
+            expect(await readdir(extensionsDir)).toEqual(['td-standup'])
+        })
+
+        it('removes it anyway with --force', async () => {
+            const dir = await writeFixtureExtension(extensionsDir, 'standup', {})
+            await writeFakeGitRepo(dir, 'https://github.com/example/td-standup.git')
+
+            await run(makeManager(), ['extension', 'remove', 'standup', '--force'])
+            expect(await readdir(extensionsDir)).toEqual([])
+        })
+
+        it('reports the removal as JSON', async () => {
+            await writeFixtureExtension(extensionsDir, 'goals', {})
+            await run(makeManager(), ['extension', 'remove', 'goals', '--json'])
+            expect(JSON.parse(lines().join(''))).toMatchObject({
+                name: 'goals',
+                kind: 'binary',
+                removed: 'directory',
+            })
+        })
+
+        it('names an extension that is not installed', async () => {
+            await expect(
+                run(makeManager(), ['extension', 'remove', 'ghost']),
+            ).rejects.toMatchObject({ code: 'EXTENSION_NOT_FOUND' })
         })
     })
 

--- a/src/lib/extensions/commands.ts
+++ b/src/lib/extensions/commands.ts
@@ -12,10 +12,11 @@
  */
 
 import { homedir } from 'node:os'
-import { formatJson, printEmpty } from '@doist/cli-core'
+import { join } from 'node:path'
+import { CliError, formatJson, printEmpty } from '@doist/cli-core'
 import type { Command } from 'commander'
 import type { ExtensionManager } from './manager.js'
-import type { ExtensionListing } from './types.js'
+import type { ExtensionListing, RemoveResult, UpgradeResult } from './types.js'
 
 /** Neither column has a value worth showing, so say so once, the same way. */
 const NOTHING = '—'
@@ -152,6 +153,113 @@ async function listExtensions(
     for (const line of body) console.log(line)
 }
 
+/** `1 extension`, `3 extensions`. */
+function count(n: number, noun: string): string {
+    return `${n} ${noun}${n === 1 ? '' : 's'}`
+}
+
+async function installExtension(
+    manager: ExtensionManager,
+    source: string,
+    options: { pin?: string; force?: boolean; json?: boolean },
+): Promise<void> {
+    const result = await manager.install(source, { pin: options.pin, force: options.force })
+
+    if (options.json) {
+        console.log(formatJson(result))
+        return
+    }
+
+    // A local install is a link to a directory the user already had, so say
+    // where the link is rather than repeating the directory they gave.
+    const destination = shorten(
+        result.kind === 'local' ? join(manager.extensionsDir, result.dirName) : result.dir,
+    )
+    const version = result.version ? ` (${result.version})` : ''
+    const verb = result.kind === 'local' ? 'Linked' : 'Installed'
+    console.log(
+        `${verb} ${result.dirName} from ${shorten(result.source)}${version} to ${destination}`,
+    )
+}
+
+const OUTCOME_LABELS: Record<UpgradeResult['outcome'], string> = {
+    upgraded: 'upgraded',
+    'up-to-date': 'up to date',
+    skipped: 'skipped',
+    'would-upgrade': 'would upgrade',
+}
+
+/** What changed, or why nothing did. */
+function describeOutcome(result: UpgradeResult): string {
+    if (result.from && result.to) return `${result.from} → ${result.to}`
+    return result.detail ?? ''
+}
+
+async function upgradeExtensions(
+    manager: ExtensionManager,
+    names: string[],
+    options: { all?: boolean; force?: boolean; dryRun?: boolean; json?: boolean },
+): Promise<void> {
+    if (options.all && names.length > 0) {
+        throw new CliError(
+            'CONFLICTING_OPTIONS',
+            'Name the extensions to upgrade, or pass --all, but not both.',
+        )
+    }
+
+    const upgradeOptions = { force: options.force, dryRun: options.dryRun }
+    const results = options.all
+        ? await manager.upgradeAll(upgradeOptions)
+        : await manager.upgrade(names, upgradeOptions)
+
+    if (options.json) {
+        console.log(formatJson(results))
+        return
+    }
+
+    if (results.length === 0) {
+        console.log('No extensions installed.')
+        return
+    }
+
+    if (options.dryRun) {
+        const changing = results.filter((result) => result.outcome === 'would-upgrade').length
+        console.log(
+            manager.theme.yellow(`[dry-run] Would upgrade ${count(changing, 'extension')}:`),
+        )
+    }
+
+    const indent = options.dryRun ? '  ' : ''
+    for (const line of alignRows(
+        results.map((result) => [
+            result.name,
+            OUTCOME_LABELS[result.outcome],
+            describeOutcome(result),
+        ]),
+    )) {
+        console.log(`${indent}${line}`)
+    }
+
+    if (options.dryRun) console.log(manager.theme.dim('Run without --dry-run to execute.'))
+}
+
+/** Removing a local install takes the link and leaves the user's own copy. */
+function describeRemoval(result: RemoveResult, manager: ExtensionManager): string {
+    const path = shorten(join(manager.extensionsDir, `${manager.binName}-${result.name}`))
+    return result.removed === 'link'
+        ? `Removed the link for ${result.name} at ${path}. Its directory was left alone.`
+        : `Removed ${result.name} from ${path}`
+}
+
+async function removeExtension(
+    manager: ExtensionManager,
+    name: string,
+    options: { force?: boolean; json?: boolean },
+): Promise<void> {
+    const result = await manager.remove(name, { force: options.force })
+    console.log(options.json ? formatJson(result) : describeRemoval(result, manager))
+}
+
 export function registerExtensionGroup(program: Command, manager: ExtensionManager): Command {
     const { binName } = manager
 
@@ -181,6 +289,36 @@ Examples:
         .description('List installed extensions')
         .option('--json', 'Output as JSON')
         .action((options) => listExtensions(manager, options))
+
+    extension
+        .command('install <source>')
+        .description('Install an extension from a repository or a local directory')
+        .option('--pin <ref>', 'Install and hold at a release tag or git ref')
+        .option('--force', 'Replace an extension that is already installed')
+        .option('--json', 'Output as JSON')
+        .action((source, options) => installExtension(manager, source, options))
+
+    const upgradeCmd = extension
+        .command('upgrade [names...]')
+        .description('Upgrade installed extensions')
+        .option('--all', 'Upgrade every installed extension')
+        .option('--force', 'Upgrade past a pin, and reset a clone that has diverged')
+        .option('--dry-run', 'Report what would change without changing it')
+        .option('--json', 'Output as JSON')
+        .action((names: string[], options) => {
+            if (names.length === 0 && !options.all) {
+                upgradeCmd.help()
+                return
+            }
+            return upgradeExtensions(manager, names, options)
+        })
+
+    extension
+        .command('remove <name>')
+        .description('Remove an installed extension')
+        .option('--force', 'Remove a clone that has uncommitted changes')
+        .option('--json', 'Output as JSON')
+        .action((name, options) => removeExtension(manager, name, options))
 
     extension
         .command('exec <name> [args...]')

--- a/src/lib/extensions/git.ts
+++ b/src/lib/extensions/git.ts
@@ -19,6 +19,16 @@ export function redactUrl(url: string): string {
 }
 
 /**
+ * Git's own message for a failure, safe to carry into a result that will be
+ * printed. A remote URL can hold `user:token@` credentials and git echoes the
+ * URL back in several of its errors, so these go through the same redaction
+ * that `clone` and `checkout` already apply to theirs.
+ */
+function gitError(result: RunResult): string {
+    return outputHints(result).map(redactUrl).join(' ')
+}
+
+/**
  * Refuse an argument that git would read as an option.
  *
  * Repository URLs and refs arrive from manifests and from the command line. A
@@ -94,7 +104,7 @@ export async function pull(dir: string): Promise<PullResult> {
     const result = await run('git', ['pull', '--quiet', '--ff-only'], { cwd: dir })
     requireGit(result)
     if (result.code !== 0) {
-        return { changed: false, from, error: outputHints(result).join(' ') }
+        return { changed: false, from, error: gitError(result) }
     }
     const to = await headSha(dir)
     return { changed: from !== to, from, to }
@@ -115,7 +125,7 @@ export async function resetToRemote(dir: string): Promise<PullResult> {
     const fetched = await run('git', ['fetch', '--quiet', 'origin'], { cwd: dir })
     requireGit(fetched)
     if (fetched.code !== 0) {
-        return { changed: false, from, error: outputHints(fetched).join(' ') }
+        return { changed: false, from, error: gitError(fetched) }
     }
 
     const target = await remoteHeadSha(dir)
@@ -125,7 +135,7 @@ export async function resetToRemote(dir: string): Promise<PullResult> {
 
     const reset = await run('git', ['reset', '--quiet', '--hard', target], { cwd: dir })
     if (reset.code !== 0) {
-        return { changed: false, from, error: outputHints(reset).join(' ') }
+        return { changed: false, from, error: gitError(reset) }
     }
 
     // Ignored files are left alone: they are build output and caches, not

--- a/src/lib/extensions/run.test.ts
+++ b/src/lib/extensions/run.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { outputHints, sanitizeOutput } from './run.js'
+
+// Built rather than written out, so the test file itself stays printable.
+const ESC = String.fromCharCode(0x1b)
+const BEL = String.fromCharCode(0x07)
+const CARRIAGE_RETURN = String.fromCharCode(0x0d)
+const C1_CSI = String.fromCharCode(0x9b)
+
+function result(stderr: string, stdout = '') {
+    return { code: 1, stdout, stderr, missing: false }
+}
+
+describe('sanitizeOutput', () => {
+    it('removes escape sequences a terminal would act on rather than show', () => {
+        // A remote controls this text, and the terminal would obey it: clear
+        // the screen, then print something of its own choosing.
+        expect(sanitizeOutput(`${ESC}[2Jfatal: nope`)).toBe('[2Jfatal: nope')
+        expect(sanitizeOutput(`over${CARRIAGE_RETURN}write`)).toBe('overwrite')
+        expect(sanitizeOutput(`ring${BEL}`)).toBe('ring')
+    })
+
+    it('removes the C1 range, which is a second way to write the same sequences', () => {
+        expect(sanitizeOutput(`a${C1_CSI}2Kb`)).toBe('a2Kb')
+    })
+
+    it('keeps tabs and newlines, which carry the shape of the output', () => {
+        expect(sanitizeOutput('one\ttwo\nthree')).toBe('one\ttwo\nthree')
+    })
+
+    it('leaves ordinary text alone', () => {
+        expect(sanitizeOutput('fatal: repository not found')).toBe('fatal: repository not found')
+    })
+})
+
+describe('outputHints', () => {
+    it('takes the last lines of both streams', () => {
+        expect(outputHints(result('one\ntwo\nthree\nfour\nfive'))).toEqual([
+            'two',
+            'three',
+            'four',
+            'five',
+        ])
+    })
+
+    it('sanitises what it returns, since these are printed to a terminal', () => {
+        expect(outputHints(result(`${ESC}[31mfatal: nope${ESC}[0m`))).toEqual([
+            '[31mfatal: nope[0m',
+        ])
+    })
+
+    it('drops blank lines and trims what is left', () => {
+        expect(outputHints(result('  spaced  \n\n\n'))).toEqual(['spaced'])
+    })
+
+    it('honours the limit', () => {
+        expect(outputHints(result('a\nb\nc'), 2)).toEqual(['b', 'c'])
+    })
+})

--- a/src/lib/extensions/run.ts
+++ b/src/lib/extensions/run.ts
@@ -78,9 +78,27 @@ export async function run(
     })
 }
 
+/**
+ * Control characters, other than tab and newline: the C0 and C1 ranges and
+ * delete.
+ *
+ * These strings are the output of a program reached over the network — a git
+ * remote's error text arrives verbatim — and they are printed to a terminal,
+ * which acts on escape sequences rather than showing them. A hostile remote
+ * could otherwise move the cursor, recolour the screen, or overwrite the lines
+ * around its own message.
+ */
+// oxlint-disable-next-line no-control-regex
+const CONTROL_CHARACTERS = /[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/g
+
+/** Make a program's output safe to print. */
+export function sanitizeOutput(text: string): string {
+    return text.replace(CONTROL_CHARACTERS, '')
+}
+
 /** The last few lines of a failed command's output, for use as error hints. */
 export function outputHints(result: RunResult, limit = 4): string[] {
-    return `${result.stderr}\n${result.stdout}`
+    return sanitizeOutput(`${result.stderr}\n${result.stdout}`)
         .split('\n')
         .map((line) => line.trim())
         .filter(Boolean)


### PR DESCRIPTION
Complete the management surface. `install` reports where the extension landed, saying "Linked" for a local directory, since that install is a symlink to a working copy rather than a copy of anything. The trust warning is left to the manager, which prints it before any step that can run code from the repository — printing it here as well would double it, and a local install does not warrant it at all.

`upgrade` shows one row per extension with what changed or why nothing did, wrapped in the standard dry-run block when previewing. Naming extensions and passing `--all` together is a usage error rather than a silent preference for one; passing neither shows the usage, so a bare invocation never reaches the network.

`remove` says plainly that a local install's own directory was left alone, which is the part a user most needs to be sure of.

> **Trying it out:** nothing in this stack is usable on its own — `td extension` and extension dispatch only exist once every PR is applied. Check out `feat/ext-cmd-9-docs` (#539), the top of the stack, which carries the instructions.
