### PR TITLE
feat(auth): read TD_USER as the fallback for --user

### DIFF
--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -509,6 +509,27 @@ describe('auth command', () => {
                 })
             })
 
+            it('falls back to getApi() when TD_USER is set, as it does for --user', async () => {
+                // Without this, status would report the default account while
+                // every other command acted as the one TD_USER names.
+                const overrideUser = { id: '99999', email: 'other@example.com', fullName: 'Other' }
+                const liveApi = createMockApi({
+                    getUser: vi.fn().mockResolvedValue(overrideUser),
+                })
+                mockGetApi.mockResolvedValue(liveApi)
+
+                vi.stubEnv('TD_USER', overrideUser.email)
+                try {
+                    await programWithSnapshot().parseAsync(['node', 'td', 'auth', 'status'])
+                } finally {
+                    vi.unstubAllEnvs()
+                }
+
+                expect(mockCreateApiForToken).not.toHaveBeenCalled()
+                expect(mockGetApi).toHaveBeenCalled()
+                expect(consoleSpy).toHaveBeenCalledWith(`  Email: ${overrideUser.email}`)
+            })
+
             it('falls back to getApi() when --user is set so the snapshot default is overridden', async () => {
                 // Stash --user in process.argv so global-args picks it up.
                 const overrideUser = { id: '99999', email: 'other@example.com', fullName: 'Other' }

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -7,6 +7,7 @@ import {
     toTodoistAccount,
     type TodoistAccount,
     type TodoistTokenStore,
+    USER_ENV_VAR,
 } from '../../lib/auth-store.js'
 import {
     type AuthMetadata,
@@ -131,10 +132,14 @@ export function attachTodoistStatusCommand(auth: Command, store: TodoistTokenSto
         store,
         description: 'Show current authentication status',
         fetchLive: async ({ token }) => {
-            // Snapshot's token only matches `--user` when no selector is set.
-            // Re-resolve via getApi when --user is present so the displayed
-            // account is the requested one, not the snapshot's default.
-            const userOverride = getRequestedUserRef() !== undefined
+            // Snapshot's token only matches the default account when nothing
+            // selects another one. Re-resolve via getApi when something does,
+            // so the displayed account is the one every other command acts as.
+            // `TD_USER` counts here exactly as `--user` does: without it,
+            // status would report the default while the rest of the CLI used
+            // the account the environment named.
+            const userOverride =
+                getRequestedUserRef() !== undefined || Boolean(process.env[USER_ENV_VAR])
             data = await gatherStatusData(userOverride ? undefined : token)
             return toTodoistAccount({
                 id: data.user.id,

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -338,7 +338,7 @@ async function checkStoredUsers(): Promise<DoctorCheck[]> {
         checks.push({
             name: 'users',
             status: 'warn',
-            message: `${reason}. Commands without --user will error`,
+            message: `${reason}. Commands without --user or TD_USER will error`,
             details: baseDetails,
         })
     }

--- a/src/lib/auth-store.ts
+++ b/src/lib/auth-store.ts
@@ -18,6 +18,12 @@ import { getStoredUsers, matchUserRef } from './users.js'
 export const SERVICE_NAME = 'todoist-cli'
 export const LEGACY_ACCOUNT = 'api-token'
 export const TOKEN_ENV_VAR = 'TODOIST_API_TOKEN'
+/**
+ * Names the stored account to act as, as `--user` does. It exists so that a
+ * process the CLI starts can pass its account on to the nested `td` calls that
+ * process makes, without every one of them having to repeat the flag.
+ */
+export const USER_ENV_VAR = 'TD_USER'
 export type CredentialStore = 'system' | 'plaintext'
 
 export function parseCredentialStore(value: string): CredentialStore {

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -242,6 +242,77 @@ describe('lib/auth', () => {
         await expect(resolveActiveUser({ ref: '222' })).resolves.toMatchObject({ id: '222' })
     })
 
+    it('TD_USER names the account when no --user was given', async () => {
+        vi.stubEnv('TD_USER', 'd@e.f')
+        setConfig({
+            config_version: 2,
+            users: [
+                { id: '111', email: 'a@b.c' },
+                { id: '222', email: 'd@e.f' },
+            ],
+        })
+        entryFor(keyring, 'user-222').token = 'token-222'
+
+        const { resolveActiveUser } = await import('./auth.js')
+
+        await expect(resolveActiveUser()).resolves.toMatchObject({ id: '222' })
+    })
+
+    it('an explicit ref beats TD_USER', async () => {
+        vi.stubEnv('TD_USER', '222')
+        setConfig({
+            config_version: 2,
+            users: [
+                { id: '111', email: 'a@b.c' },
+                { id: '222', email: 'd@e.f' },
+            ],
+        })
+        entryFor(keyring, 'user-111').token = 'token-111'
+
+        const { resolveActiveUser } = await import('./auth.js')
+
+        await expect(resolveActiveUser({ ref: '111' })).resolves.toMatchObject({ id: '111' })
+    })
+
+    it('TODOIST_API_TOKEN still short-circuits ahead of TD_USER', async () => {
+        vi.stubEnv('TODOIST_API_TOKEN', 'env-token-123456')
+        vi.stubEnv('TD_USER', '222')
+        setConfig({
+            config_version: 2,
+            users: [{ id: '222', email: 'd@e.f' }],
+        })
+
+        const { resolveActiveUser } = await import('./auth.js')
+
+        await expect(resolveActiveUser()).resolves.toMatchObject({ id: 'env', source: 'env' })
+    })
+
+    it('treats an empty TD_USER as unset rather than as an account name', async () => {
+        vi.stubEnv('TD_USER', '')
+        setConfig({
+            config_version: 2,
+            users: [{ id: '111', email: 'a@b.c' }],
+        })
+        entryFor(keyring, 'user-111').token = 'stored-token'
+
+        const { resolveActiveUser } = await import('./auth.js')
+
+        await expect(resolveActiveUser()).resolves.toMatchObject({ id: '111' })
+    })
+
+    it('reports an unresolvable TD_USER the same way an unresolvable --user is reported', async () => {
+        vi.stubEnv('TD_USER', 'nope')
+        setConfig({
+            config_version: 2,
+            users: [{ id: '111', email: 'a@b.c' }],
+        })
+
+        const { resolveActiveUser } = await import('./auth.js')
+        const { UserNotFoundError } = await import('./users.js')
+
+        await expect(resolveActiveUser()).rejects.toBeInstanceOf(UserNotFoundError)
+    })
+
     it('throws UserNotFoundError when ref does not match', async () => {
         setConfig({
             config_version: 2,

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -258,6 +258,34 @@ describe('lib/auth', () => {
         await expect(resolveActiveUser()).resolves.toMatchObject({ id: '222' })
     })
 
+    it('the --user flag beats TD_USER', async () => {
+        // Through argv rather than through `opts.ref`: production callers pass
+        // no ref, so the flag reaches the resolver via the global-args store,
+        // and that is the precedence worth pinning.
+        const realArgv = process.argv
+        process.argv = ['node', 'td', '--user', '111', 'task', 'list']
+        vi.stubEnv('TD_USER', '222')
+        setConfig({
+            config_version: 2,
+            users: [
+                { id: '111', email: 'a@b.c' },
+                { id: '222', email: 'd@e.f' },
+            ],
+        })
+        entryFor(keyring, 'user-111').token = 'token-111'
+
+        const { resetGlobalArgs } = await import('./global-args.js')
+        resetGlobalArgs()
+        const { resolveActiveUser } = await import('./auth.js')
+
+        try {
+            await expect(resolveActiveUser()).resolves.toMatchObject({ id: '111' })
+        } finally {
+            process.argv = realArgv
+            resetGlobalArgs()
+        }
+    })
+
     it('an explicit ref beats TD_USER', async () => {
         vi.stubEnv('TD_USER', '222')
         setConfig({

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -13,7 +13,7 @@ export {
     type UpdateChannel,
 } from './config.js'
 
-import { accountForUser, SERVICE_NAME, TOKEN_ENV_VAR } from './auth-store.js'
+import { accountForUser, SERVICE_NAME, TOKEN_ENV_VAR, USER_ENV_VAR } from './auth-store.js'
 import { type AuthFlag, type AuthMode, readConfig, type StoredUser } from './config.js'
 import { CliError } from './errors.js'
 import { getRequestedUserRef } from './global-args.js'
@@ -25,7 +25,7 @@ import {
     UserNotFoundError,
 } from './users.js'
 
-export { TOKEN_ENV_VAR } from './auth-store.js'
+export { TOKEN_ENV_VAR, USER_ENV_VAR } from './auth-store.js'
 
 export interface AuthMetadata {
     authMode: AuthMode
@@ -60,10 +60,10 @@ export class NoTokenError extends CliError {
 
 /**
  * Resolve which stored user this invocation should act as, and load their
- * token. Honors `--user <ref>`, then `user.defaultUser`, then a single stored
- * user. Throws `NoUserSelectedError` when multiple users are stored without a
- * default and no `--user` was passed; `UserNotFoundError` when `--user` does
- * not match; `NoTokenError` when no users are stored.
+ * token. Honors `--user <ref>`, then `TD_USER`, then `user.defaultUser`, then
+ * a single stored user. Throws `NoUserSelectedError` when multiple users are
+ * stored without a default and none of the three named one; `UserNotFoundError`
+ * when the named one does not match; `NoTokenError` when no users are stored.
  *
  * `TODOIST_API_TOKEN` short-circuits the resolver entirely — env tokens act as
  * an anonymous identity for the duration of the command.
@@ -76,7 +76,12 @@ export async function resolveActiveUser(opts: { ref?: string } = {}): Promise<Re
 
     const config = await readConfig()
     const users = getStoredUsers(config)
-    const ref = opts.ref ?? getRequestedUserRef()
+    // The flag before the environment: a flag is this invocation saying what
+    // it wants, while `TD_USER` is the surrounding context saying who it is,
+    // and the specific instruction should win. `||` for the variable, because
+    // `TD_USER=` is someone clearing it, not naming an account called the
+    // empty string.
+    const ref = opts.ref ?? getRequestedUserRef() ?? (process.env[USER_ENV_VAR] || undefined)
 
     if (users.length === 0) {
         throw ref ? new UserNotFoundError(ref) : new NoTokenError()


### PR DESCRIPTION
A process the CLI starts should be able to pass its account on to the nested `td` calls it makes, without repeating `--user` on every one. Read `TD_USER` as the fallback, between the flag and the configured default: the flag is this invocation saying what it wants, the variable is the surrounding context saying who it is, and the specific instruction wins.

`TODOIST_API_TOKEN` still short-circuits ahead of both, and an unresolvable `TD_USER` reports the same `UserNotFoundError` an unresolvable `--user` does, so neither silently falls back to some other account. An empty value counts as unset.

Useful outside extensions too: `TD_USER=alice td task list` now works for anyone.

> **Trying it out:** nothing in this stack is usable on its own — `td extension` and extension dispatch only exist once every PR is applied. Check out `feat/ext-cmd-9-docs` (#539), the top of the stack, which carries the instructions.
