### PR TITLE
docs: document td extension

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -46,7 +46,7 @@ src/
 │  ├─ task/, project/, label/, comment/, section/, filter/,
 │  │  reminder/, workspace/, folder/, notification/, template/,
 │  │  backup/, apps/, billing/, stats/, completed/, auth/, settings/,
-│  │  config/, skill/, hc/, completion/, update/
+│  │  config/, skill/, hc/, completion/, update/, extension/
 │  └─ *.test.ts           # Co-located tests
 ├─ lib/                   # Shared utilities. See catalog — don't reimplement.
 │  ├─ api/                # SDK wrapper + typed helpers (core, filters, workspaces,
@@ -67,15 +67,24 @@ src/
    and builds a **lazy command registry** — a `Record<name, [description, loader]>`.
 2. Placeholder subcommands are registered so `--help` lists everything without
    importing anything.
-3. The invoked command name is extracted from `process.argv`; only its loader
-   runs (`./commands/<name>.js` for flat commands, `./commands/<name>/index.js`
-   for groups), then the real `registerXxxCommand(program)` replaces the
-   placeholder.
-4. If output will be human-readable, `preloadMarkdown()` runs in parallel with
+3. `findCommandToken()` (`lib/command-token.ts`) walks argv from the start,
+   stepping over global flags and the values of the two that take one, and
+   stops at the first remaining token. Nothing after it is inspected — that
+   belongs to whatever the token names.
+4. When the token does not name a built-in, the installed extensions are
+   discovered and registered as commands (`commands/extension/dispatch.ts`).
+   A built-in always wins, so `td task list` skips this and never loads the
+   extension system at all. If the token names an extension, it is spawned
+   here, before commander parses, and the process exits with its exit code —
+   which is what makes everything after the name reach it exactly as typed.
+5. Otherwise only the token's loader runs (`./commands/<name>.js` for flat
+   commands, `./commands/<name>/index.js` for groups), then the real
+   `registerXxxCommand(program)` replaces the placeholder.
+6. If output will be human-readable, `preloadMarkdown()` runs in parallel with
    the command import. `startEarlySpinner()` covers the import latency.
-5. `program.parseAsync()` runs the command's action handler. Uncaught
-   `CliError` is rendered via `formatError()` or `formatErrorJson()` depending
-   on `isJsonMode()`.
+7. `program.parseAsync()` runs the command's action handler. Uncaught
+   `CliError` is rendered by `reportFatal()` via `formatError()` or
+   `formatErrorJson()` depending on `isJsonMode()`.
 
 ## Command registration pattern
 
@@ -86,6 +95,13 @@ src/
   then calls `task.command('<sub>')` for each subcommand — each subcommand's
   logic lives in a sibling file (`task/add.ts`, `task/list.ts`, …) re-imported
   by `index.ts`. Shared helpers live in `task/helpers.ts`.
+- **Pass-through command** (extensions): registered from
+  `lib/extensions/commands.ts` with `.allowUnknownOption()`,
+  `.allowExcessArguments()`, `.helpOption(false)` and `.helpGroup('Extensions:')`,
+  so commander touches nothing after the name and `--help` lists them under
+  their own heading. Not `.passThroughOptions()`: commander requires
+  `enablePositionalOptions()` on the parent for that, which makes every
+  ordinary command reject the global flags it accepts today.
 - **Implicit `view` subcommand**: most group commands register
   `.command('view [ref]', { isDefault: true })` so `td project <ref>`
   dispatches to `td project view <ref>`. Same for task, workspace, comment,
@@ -131,16 +147,24 @@ New subcommand? Copy a sibling in the target group, wire it in that group's
   the `(default)` marker in `accounts list`/`current`, `auth status`,
   `config view`).
 - **`extensions/`** — the extension system: `manager.ts`
-  (`createExtensionManager`, the only entry point a host needs), plus
-  `discover`, `install`, `upgrade`, `remove`, `dispatch`, `github`, `git`,
-  `npm`, `manifest`, `state`, `source`, `version-range`, `run`, `fs-utils`.
+  (`createExtensionManager`, the only entry point a host needs), `commands.ts`
+  (`registerExtensionGroup` for `td extension …`, `registerExtensionPassThrough`
+  for the per-extension commands), plus `discover`, `install`, `upgrade`,
+  `remove`, `dispatch`, `github`, `git`, `npm`, `manifest`, `schemas`,
+  `state`, `source`, `version-range`, `run`, `fs-utils`.
   Host-agnostic by design: the binary name, directories, version, reserved
   command names and first-party source all arrive through the manager's
   options, and nothing in the directory imports from the rest of the repo, so
-  it can move to `@doist/cli-core` as a file move. See
-  `docs/specs/extensions.md`.
+  it can move to `@doist/cli-core` as a file move. Everything td-specific is
+  decided in `commands/extension/index.ts`. See `docs/specs/extensions.md`.
 - **`auth-flags.ts`** — `buildReloginCommand()` (rebuilds `td auth login`
   with `--read-only` / `--additional-scopes=...` preserved)
+- **`paths.ts`** — `getDataDir()` / `getStateDir()`: the XDG data and state
+  directories (`%LOCALAPPDATA%` on Windows). cli-core owns the config path
+  only. `getConfigDir()` lives in `config.ts`, derived from it.
+- **`command-token.ts`** — `findCommandToken()` (which argv entry names the
+  command) and `needsExtensionLookup()` (whether this invocation has any use
+  for the installed extensions).
 - **`config.ts`** — `~/.config/todoist-cli/config.json` read/write,
   `stripLegacyAuthFields`, `AuthMode`, `UpdateChannel`, `AUTH_FLAG_ORDER`.
 - **`auth-provider.ts`** — `createTodoistAuthProvider()`: cli-core PKCE

--- a/docs/specs/extensions.md
+++ b/docs/specs/extensions.md
@@ -92,7 +92,7 @@ Repository names must start with `td-`. The command name is the repository name 
 
 Install steps for a GitHub source:
 
-1. Validate the name: must match `^td-[a-z0-9][a-z0-9-]*$`, and the command name must not match a built-in command or alias. Refuse with `EXTENSION_NAME_RESERVED` and a hint pointing at `td extension exec` if the extension is already installed and a later `td` release added a core command with the same name.
+1. Validate the name: must match `^td-[a-z0-9][a-z0-9-]*$`, and the command name must not match a built-in command or alias. The reserved set also names `extension`, `ext` and the internal `completion-server` explicitly, because none of the three is reliably registered on the program at the moment the check runs, and the last is what the shell invokes on every tab press. Refuse with `EXTENSION_NAME_RESERVED` and a hint pointing at `td extension exec` if the extension is already installed and a later `td` release added a core command with the same name.
 2. If an extension with this command name is already installed from a different owner, refuse with `EXTENSION_ALREADY_INSTALLED` (`--force` replaces it). Same owner: report already installed, suggest `upgrade`.
 3. Print the trust warning (below). It goes out before any step that can run code from the repository, so a user sees it even if a later step fails or executes something.
 4. Query `GET /repos/{owner}/{repo}/releases/latest`, or `GET /repos/{owner}/{repo}/releases/tags/{ref}` when `--pin <ref>` is given. If the release has an asset whose name ends in `<platform>-<arch>[.exe]` for the current machine, treat it as a **binary extension**: download the asset to `<dir>/td-<name>[.exe]`, `chmod 0755`, verify the checksum when the release also carries `checksums.txt` or `<asset>.sha256`, fetch the repository's `td-extension.json` at the release tag (`GET /repos/{owner}/{repo}/contents/td-extension.json?ref={tag}`, optional, a 404 is not an error), and write `.td-manifest.json` including any `description` and `requires` found there. A pinned tag with no release falls through to the git path below. Platform names use Node's `process.platform` / `process.arch` values (`linux-x64`, `darwin-arm64`, `win32-x64`) rather than Go's, since extension authors building with Node will already have those in hand. A release workflow template (phase 2) produces both spellings so a single repo can serve both `gh` and `td` if the author wants.
@@ -147,6 +147,8 @@ No `--yes` prompt: with the rules above nothing the user authored is deleted wit
 #### `exec`
 
 `td extension exec <name> [args...]` dispatches directly, bypassing the built-in command table. It is the escape hatch for the shadowed case and for scripting where an explicit form is preferable.
+
+Everything after `<name>` is the extension's, `--help` included: `exec` disables Commander's own help option, since this is the only form that can reach the usage of an extension a built-in command is hiding. The pre-parse `--user` handling also skips the whole `extension` group, because `td extension exec goals --user alice` is passing that flag to `goals`. The consequence is that `--user` is not accepted by the group's other subcommands, where it would mean nothing anyway.
 
 ### Help and discovery
 

--- a/docs/specs/extensions.md
+++ b/docs/specs/extensions.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft — for discussion.
+Accepted. Phase 1 is implemented; phases 2 and 3 are not started.
 
 ## Summary
 
@@ -184,6 +184,7 @@ The config file is untouched. Nothing in this design needs a new config key, so 
 
 ```json
 {
+    "manifestVersion": 1,
     "owner": "Doist",
     "name": "td-goals",
     "host": "github.com",
@@ -201,11 +202,14 @@ The config file is untouched. Nothing in this design needs a new config key, so 
 
 ```json
 {
+    "manifestVersion": 1,
     "description": "Track quarterly goals against Todoist projects",
     "requires": { "td": ">=4.0.0" },
     "completion": false
 }
 ```
+
+- `manifestVersion` says which format the file is written in. It is optional and defaults to `1`, so an author who omits it is writing version 1. A file declaring a version newer than the running `td` understands is still read for the fields this version knows, and `list` and `doctor` say that some of its metadata is being ignored; the CLI's own `.td-manifest.json` is stricter and is refused outright, because a shape `td` does not recognise means a different version of `td` wrote it and reading it anyway would be guessing.
 
 - `description` is shown in `td --help` and `td extension list`. For binary installs it is copied into `.td-manifest.json` at install time, since the binary asset does not carry the file.
 - `requires.td` is a semver range. When the running `td` does not satisfy it, dispatch still happens, but a warning goes to stderr first. Refusing outright would make a `td` upgrade break a working extension for no good reason; the extension can enforce it itself using `TD_VERSION` if it must.
@@ -267,15 +271,22 @@ Because `td` already treats `--json` output and `CliError` JSON envelopes as a s
 
 ### Startup cost
 
-`td` starts by registering placeholders for its built-in commands without importing them. Extensions are discovered by a single `readdir` of the extensions directory, which costs well under a millisecond and returns nothing for the majority of users who have no extensions. Discovery runs on every invocation because it is needed for `--help`, for completion, and for the unknown-command path. Manifests are read lazily: for `list`, `--help`, the shadowing check, and at dispatch for the one extension being run (a single small file, needed for the `requires.td` warning).
+`td` starts by registering placeholders for its built-in commands without importing them. Extensions are discovered by a single `readdir` of the extensions directory, which costs well under a millisecond and returns nothing for the majority of users who have no extensions.
+
+Discovery is skipped entirely when the command token names a built-in. A built-in always wins over an extension of the same name, so for `td task list` there is nothing on disk that could change the outcome, and the extension system is not imported at all. What is left is exactly the set of cases that need the answer: `--help`, completion, an extension being run, and a mistyped command, which could be either. `--version` is excluded too, since it lists nothing.
+
+Manifests are read lazily: for `list`, `--help`, the shadowing check, and at dispatch for the one extension being run (a single small file, needed for the `requires.td` warning).
 
 ### Registration
 
 Each discovered extension whose name does not collide with a built-in command is registered as a Commander command with:
 
 - `.description()` from its manifest, or `Extension <name>`.
-- `.allowUnknownOption()`, `.passThroughOptions()`, and `.helpOption(false)`, so Commander touches nothing after the name.
+- `.allowUnknownOption()`, `.allowExcessArguments()`, and `.helpOption(false)`, so Commander touches nothing after the name.
+- `.helpGroup('Extensions:')`, which is what produces the `Extensions:` section in `td --help`.
 - An action that spawns the executable.
+
+Not `.passThroughOptions()`, which is the obvious choice and cannot be used: Commander refuses it unless `enablePositionalOptions()` is set on the parent program, and that makes ordinary commands reject the global flags they accept today (`td task list --accessible`, `td doctor --json -q`, `td task list -v` all become `unknown option`). Exact passthrough comes from dispatching before `parseAsync()` instead, so Commander never sees the arguments at all; the registered command is what makes `--help` and completion work, and reads its arguments back off `process.argv` when it is the one that runs.
 
 Registering real commands, rather than catching the unknown-command error, is what `gh` does and it is the right call here too: it makes `--help` and name completion work with no special cases. A colliding name is skipped and surfaces as `shadowed` in `list`.
 
@@ -327,8 +338,8 @@ An unknown command that is not an extension keeps Commander's current message, w
 
 ### Phase 1 — core (ships the feature)
 
-- `src/lib/extensions/`: `createExtensionManager({ binName, dataDir, stateDir, envPrefix, reservedNames, officialSource })` returning discover, install (GitHub git/binary, local), list, upgrade, remove, dispatch, where `officialSource` is `{ host: 'github.com', owner: 'Doist' }`. Nothing in it may import from `src/commands/` or read `td`-specific config directly: every host-specific value comes in through that options object, and its only dependencies are Node built-ins and what `@doist/cli-core` already exports. That is what makes the later move to cli-core a file move rather than a rewrite.
-- `src/lib/extensions/commands.ts`: `registerExtensionCommands(program, manager)` adding `extension` / `ext` and the per-extension pass-through commands. It lives with the manager, under the same no-host-imports rule, so it is extracted with it and another CLI really does adopt the feature with one call. `src/commands/extension/index.ts` is the usual group-command entry point and does nothing but call it.
+- `src/lib/extensions/`: `createExtensionManager({ binName, dataDir, stateDir, envPrefix, reservedNames, officialSource })` returning discover, install (GitHub git/binary, local), list, upgrade, remove, dispatch, where `officialSource` is `{ host: 'github.com', owner: 'Doist' }`. Nothing in it may import from `src/commands/` or read `td`-specific config directly: every host-specific value comes in through that options object, and its only dependencies are Node built-ins, what `@doist/cli-core` already exports, `commander` as a type, and zod. That is what makes the later move to cli-core a file move rather than a rewrite. Zod validates the manifests and the state file — all three are hand-written, two of them by people the CLI does not control — and is behind a dynamic import so that importing a validation library is never on the way to `--version`.
+- `src/lib/extensions/commands.ts`: `registerExtensionCommands(program, manager)` adding `extension` / `ext` and the per-extension pass-through commands. It lives with the manager, under the same no-host-imports rule, so it is extracted with it and another CLI really does adopt the feature with one call. It also exports the two halves separately — `registerExtensionGroup` and `registerExtensionPassThrough` — because they sit on different startup paths: the group is loaded only for `td extension …`, while the pass-through commands are needed whenever the command token is not a built-in. `src/commands/extension/index.ts` is the usual group-command entry point and does nothing but decide the td-specific values and call it.
 - Wire it in `src/index.ts`; add `TD_USER` env support to the user resolver; adjust `--user` stripping; add the unknown-command hint; doctor checks; `SKILL_CONTENT` entries for `td extension …`; `CODEBASE.md` registration-pattern update.
 - Trust warning on install/upgrade. Checksum verification when a checksums asset exists. `✓ Todoist` marker in `list`.
 - Windows is best effort in this phase: the path-file local install, the Node-shebang shortcut, the `sh.exe` fallback, and `.exe` asset matching are all specified and implemented, but the release does not wait on a full Windows pass. `td doctor` reports extensions as experimental on Windows until that pass is done.
@@ -366,10 +377,7 @@ An unknown command that is not an extension keeps Commander's current message, w
 2. **First-party marker, yes.** Extensions whose install source is the `Doist` organisation on `github.com` (host and owner both checked) show `✓ Todoist` in `list` (and `search` when that ships) and `official: true` in `--json`. The host and owner pair is a single constant, to be updated when the organisation is renamed. The trust warning is still printed for them.
 3. **Windows is best effort in phase 1.** All Windows paths are specified and implemented, but the first release does not wait on a full Windows test pass. `doctor` labels extensions experimental on Windows until phase 2 completes that pass.
 4. **The name is `extension`.** With `ext` as the alias, as the Terminology section says. `plugin` is not used anywhere in code, commands, or docs.
-
-## Open questions
-
-1. **Telemetry.** `setActiveCommandPath` records `td <command>` for usage tracking. Proposal: record `td extension` for third-party extensions without the name, and the full name for Todoist-owned ones, mirroring `gh`. Not decided yet; phase 1 can ship without recording extension runs at all.
+5. **Extension runs are not recorded.** `setActiveCommandPath` exists to populate the `cli-command` header on outbound Todoist API requests, and dispatching an extension makes no such request — `td` spawns a child and waits. There is nothing to tag, and recording a synthetic path would need a transport this CLI does not have. The data arrives anyway: an extension that wants Todoist data calls `td … --json`, and that nested process reports its own real command path. If attribution is wanted later, the nested process can add a header of its own when it sees `TD_EXTENSION` in its environment, which needs no decision from the parent. `td extension install|list|…` are ordinary commands and are recorded normally.
 
 ## References
 

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -28,7 +28,7 @@ metadata:
 - Mutating commands support `--dry-run` to preview actions without executing them.
 - Destructive commands typically require `--yes`.
 - `--quiet` / `-q` suppresses success messages. Create commands still print the bare ID for scripting (e.g. `id=$(td task add "Buy milk" --quiet)`).
-- Global flags: `--no-spinner`, `--progress-jsonl`, `-v/--verbose`, `--accessible`, `--quiet`, `--user <id|email>`.
+- Global flags: `--no-spinner`, `--progress-jsonl`, `-v/--verbose`, `--accessible`, `--quiet`, `--user <id|email>`. `TD_USER` is read as the fallback for `--user`.
 
 ## Authentication
 
@@ -82,12 +82,13 @@ td accounts use <id|email>             # set the default account (alias: td acco
 td accounts current                    # show the active account (--json/--ndjson supported)
 td accounts remove <id|email>          # delete an account and its token (--json/--ndjson supported)
 td --user <id|email> task list         # one-off override for any command
+TD_USER=<id|email> td task list        # same, for every nested call in a script
 td auth logout --user <id|email>       # log out a specific account
 ```
 
 `td accounts` is also available as `td user` / `td users` (back-compat aliases).
 
-Resolution order: `--user <ref>` > `user.defaultUser` from config > the only stored account. With multiple accounts and no default, commands error and ask for `--user` (or `td accounts use`). `<ref>` matches an exact id or email (case-insensitive on email). `TODOIST_API_TOKEN` still bypasses the resolver entirely.
+Resolution order: `--user <ref>` > `TD_USER` > `user.defaultUser` from config > the only stored account. With multiple accounts and no default, commands error and ask for `--user` (or `td accounts use`). `<ref>` matches an exact id or email (case-insensitive on email). `TODOIST_API_TOKEN` still bypasses the resolver entirely.
 
 ## Quick Reference
 
@@ -100,6 +101,7 @@ Resolution order: `--user <ref>` > `user.defaultUser` from config > the only sto
 - Templates and files: `td template ...`, `td attachment view <file-url>`, `td backup ...`
 - Help Center: `td hc locales/search/view`
 - Account and tooling: `td stats`, `td settings ...`, `td config view`, `td accounts ...`, `td completion ...`, `td view <todoist-url>`, `td doctor`, `td update`, `td changelog`
+- Extensions: `td extension install/list/upgrade/remove/exec` (alias: `td ext`)
 - Developer apps: `td apps list/view` (requires `td auth login --additional-scopes=app-management`)
 - Backups: `td backup list/download` (requires `td auth login --additional-scopes=backups`)
 - Billing: `td billing subscription/plan/prices/pricing` (requires `td auth login --additional-scopes=billing`)
@@ -391,6 +393,27 @@ td billing pricing --formatted
 The `billing` command surface is **read-only** and requires the `billing` OAuth scope — re-run `td auth login --additional-scopes=billing` to grant it. A normal login grants `billing:read_write`; adding `--read-only` narrows it to `billing:read`. Either satisfies these read commands. Without the scope, calls fail with a `MISSING_SCOPE` error whose hint preserves any previously used flags. All subcommands accept `--json` / `--ndjson`, which dump the raw SDK payload verbatim.
 
 `td billing subscription` (the default subcommand) shows the current plan, status, activation method, expiration date, plan price, invoice credit balance, and billing-portal URLs when present. `td billing plan` shows Pro plan status, downgrade date, and the per-cycle price list. `td billing prices` lists available Pro and Teams prices by billing cycle. `td billing pricing` shows current and legacy pricing keyed by version; `--formatted` returns localized price strings instead of minor-unit numbers.
+
+### Extensions
+
+An extension is an executable named `td-<name>` that td runs as `td <name> ...`. It can be written in any language; the contract is the process boundary, not a JavaScript API.
+
+```bash
+td extension install owner/td-goals    # from a GitHub release or a clone
+td extension install --pin v0.3.0 owner/td-goals
+td extension install ./td-scratch      # a local directory, symlinked, for development
+td extension list                      # --json for the full record of each one
+td extension upgrade --all             # --dry-run to preview; --force to pass a pin
+td extension remove goals              # --force for a clone with uncommitted changes
+td extension exec goals list --json    # bypass the built-in commands entirely
+```
+
+Two rules matter when calling one:
+
+- Everything after the extension name is passed through untouched. `td goals --json` is `--json` for `goals`, not for td. Global flags only apply before the name: `td --user alice goals list`.
+- td exits with the extension's exit code.
+
+An extension is not reviewed or endorsed by Todoist, and runs with the user's own permissions.
 
 ### Settings, Stats, And Utilities
 ```bash

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -25,7 +25,7 @@ export const SKILL_CONTENT = `# Todoist CLI (td)
 - Mutating commands support \`--dry-run\` to preview actions without executing them.
 - Destructive commands typically require \`--yes\`.
 - \`--quiet\` / \`-q\` suppresses success messages. Create commands still print the bare ID for scripting (e.g. \`id=$(td task add "Buy milk" --quiet)\`).
-- Global flags: \`--no-spinner\`, \`--progress-jsonl\`, \`-v/--verbose\`, \`--accessible\`, \`--quiet\`, \`--user <id|email>\`.
+- Global flags: \`--no-spinner\`, \`--progress-jsonl\`, \`-v/--verbose\`, \`--accessible\`, \`--quiet\`, \`--user <id|email>\`. \`TD_USER\` is read as the fallback for \`--user\`.
 
 ## Authentication
 
@@ -79,12 +79,13 @@ td accounts use <id|email>             # set the default account (alias: td acco
 td accounts current                    # show the active account (--json/--ndjson supported)
 td accounts remove <id|email>          # delete an account and its token (--json/--ndjson supported)
 td --user <id|email> task list         # one-off override for any command
+TD_USER=<id|email> td task list        # same, for every nested call in a script
 td auth logout --user <id|email>       # log out a specific account
 \`\`\`
 
 \`td accounts\` is also available as \`td user\` / \`td users\` (back-compat aliases).
 
-Resolution order: \`--user <ref>\` > \`user.defaultUser\` from config > the only stored account. With multiple accounts and no default, commands error and ask for \`--user\` (or \`td accounts use\`). \`<ref>\` matches an exact id or email (case-insensitive on email). \`TODOIST_API_TOKEN\` still bypasses the resolver entirely.
+Resolution order: \`--user <ref>\` > \`TD_USER\` > \`user.defaultUser\` from config > the only stored account. With multiple accounts and no default, commands error and ask for \`--user\` (or \`td accounts use\`). \`<ref>\` matches an exact id or email (case-insensitive on email). \`TODOIST_API_TOKEN\` still bypasses the resolver entirely.
 
 ## Quick Reference
 
@@ -97,6 +98,7 @@ Resolution order: \`--user <ref>\` > \`user.defaultUser\` from config > the only
 - Templates and files: \`td template ...\`, \`td attachment view <file-url>\`, \`td backup ...\`
 - Help Center: \`td hc locales/search/view\`
 - Account and tooling: \`td stats\`, \`td settings ...\`, \`td config view\`, \`td accounts ...\`, \`td completion ...\`, \`td view <todoist-url>\`, \`td doctor\`, \`td update\`, \`td changelog\`
+- Extensions: \`td extension install/list/upgrade/remove/exec\` (alias: \`td ext\`)
 - Developer apps: \`td apps list/view\` (requires \`td auth login --additional-scopes=app-management\`)
 - Backups: \`td backup list/download\` (requires \`td auth login --additional-scopes=backups\`)
 - Billing: \`td billing subscription/plan/prices/pricing\` (requires \`td auth login --additional-scopes=billing\`)
@@ -388,6 +390,27 @@ td billing pricing --formatted
 The \`billing\` command surface is **read-only** and requires the \`billing\` OAuth scope — re-run \`td auth login --additional-scopes=billing\` to grant it. A normal login grants \`billing:read_write\`; adding \`--read-only\` narrows it to \`billing:read\`. Either satisfies these read commands. Without the scope, calls fail with a \`MISSING_SCOPE\` error whose hint preserves any previously used flags. All subcommands accept \`--json\` / \`--ndjson\`, which dump the raw SDK payload verbatim.
 
 \`td billing subscription\` (the default subcommand) shows the current plan, status, activation method, expiration date, plan price, invoice credit balance, and billing-portal URLs when present. \`td billing plan\` shows Pro plan status, downgrade date, and the per-cycle price list. \`td billing prices\` lists available Pro and Teams prices by billing cycle. \`td billing pricing\` shows current and legacy pricing keyed by version; \`--formatted\` returns localized price strings instead of minor-unit numbers.
+
+### Extensions
+
+An extension is an executable named \`td-<name>\` that td runs as \`td <name> ...\`. It can be written in any language; the contract is the process boundary, not a JavaScript API.
+
+\`\`\`bash
+td extension install owner/td-goals    # from a GitHub release or a clone
+td extension install --pin v0.3.0 owner/td-goals
+td extension install ./td-scratch      # a local directory, symlinked, for development
+td extension list                      # --json for the full record of each one
+td extension upgrade --all             # --dry-run to preview; --force to pass a pin
+td extension remove goals              # --force for a clone with uncommitted changes
+td extension exec goals list --json    # bypass the built-in commands entirely
+\`\`\`
+
+Two rules matter when calling one:
+
+- Everything after the extension name is passed through untouched. \`td goals --json\` is \`--json\` for \`goals\`, not for td. Global flags only apply before the name: \`td --user alice goals list\`.
+- td exits with the extension's exit code.
+
+An extension is not reviewed or endorsed by Todoist, and runs with the user's own permissions.
 
 ### Settings, Stats, And Utilities
 \`\`\`bash


### PR DESCRIPTION
Adds an Extensions section to SKILL_CONTENT, with the two rules an agent has to know: everything after the extension name is forwarded verbatim, and td exits with the extension's exit code. Regenerates SKILL.md.

CODEBASE.md gains the argv token scan, the discovery gate and the pre-parse dispatch in the architecture flow, the pass-through command pattern beside the flat and group ones, and the new lib modules.

The spec catches up with what was built. `passThroughOptions` is recorded as unusable, with the reason, so nobody reaches for it again. Discovery is described as gated rather than unconditional. The manifest examples carry `manifestVersion`, and the paragraph claiming the extensions directory depends only on Node built-ins and cli-core is corrected — zod is a dependency, behind a dynamic import. Telemetry moves from the open question it was to a decision: there is no outbound request to tag when td spawns a child and waits, and the nested td calls an extension makes already report their own command paths.

## Trying it out

This is the top of the stack, so this branch has the whole feature. None of the earlier PRs is usable on its own.

```bash
git checkout feat/ext-cmd-9-docs
npm ci && npm run build && npm link
td extension install scottlovegrove/td-hello
```

Then:

```bash
td hello                              # runs it
td hello Scott --json                 # arguments pass through untouched
td hello --help                       # the extension answers, not td
td --help                             # lists it under "Extensions:"
td extension list                     # NAME / SOURCE / VERSION / KIND / OFFICIAL
td extension upgrade --all --dry-run
td doctor                             # reports on what is installed
td extension remove hello
```

`--user` before the name is td's and reaches the extension as `TD_USER`; after the name it belongs to the extension:

```bash
td --user you@example.com hello --json   # "actingAs": "you@example.com"
td hello --json --user someone           # "actingAs": null, flag passed through
TD_USER=you@example.com td hello --json  # "actingAs": "you@example.com"
```

Two caveats. `npm link` replaces your installed `td`, and the install writes to your real `~/.local/share/todoist-cli/extensions`. To keep it contained, skip the link and point the directories somewhere scratch:

```bash
XDG_DATA_HOME=/tmp/td-ext/data XDG_STATE_HOME=/tmp/td-ext/state \
  node dist/index.js extension install scottlovegrove/td-hello
```

Undo with `td extension remove hello`, then `npm unlink -g @doist/todoist-cli && npm i -g @doist/todoist-cli`.

`scottlovegrove/td-hello` ships no release assets, so it installs as a git clone — which is why `list` shows a short SHA rather than a tag. The release-binary and checksum paths have unit tests but no extension publishing real assets to try them against yet.
