### PR TITLE
feat(doctor): check installed extensions

### DIFF
--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -25,6 +25,13 @@ vi.mock('node:fs/promises', () => ({
     readFile: vi.fn(),
 }))
 
+// The extension checks read the real extensions directory and have their own
+// tests. Left alone here, the counts these tests assert would depend on what
+// the person running the suite happens to have installed.
+vi.mock('./extension/doctor.js', () => ({
+    checkExtensions: vi.fn(async () => []),
+}))
+
 vi.mock('../lib/progress.js', () => ({
     getProgressTracker: vi.fn(() => mockProgressTracker),
 }))

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -20,15 +20,16 @@ import {
     isNewer,
 } from '../lib/update.js'
 import { getDefaultUserId, NoUserSelectedError } from '../lib/users.js'
+import { checkExtensions } from './extension/doctor.js'
 
-type CheckStatus = 'pass' | 'warn' | 'fail' | 'skip'
+export type CheckStatus = 'pass' | 'warn' | 'fail' | 'skip'
 
 interface DoctorOptions {
     json?: boolean
     offline?: boolean
 }
 
-interface DoctorCheck {
+export interface DoctorCheck {
     name: string
     status: CheckStatus
     message: string
@@ -355,18 +356,19 @@ async function checkStoredUsers(): Promise<DoctorCheck[]> {
     return checks
 }
 
-async function runDoctorChecks(options: DoctorOptions): Promise<DoctorCheck[]> {
+async function runDoctorChecks(options: DoctorOptions, program: Command): Promise<DoctorCheck[]> {
     return [
         checkNodeVersion(),
         await checkConfigFile(),
         ...(await checkStoredUsers()),
         await checkAuthentication(Boolean(options.offline)),
+        ...(await checkExtensions(program)),
         await checkForUpdates(Boolean(options.offline)),
     ].filter((check): check is DoctorCheck => check !== null)
 }
 
-export async function doctorAction(options: DoctorOptions): Promise<void> {
-    const checks = await runDoctorChecks(options)
+export async function doctorAction(options: DoctorOptions, program: Command): Promise<void> {
+    const checks = await runDoctorChecks(options, program)
     const summary = summarize(checks)
     const ok = summary.failed === 0
 
@@ -392,5 +394,8 @@ export function registerDoctorCommand(program: Command): void {
         .description('Diagnose common CLI setup and environment issues')
         .option('--json', 'Output diagnostic results as JSON')
         .option('--offline', 'Skip network checks against Todoist and npm')
-        .action(doctorAction)
+        // The program is passed on so the extension checks can see which
+        // command names are taken, which is what decides whether an extension
+        // is being shadowed.
+        .action((options: DoctorOptions) => doctorAction(options, program))
 }

--- a/src/commands/extension/doctor.test.ts
+++ b/src/commands/extension/doctor.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { captureConsole } from '@doist/cli-core/testing'
@@ -53,6 +53,33 @@ describe('checkExtensions', () => {
         expect(checks).toHaveLength(1)
         expect(checks[0]).toMatchObject({ name: 'extensions', status: 'pass' })
         expect(checks[0].message).toContain('1 extension(s) installed')
+    })
+
+    // Root reads a 0o000 directory regardless, so there is nothing to observe.
+    it.skipIf(process.getuid?.() === 0)(
+        'reports a directory it cannot read rather than saying nothing is installed',
+        async () => {
+            await writeFixtureExtension(extensionsDir, 'goals', {})
+            await chmod(extensionsDir, 0o000)
+
+            try {
+                const checks = await checkExtensions(program())
+                expect(checks).toHaveLength(1)
+                expect(checks[0]).toMatchObject({ status: 'fail' })
+                expect(checks[0].message).toContain('Cannot read')
+            } finally {
+                await chmod(extensionsDir, 0o755)
+            }
+        },
+    )
+
+    it('warns about a manifest that is not a regular file', async () => {
+        const dir = await writeFixtureExtension(extensionsDir, 'goals', {})
+        // An extension chooses what sits in its own directory, and reading a
+        // FIFO or a device would never finish.
+        await symlink('/dev/zero', join(dir, 'td-extension.json'))
+
+        expect(messages(await checkExtensions(program()))).toContain('not a regular file')
     })
 
     it('fails an extension that cannot be run', async () => {

--- a/src/commands/extension/doctor.test.ts
+++ b/src/commands/extension/doctor.test.ts
@@ -1,0 +1,127 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { captureConsole } from '@doist/cli-core/testing'
+import { Command } from 'commander'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { writeFixtureExtension } from '../../test-support/extension-fixture.js'
+import { checkExtensions } from './doctor.js'
+
+const REAL_PLATFORM = process.platform
+
+describe('checkExtensions', () => {
+    let root: string
+    let extensionsDir: string
+
+    /** A program shaped like td's, so shadowing is measured against real names. */
+    function program(): Command {
+        const command = new Command()
+        command.command('task')
+        return command
+    }
+
+    function messages(checks: { message: string }[]): string {
+        return checks.map((check) => check.message).join('\n')
+    }
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-doctor-'))
+        extensionsDir = join(root, 'data', 'todoist-cli', 'extensions')
+        await mkdir(extensionsDir, { recursive: true })
+        vi.stubEnv('XDG_DATA_HOME', join(root, 'data'))
+        vi.stubEnv('XDG_STATE_HOME', join(root, 'state'))
+        captureConsole('log')
+    })
+
+    afterEach(async () => {
+        Object.defineProperty(process, 'platform', {
+            value: REAL_PLATFORM,
+            configurable: true,
+        })
+        vi.unstubAllEnvs()
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('reports nothing when no extension is installed', async () => {
+        expect(await checkExtensions(program())).toEqual([])
+    })
+
+    it('reports a healthy extension with one line and no warnings', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {})
+        const checks = await checkExtensions(program())
+
+        expect(checks).toHaveLength(1)
+        expect(checks[0]).toMatchObject({ name: 'extensions', status: 'pass' })
+        expect(checks[0].message).toContain('1 extension(s) installed')
+    })
+
+    it('fails an extension that cannot be run', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', { notExecutable: true })
+        const checks = await checkExtensions(program())
+
+        expect(checks.some((check) => check.status === 'fail')).toBe(true)
+        expect(messages(checks)).toContain('is missing or not executable')
+    })
+
+    it('warns about an extension a built-in command hides, and how to run it', async () => {
+        await writeFixtureExtension(extensionsDir, 'task', {})
+        const checks = await checkExtensions(program())
+
+        const shadowed = checks.find((check) => check.message.includes('hidden by the built-in'))
+        expect(shadowed?.status).toBe('warn')
+        expect(shadowed?.message).toContain('td extension exec task')
+    })
+
+    it('warns about a manifest it cannot read', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            files: { 'td-extension.json': '{ not json' },
+        })
+        const checks = await checkExtensions(program())
+
+        expect(messages(checks)).toContain('td-extension.json could not be read')
+        expect(messages(checks)).toContain('Fix or delete the file')
+    })
+
+    it('warns when the running td is older than the extension asks for', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            authoredManifest: { requires: { td: '>=99.0.0' } },
+        })
+        const checks = await checkExtensions(program())
+
+        const incompatible = checks.find((check) => check.message.includes('expects td >=99.0.0'))
+        expect(incompatible?.status).toBe('warn')
+        expect(incompatible?.message).toContain('td update')
+    })
+
+    it('says nothing about a requirement the running td satisfies', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            authoredManifest: { requires: { td: '>=1.0.0' } },
+        })
+        expect(await checkExtensions(program())).toHaveLength(1)
+    })
+
+    it('warns about a manifest from a newer format', async () => {
+        await writeFixtureExtension(extensionsDir, 'goals', {
+            authoredManifest: { manifestVersion: 99 },
+        })
+        expect(messages(await checkExtensions(program()))).toContain(
+            'manifest format newer than this td understands',
+        )
+    })
+
+    it('says extensions are experimental on Windows', async () => {
+        Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+        await writeFixtureExtension(extensionsDir, 'goals', {})
+
+        expect(messages(await checkExtensions(program()))).toContain('experimental on Windows')
+    })
+
+    it('reports one extension problem per check rather than one per extension', async () => {
+        await writeFixtureExtension(extensionsDir, 'task', { notExecutable: true })
+        const checks = await checkExtensions(program())
+
+        // Summary, plus the two separate things wrong with this one extension.
+        expect(checks).toHaveLength(3)
+        expect(checks.map((check) => check.status)).toEqual(['pass', 'fail', 'warn'])
+    })
+})

--- a/src/commands/extension/doctor.ts
+++ b/src/commands/extension/doctor.ts
@@ -1,0 +1,114 @@
+/**
+ * What `td doctor` reports about installed extensions.
+ *
+ * Nothing here reaches the network: `list` is a directory read plus, for a
+ * clone, a `git rev-parse`. Someone with no extensions sees nothing at all.
+ */
+
+import type { Command } from 'commander'
+import packageJson from '../../../package.json' with { type: 'json' }
+import { findManifestProblems } from '../../lib/extensions/manifest.js'
+import { satisfiesRange } from '../../lib/extensions/version-range.js'
+import type { DoctorCheck } from '../doctor.js'
+import { buildExtensionManager } from './index.js'
+
+const NAME = 'extensions'
+const TD_VERSION = packageJson.version
+
+/**
+ * Windows paths are implemented but have not had a full test pass, so say so
+ * rather than letting someone discover it themselves.
+ */
+function windowsCheck(): DoctorCheck | null {
+    if (process.platform !== 'win32') return null
+    return {
+        name: NAME,
+        status: 'warn',
+        message: 'Extensions are experimental on Windows in this release',
+        details: { platform: process.platform },
+    }
+}
+
+export async function checkExtensions(program: Command): Promise<DoctorCheck[]> {
+    const manager = buildExtensionManager(program)
+
+    if (await manager.isEmpty()) return []
+
+    let listing: Awaited<ReturnType<typeof manager.list>>
+    try {
+        listing = await manager.list()
+    } catch (error) {
+        return [
+            {
+                name: NAME,
+                status: 'fail',
+                message: `Cannot read ${manager.extensionsDir}: ${error instanceof Error ? error.message : String(error)}`,
+                details: { extensionsDir: manager.extensionsDir },
+            },
+        ]
+    }
+
+    const checks: DoctorCheck[] = [
+        {
+            name: NAME,
+            status: 'pass',
+            message: `${listing.length} extension(s) installed in ${manager.extensionsDir}`,
+            details: { count: listing.length, extensionsDir: manager.extensionsDir },
+        },
+    ]
+
+    for (const entry of listing) {
+        const details = { name: entry.name, kind: entry.kind, dir: entry.dir }
+
+        if (!entry.executable) {
+            checks.push({
+                name: NAME,
+                status: 'fail',
+                message: `${entry.name}: ${entry.executablePath} is missing or not executable`,
+                details,
+            })
+        }
+
+        if (entry.shadowed) {
+            checks.push({
+                name: NAME,
+                status: 'warn',
+                message: `${entry.name} is hidden by the built-in command of the same name. Run \`td extension exec ${entry.name}\`, or reinstall it under another name`,
+                details,
+            })
+        }
+
+        for (const problem of await findManifestProblems(entry.dir, manager.binName)) {
+            checks.push({
+                name: NAME,
+                status: 'warn',
+                message: `${entry.name}: ${problem}. Fix or delete the file`,
+                details,
+            })
+        }
+
+        const range = entry.requires?.[manager.binName]
+        if (range && !satisfiesRange(TD_VERSION, range)) {
+            checks.push({
+                name: NAME,
+                status: 'warn',
+                message: `${entry.name} expects td ${range}, but this is td ${TD_VERSION}. Run \`td update\`, or \`td extension upgrade ${entry.name}\``,
+                details: { ...details, requires: range },
+            })
+        }
+
+        if (entry.manifestFromNewerFormat) {
+            checks.push({
+                name: NAME,
+                status: 'warn',
+                message: `${entry.name} declares a manifest format newer than this td understands, so some of its metadata is being ignored. Run \`td update\``,
+                details,
+            })
+        }
+    }
+
+    const windows = windowsCheck()
+    if (windows) checks.push(windows)
+
+    return checks
+}

--- a/src/commands/extension/doctor.ts
+++ b/src/commands/extension/doctor.ts
@@ -7,6 +7,7 @@
 
 import type { Command } from 'commander'
 import packageJson from '../../../package.json' with { type: 'json' }
+import { mapWithConcurrency } from '../../lib/extensions/concurrency.js'
 import { findManifestProblems } from '../../lib/extensions/manifest.js'
 import { satisfiesRange } from '../../lib/extensions/version-range.js'
 import type { DoctorCheck } from '../doctor.js'
@@ -32,8 +33,10 @@ function windowsCheck(): DoctorCheck | null {
 export async function checkExtensions(program: Command): Promise<DoctorCheck[]> {
     const manager = buildExtensionManager(program)
 
-    if (await manager.isEmpty()) return []
-
+    // `list` rather than `isEmpty` first: `isEmpty` answers "yes" for any
+    // directory it cannot read, which would make a permissions problem look
+    // like having no extensions — exactly the failure this check is for. A
+    // directory that is simply not there yields an empty list, not an error.
     let listing: Awaited<ReturnType<typeof manager.list>>
     try {
         listing = await manager.list()
@@ -48,6 +51,14 @@ export async function checkExtensions(program: Command): Promise<DoctorCheck[]> 
         ]
     }
 
+    if (listing.length === 0) return []
+
+    // Two file reads per extension, and they do not depend on each other.
+    const manifestProblems = await mapWithConcurrency(listing, 4, async (entry) => ({
+        entry,
+        problems: await findManifestProblems(entry.dir, manager.binName),
+    }))
+
     const checks: DoctorCheck[] = [
         {
             name: NAME,
@@ -57,7 +68,7 @@ export async function checkExtensions(program: Command): Promise<DoctorCheck[]> 
         },
     ]
 
-    for (const entry of listing) {
+    for (const { entry, problems } of manifestProblems) {
         const details = { name: entry.name, kind: entry.kind, dir: entry.dir }
 
         if (!entry.executable) {
@@ -78,7 +89,7 @@ export async function checkExtensions(program: Command): Promise<DoctorCheck[]> 
             })
         }
 
-        for (const problem of await findManifestProblems(entry.dir, manager.binName)) {
+        for (const problem of problems) {
             checks.push({
                 name: NAME,
                 status: 'warn',

--- a/src/lib/extensions/json-file.ts
+++ b/src/lib/extensions/json-file.ts
@@ -6,7 +6,7 @@
  * apart, and one place decides what counts as a JSON object.
  */
 
-import { readFile, writeFile } from 'node:fs/promises'
+import { open, writeFile } from 'node:fs/promises'
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -23,18 +23,46 @@ export type JsonReadResult =
     | { status: 'unreadable'; reason: string }
 
 /**
+ * More than any of these files could honestly need. The point is not the exact
+ * figure: an extension chooses what sits in its own directory, and reading
+ * without a limit lets a large file become a memory problem for whoever runs
+ * `list` or `doctor`.
+ */
+const MAX_BYTES = 1024 * 1024
+
+/**
  * Read a JSON file, keeping "not there" and "there but broken" apart. Callers
  * that only want the value can use `readJsonValue`; `doctor` needs the
  * distinction, because an unreadable manifest is a problem worth reporting and
  * a missing one is not.
+ *
+ * Opened and checked rather than read straight through. An extension can
+ * commit anything under its own name, including a symlink to a device or a
+ * FIFO, and `readFile` on one of those never reaches the end.
  */
 export async function readJsonFile(path: string): Promise<JsonReadResult> {
-    let raw: string
+    let handle: Awaited<ReturnType<typeof open>>
     try {
-        raw = await readFile(path, 'utf8')
+        handle = await open(path, 'r')
     } catch (error) {
         if (isMissingFile(error)) return { status: 'absent' }
         return { status: 'unreadable', reason: (error as Error).message }
+    }
+
+    let raw: string
+    try {
+        const stats = await handle.stat()
+        if (!stats.isFile()) {
+            return { status: 'unreadable', reason: 'not a regular file' }
+        }
+        if (stats.size > MAX_BYTES) {
+            return { status: 'unreadable', reason: `larger than ${MAX_BYTES} bytes` }
+        }
+        raw = await handle.readFile('utf8')
+    } catch (error) {
+        return { status: 'unreadable', reason: (error as Error).message }
+    } finally {
+        await handle.close()
     }
 
     try {


### PR DESCRIPTION
Adds a check per installed extension: the executable is there and can be run, no built-in command is hiding it, its manifests parse, the running td satisfies what it asks for, and its manifest format is one this version understands. Each says what to do about it.

Only problems are reported, after a single summary line, the way the Node version check stays quiet when there is nothing wrong. Someone with no extensions installed sees nothing at all.

The program is passed through to the check because which command names are taken is what decides whether an extension is shadowed, and that is only knowable from the program itself.

This gives `findManifestProblems` its first caller — it was written for exactly this and has been sitting unused.

> **Trying it out:** nothing in this stack is usable on its own — `td extension` and extension dispatch only exist once every PR is applied. Check out `feat/ext-cmd-9-docs` (#539), the top of the stack, which carries the instructions.
