### PR TITLE
feat(extensions): pass-through commands and the unknown-command hint

### DIFF
--- a/src/lib/extensions/commands.test.ts
+++ b/src/lib/extensions/commands.test.ts
@@ -5,7 +5,12 @@ import { captureConsole, captureStream, createTestProgram } from '@doist/cli-cor
 import type { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { writeFakeGitRepo, writeFixtureExtension } from '../../test-support/extension-fixture.js'
-import { registerExtensionGroup } from './commands.js'
+import {
+    type ExtensionCommands,
+    registerExtensionCommands,
+    registerExtensionGroup,
+    registerExtensionPassThrough,
+} from './commands.js'
 import { createExtensionManager, type ExtensionManager } from './manager.js'
 import { run as runProcess } from './run.js'
 
@@ -499,5 +504,158 @@ describe('registerExtensionGroup', () => {
                 hints: ['Run `td extension list` to see what is installed.'],
             })
         })
+    })
+})
+
+describe('registerExtensionPassThrough', () => {
+    let root: string
+    let extensionsDir: string
+    let manager: ExtensionManager
+
+    function makeManager(reserved: string[] = []): ExtensionManager {
+        return createExtensionManager({
+            binName: 'td',
+            envPrefix: 'TD',
+            version: '5.3.1',
+            dataDir: join(root, 'todoist-cli'),
+            stateDir: join(root, 'state'),
+            configDir: join(root, 'config'),
+            hostPath: '/host/dist/index.js',
+            reservedNames: () => reserved,
+            officialSource: { host: 'github.com', owner: 'Doist' },
+            officialLabel: 'Todoist',
+            warn: () => undefined,
+            log: () => undefined,
+        })
+    }
+
+    /** A program shaped like the host: built-ins registered, extensions after. */
+    async function hostProgram(): Promise<{ program: Command; extensions: ExtensionCommands }> {
+        const program = createTestProgram((p) => {
+            p.command('task').description('Manage tasks')
+            p.command('accounts').description('Manage stored accounts').alias('users')
+        })
+        const extensions = await registerExtensionPassThrough(program, manager)
+        return { program, extensions }
+    }
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-passthrough-'))
+        extensionsDir = join(root, 'todoist-cli', 'extensions')
+        await mkdir(extensionsDir, { recursive: true })
+        manager = makeManager()
+        // The group is not registered here, but a stray log would still be noise.
+        captureConsole('log')
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('registers nothing when nothing is installed', async () => {
+        const { extensions } = await hostProgram()
+        expect(extensions.names.size).toBe(0)
+    })
+
+    it('lists extensions under their own help heading', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            authoredManifest: { description: 'Track quarterly goals' },
+        })
+        await writeFixtureExtension(extensionsDir, 'standup', {})
+
+        const { program } = await hostProgram()
+        const help = program.helpInformation()
+
+        expect(help).toContain('Extensions:')
+        expect(help).toMatch(/goals\s+Track quarterly goals/)
+        // No manifest, so the name is all there is to say.
+        expect(help).toMatch(/standup\s+Extension standup/)
+    })
+
+    it('leaves a built-in command in place and does not register over it', async () => {
+        await writeFixtureExtension(extensionsDir, 'task', {})
+        const { program, extensions } = await hostProgram()
+
+        expect(extensions.names.has('task')).toBe(false)
+        expect(program.commands.filter((command) => command.name() === 'task')).toHaveLength(1)
+        expect(program.commands.find((command) => command.name() === 'task')?.description()).toBe(
+            'Manage tasks',
+        )
+    })
+
+    it('does not register over a built-in alias either', async () => {
+        await writeFixtureExtension(extensionsDir, 'users', {})
+        const { extensions } = await hostProgram()
+        expect(extensions.names.has('users')).toBe(false)
+    })
+
+    it('reports the names it registered', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {})
+        await writeFixtureExtension(extensionsDir, 'standup', {})
+        const { extensions } = await hostProgram()
+        expect([...extensions.names].sort()).toEqual(['goals', 'standup'])
+    })
+
+    it('runs an extension, passing everything after the name through', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {})
+        process.env.XX_REPORT = join(root, 'report.json')
+        const argv = ['node', 'td', 'goals', '--help', 'list', '--json']
+        vi.spyOn(process, 'argv', 'get').mockReturnValue(argv)
+
+        const { program } = await hostProgram()
+        const previous = process.exitCode
+        await program.parseAsync(argv)
+
+        const report = JSON.parse(await readFile(join(root, 'report.json'), 'utf8'))
+        expect(report.args).toEqual(['--help', 'list', '--json'])
+        expect(report.env.TD_EXTENSION_NAME).toBe('goals')
+        process.exitCode = previous
+        delete process.env.XX_REPORT
+    })
+
+    describe('the unknown-command hint', () => {
+        /** Commander writes this itself and exits, so read the stream. */
+        async function unknownCommandOutput(): Promise<string> {
+            const stderr = captureStream('stderr')
+            const { program } = await hostProgram()
+            await program.parseAsync(['node', 'td', 'nope']).catch(() => undefined)
+            return stderr.mock.calls.map((call) => String(call[0])).join('')
+        }
+
+        it('offers the feature when there are no extensions', async () => {
+            expect(await unknownCommandOutput()).toContain(
+                'Run `td extension install <owner/repo>` to add commands from extensions.',
+            )
+        })
+
+        it('keeps commander own message', async () => {
+            expect(await unknownCommandOutput()).toContain("error: unknown command 'nope'")
+        })
+
+        it('stays quiet for someone who already has an extension', async () => {
+            await writeFixtureExtension(extensionsDir, 'goals', {})
+            expect(await unknownCommandOutput()).not.toContain('extension install')
+        })
+
+        it('does not attach itself to other usage errors', async () => {
+            const stderr = captureStream('stderr')
+            const { program } = await hostProgram()
+            program.command('doctor').requiredOption('--out <path>')
+            await program.parseAsync(['node', 'td', 'doctor']).catch(() => undefined)
+            expect(stderr.mock.calls.map((call) => String(call[0])).join('')).not.toContain(
+                'extension install',
+            )
+        })
+    })
+
+    it('registers the group and the pass-through commands together', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {})
+        const program = createTestProgram(() => undefined)
+        const extensions = await registerExtensionCommands(program, manager)
+
+        expect(program.commands.map((command) => command.name())).toEqual(
+            expect.arrayContaining(['extension', 'goals']),
+        )
+        expect(extensions.names.has('goals')).toBe(true)
     })
 })

--- a/src/lib/extensions/commands.test.ts
+++ b/src/lib/extensions/commands.test.ts
@@ -10,6 +10,7 @@ import {
     registerExtensionCommands,
     registerExtensionGroup,
     registerExtensionPassThrough,
+    UNKNOWN_COMMAND_PREFIX,
 } from './commands.js'
 import { createExtensionManager, type ExtensionManager } from './manager.js'
 import { run as runProcess } from './run.js'
@@ -630,6 +631,19 @@ describe('registerExtensionPassThrough', () => {
 
         it('keeps commander own message', async () => {
             expect(await unknownCommandOutput()).toContain("error: unknown command 'nope'")
+        })
+
+        it('keys off wording commander still uses', async () => {
+            // Without this, a reworded commander message would drop the hint
+            // silently rather than failing here.
+            const program = createTestProgram(() => undefined)
+            program.command('task')
+            const stderr = captureStream('stderr')
+            await program.parseAsync(['node', 'td', 'nope']).catch(() => undefined)
+
+            expect(stderr.mock.calls.map((call) => String(call[0])).join('')).toContain(
+                UNKNOWN_COMMAND_PREFIX,
+            )
         })
 
         it('stays quiet for someone who already has an extension', async () => {

--- a/src/lib/extensions/commands.ts
+++ b/src/lib/extensions/commands.ts
@@ -351,6 +351,17 @@ export type ExtensionCommands = {
 }
 
 /**
+ * How commander opens the message it writes for an unknown command.
+ *
+ * Matching on the rendered text is not ideal — the error code would be
+ * steadier — but `outputError` is handed the finished string and nothing else,
+ * and it is the only hook that runs before commander exits. Naming the prefix
+ * at least puts it somewhere a commander upgrade can be checked against, and
+ * the tests pin it.
+ */
+export const UNKNOWN_COMMAND_PREFIX = 'error: unknown command'
+
+/**
  * Point at the feature from the one place someone will be looking when they
  * have mistyped a command, and only when they have no extensions — anyone who
  * has installed one does not need telling.
@@ -367,7 +378,7 @@ function addInstallHint(program: Command, binName: string): void {
     program.configureOutput({
         outputError(message, write) {
             base(message, write)
-            if (message.startsWith('error: unknown command')) {
+            if (message.startsWith(UNKNOWN_COMMAND_PREFIX)) {
                 write(
                     `\nRun \`${binName} extension install <owner/repo>\` to add commands from extensions.\n`,
                 )

--- a/src/lib/extensions/commands.ts
+++ b/src/lib/extensions/commands.ts
@@ -16,7 +16,7 @@ import { join } from 'node:path'
 import { CliError, formatJson, printEmpty } from '@doist/cli-core'
 import type { Command } from 'commander'
 import type { ExtensionManager } from './manager.js'
-import type { ExtensionListing, RemoveResult, UpgradeResult } from './types.js'
+import type { DispatchOptions, ExtensionListing, RemoveResult, UpgradeResult } from './types.js'
 
 /** Neither column has a value worth showing, so say so once, the same way. */
 const NOTHING = '—'
@@ -30,13 +30,14 @@ const NOTHING = '—'
  * it requires `enablePositionalOptions` on the parent, which makes ordinary
  * commands reject the global flags they accept today.
  *
- * The search starts after the subcommand token so that a value elsewhere on
- * the line cannot be mistaken for the name.
+ * `marker` is the subcommand the name follows, so that a value elsewhere on
+ * the line cannot be mistaken for it. An extension invoked directly has no
+ * marker: its name is the first thing on the line that is not a global flag.
  */
-function argsAfter(marker: string, name: string): string[] {
-    const markerIndex = process.argv.indexOf(marker, 2)
-    if (markerIndex === -1) return []
-    const nameIndex = process.argv.indexOf(name, markerIndex + 1)
+function argsAfter(name: string, marker?: string): string[] {
+    const start = marker ? process.argv.indexOf(marker, 2) : 1
+    if (start === -1) return []
+    const nameIndex = process.argv.indexOf(name, start + 1)
     return nameIndex === -1 ? [] : process.argv.slice(nameIndex + 1)
 }
 
@@ -335,8 +336,103 @@ Examples:
             // `require` first, so an unknown name is a clean error rather than
             // a failed spawn.
             const target = await manager.require(name)
-            process.exitCode = await manager.dispatch(target.name, argsAfter('exec', name))
+            process.exitCode = await manager.dispatch(target.name, argsAfter(name, 'exec'))
         })
 
     return extension
+}
+
+/** What a host needs to route an invocation to an extension. */
+export type ExtensionCommands = {
+    /** The names registered as commands, for the host to match against argv. */
+    readonly names: ReadonlySet<string>
+    /** Run one and resolve to the exit code the host should exit with. */
+    dispatch(name: string, args: string[], options?: DispatchOptions): Promise<number>
+}
+
+/**
+ * Point at the feature from the one place someone will be looking when they
+ * have mistyped a command, and only when they have no extensions — anyone who
+ * has installed one does not need telling.
+ *
+ * Commander writes this error and exits without the promise from `parseAsync`
+ * ever rejecting, so there is nothing to catch. `outputError` runs first and
+ * is the one place to add to the message while leaving commander's own
+ * wording, and its "did you mean" suggestion, exactly as they are.
+ */
+function addInstallHint(program: Command, binName: string): void {
+    const base = program.configureOutput().outputError
+    if (!base) return
+
+    program.configureOutput({
+        outputError(message, write) {
+            base(message, write)
+            if (message.startsWith('error: unknown command')) {
+                write(
+                    `\nRun \`${binName} extension install <owner/repo>\` to add commands from extensions.\n`,
+                )
+            }
+        },
+    })
+}
+
+/**
+ * Register one command per installed extension, so that `--help` lists them
+ * and name completion works with no special cases.
+ *
+ * A name a built-in already uses is skipped rather than replacing it; `list`
+ * reports it as shadowed, and `exec` still runs it.
+ *
+ * Note what is deliberately absent: `passThroughOptions`, which looks like
+ * exactly the right tool. It cannot be used, because commander requires
+ * `enablePositionalOptions` on the parent for it, and that makes every
+ * ordinary command reject the global flags it accepts today. The arguments
+ * are read from argv instead.
+ */
+export async function registerExtensionPassThrough(
+    program: Command,
+    manager: ExtensionManager,
+): Promise<ExtensionCommands> {
+    const extensions = await manager.discover()
+
+    // Snapshotted before anything is added, so two extensions cannot be
+    // measured against each other.
+    const taken = new Set(
+        program.commands.flatMap((command) => [command.name(), ...command.aliases()]),
+    )
+    const names = new Set<string>()
+
+    for (const extension of extensions) {
+        if (taken.has(extension.name)) continue
+        names.add(extension.name)
+
+        program
+            .command(extension.name)
+            .description(extension.description ?? `Extension ${extension.name}`)
+            .helpGroup('Extensions:')
+            // Nothing after the name is commander's to read, including
+            // `--help`, which the extension answers itself.
+            .allowUnknownOption()
+            .allowExcessArguments()
+            .helpOption(false)
+            .action(async () => {
+                process.exitCode = await manager.dispatch(extension.name, argsAfter(extension.name))
+            })
+    }
+
+    if (extensions.length === 0) addInstallHint(program, manager.binName)
+
+    return {
+        names,
+        dispatch: (name, args, options) => manager.dispatch(name, args, options),
+    }
+}
+
+/** The whole feature in one call, for a host that wants it that way. */
+export async function registerExtensionCommands(
+    program: Command,
+    manager: ExtensionManager,
+): Promise<ExtensionCommands> {
+    registerExtensionGroup(program, manager)
+    return registerExtensionPassThrough(program, manager)
 }


### PR DESCRIPTION
Register one command per installed extension, so `--help` lists them under their own heading and name completion works with no special cases. A name a built-in already uses is skipped rather than replacing it; `list` reports it as shadowed and `exec` still runs it.

`passThroughOptions` is what this looks like it should use, and cannot: commander requires `enablePositionalOptions` on the parent for it, which makes every ordinary command reject the global flags it accepts today. The arguments are read from argv instead, which is stronger anyway — the host can short-circuit before commander parses at all.

The unknown-command hint is added at `outputError`, because commander writes that error and exits without the parse promise ever rejecting. Going through `outputError` keeps commander's own wording and its "did you mean" suggestion intact. It appears only for someone with no extensions installed, who is the only person it can tell anything.

> **Trying it out:** nothing in this stack is usable on its own — `td extension` and extension dispatch only exist once every PR is applied. Check out `feat/ext-cmd-9-docs` (#539), the top of the stack, which carries the instructions.
