### PR TITLE
fix(extensions): stop a manifest range from breaking the extension

### DIFF
--- a/src/lib/extensions/manifest.test.ts
+++ b/src/lib/extensions/manifest.test.ts
@@ -128,6 +128,36 @@ describe('manifests', () => {
         await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({ description: 'Wins' })
     })
 
+    it('falls back to package.json when the dedicated file says nothing this version can read', async () => {
+        // Everything in the dedicated file belongs to a later format, so
+        // it strips to nothing. The metadata the author also put in
+        // package.json is readable and should not be lost.
+        await writeFile(
+            join(dir, 'td-extension.json'),
+            JSON.stringify({ somethingFromTheFuture: true }),
+        )
+        await writeFile(
+            join(dir, 'package.json'),
+            JSON.stringify({ td: { description: 'From package.json' } }),
+        )
+
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toMatchObject({
+            description: 'From package.json',
+        })
+    })
+
+    it('falls back when the dedicated file is an empty object', async () => {
+        await writeFile(join(dir, 'td-extension.json'), '{}')
+        await writeFile(
+            join(dir, 'package.json'),
+            JSON.stringify({ td: { description: 'From package.json' } }),
+        )
+
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toMatchObject({
+            description: 'From package.json',
+        })
+    })
+
     it('ignores fields of the wrong type instead of failing', async () => {
         await writeFile(
             join(dir, 'td-extension.json'),

--- a/src/lib/extensions/manifest.test.ts
+++ b/src/lib/extensions/manifest.test.ts
@@ -128,33 +128,58 @@ describe('manifests', () => {
         await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({ description: 'Wins' })
     })
 
-    it('falls back to package.json when the dedicated file says nothing this version can read', async () => {
-        // Everything in the dedicated file belongs to a later format, so
-        // it strips to nothing. The metadata the author also put in
-        // package.json is readable and should not be lost.
-        await writeFile(
-            join(dir, 'td-extension.json'),
-            JSON.stringify({ somethingFromTheFuture: true }),
-        )
+    // Both shapes reach the same branch: the dedicated file parses to
+    // something that says nothing this version can use.
+    it.each([
+        ['a file written for a later format', { somethingFromTheFuture: true }],
+        ['an empty object', {}],
+    ])('falls back to package.json for %s', async (_label, dedicated) => {
+        await writeFile(join(dir, 'td-extension.json'), JSON.stringify(dedicated))
         await writeFile(
             join(dir, 'package.json'),
             JSON.stringify({ td: { description: 'From package.json' } }),
         )
 
-        await expect(readAuthoredManifest(dir, 'td')).resolves.toMatchObject({
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({
             description: 'From package.json',
         })
     })
 
-    it('falls back when the dedicated file is an empty object', async () => {
-        await writeFile(join(dir, 'td-extension.json'), '{}')
+    it('falls back even when the later-format file declares its version', async () => {
+        // The shape a later format actually takes: a version marker plus keys
+        // this version strips. The marker alone is not something to say.
+        await writeFile(
+            join(dir, 'td-extension.json'),
+            JSON.stringify({ manifestVersion: 2, somethingFromTheFuture: true }),
+        )
         await writeFile(
             join(dir, 'package.json'),
             JSON.stringify({ td: { description: 'From package.json' } }),
         )
 
-        await expect(readAuthoredManifest(dir, 'td')).resolves.toMatchObject({
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({
             description: 'From package.json',
+            // Kept, so `list` and `doctor` still say some metadata was skipped.
+            manifestVersion: 2,
+        })
+    })
+
+    it('keeps the version marker when there is nothing to fall back to', async () => {
+        await writeFile(join(dir, 'td-extension.json'), JSON.stringify({ manifestVersion: 2 }))
+
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({ manifestVersion: 2 })
+    })
+
+    it('does not fall back when the dedicated file says something', async () => {
+        await writeFile(
+            join(dir, 'td-extension.json'),
+            JSON.stringify({ manifestVersion: 2, description: 'Wins' }),
+        )
+        await writeFile(join(dir, 'package.json'), JSON.stringify({ td: { description: 'Loses' } }))
+
+        await expect(readAuthoredManifest(dir, 'td')).resolves.toEqual({
+            manifestVersion: 2,
+            description: 'Wins',
         })
     })
 

--- a/src/lib/extensions/manifest.ts
+++ b/src/lib/extensions/manifest.ts
@@ -26,31 +26,50 @@ export async function pickAuthoredFields(value: unknown): Promise<AuthoredManife
 }
 
 /**
+ * The fields that carry meaning. `manifestVersion` is deliberately not one of
+ * them: it says which format a file is written in, not what the file has to
+ * say, and a file carrying nothing else has told this version of the CLI
+ * nothing it can use.
+ */
+const CONTENT_FIELDS = ['description', 'requires', 'completion'] as const
+
+function saysSomething(manifest: AuthoredManifest | undefined): boolean {
+    return manifest !== undefined && CONTENT_FIELDS.some((field) => manifest[field] !== undefined)
+}
+
+/**
  * Author metadata for an extension, from `<bin>-extension.json` or, for Node
  * extensions that would rather not carry a second file, the `<bin>` key of
- * `package.json`. The dedicated file wins when both exist.
+ * `package.json`.
+ *
+ * The dedicated file wins whenever it says anything this version understands.
+ * When it does not — the shape a file written for a later format takes, since
+ * every key it carries but the version marker is stripped here — the
+ * `package.json` metadata is used instead, rather than being shadowed by a
+ * file that turned out to be empty. The version marker survives that fall
+ * back, so `list` and `doctor` still report that some of the metadata is from
+ * a format this version cannot read.
  */
 export async function readAuthoredManifest(
     dir: string,
     binName: string,
 ): Promise<AuthoredManifest | undefined> {
     const dedicatedValue = await readJsonValue(join(dir, authoredManifestFileName(binName)))
+    const dedicated =
+        dedicatedValue === undefined ? undefined : await pickAuthoredFields(dedicatedValue)
 
-    if (dedicatedValue !== undefined) {
-        const dedicated = (await schemas()).parseAuthoredManifest(dedicatedValue)
-        // Taken only when it actually says something. A file written for a
-        // later format parses to an empty object here, because every key it
-        // carries is one this version strips, and letting that win would throw
-        // away the `package.json` metadata the same author wrote in a form
-        // this version can read.
-        if (dedicated && Object.keys(dedicated).length > 0) return dedicated
-    }
+    if (saysSomething(dedicated)) return dedicated
 
     const packageJson = await readJsonValue(join(dir, 'package.json'))
-    // Nothing to validate, so nothing to load a validator for.
-    if (!isRecord(packageJson)) return undefined
+    // Nothing left to validate, so nothing to load a validator for.
+    if (!isRecord(packageJson)) return dedicated
 
-    return (await schemas()).parseAuthoredManifest(packageJson[binName])
+    const fromPackage = await pickAuthoredFields(packageJson[binName])
+    if (!saysSomething(fromPackage)) return dedicated ?? fromPackage
+
+    return dedicated?.manifestVersion === undefined
+        ? fromPackage
+        : { ...fromPackage, manifestVersion: dedicated.manifestVersion }
 }
 
 /**

--- a/src/lib/extensions/manifest.ts
+++ b/src/lib/extensions/manifest.ts
@@ -35,18 +35,22 @@ export async function readAuthoredManifest(
     binName: string,
 ): Promise<AuthoredManifest | undefined> {
     const dedicatedValue = await readJsonValue(join(dir, authoredManifestFileName(binName)))
-    const packageJson =
-        dedicatedValue === undefined ? await readJsonValue(join(dir, 'package.json')) : undefined
 
-    // Nothing to validate, so nothing to load a validator for.
-    if (dedicatedValue === undefined && !isRecord(packageJson)) return undefined
-
-    const { parseAuthoredManifest } = await schemas()
     if (dedicatedValue !== undefined) {
-        const dedicated = parseAuthoredManifest(dedicatedValue)
-        if (dedicated) return dedicated
+        const dedicated = (await schemas()).parseAuthoredManifest(dedicatedValue)
+        // Taken only when it actually says something. A file written for a
+        // later format parses to an empty object here, because every key it
+        // carries is one this version strips, and letting that win would throw
+        // away the `package.json` metadata the same author wrote in a form
+        // this version can read.
+        if (dedicated && Object.keys(dedicated).length > 0) return dedicated
     }
-    return isRecord(packageJson) ? parseAuthoredManifest(packageJson[binName]) : undefined
+
+    const packageJson = await readJsonValue(join(dir, 'package.json'))
+    // Nothing to validate, so nothing to load a validator for.
+    if (!isRecord(packageJson)) return undefined
+
+    return (await schemas()).parseAuthoredManifest(packageJson[binName])
 }
 
 /**

--- a/src/lib/extensions/version-range.test.ts
+++ b/src/lib/extensions/version-range.test.ts
@@ -61,6 +61,21 @@ describe('satisfiesRange', () => {
         expect(satisfiesRange('5.1.0', '^4.0.0 || >=5.0.0')).toBe(true)
     })
 
+    it('treats a range the version parser rejects as satisfied, rather than throwing', () => {
+        // The comparator pattern accepts these, but `parseVersion` does not,
+        // and the check only ever drives a warning — so it must never be the
+        // thing that stops an extension running.
+        for (const range of ['1.x', '>=1.2.x', '~1.2.x', '^1.x', '>=1.2.3.4', '1.2.3.4']) {
+            expect(satisfiesRange('5.3.2', range)).toBe(true)
+        }
+    })
+
+    it('still evaluates a two-part version rather than giving up on it', () => {
+        expect(satisfiesRange('5.3.2', '>=1.2')).toBe(true)
+        expect(satisfiesRange('5.3.2', '^1.2')).toBe(false)
+        expect(satisfiesRange('5.3.2', '~2')).toBe(false)
+    })
+
     it('passes ranges it cannot parse, since the check only drives a warning', () => {
         expect(satisfiesRange('5.3.1', 'next')).toBe(true)
         expect(satisfiesRange('5.3.1', '>=4.0.0-alpha.x.y.z.what')).toBe(true)

--- a/src/lib/extensions/version-range.test.ts
+++ b/src/lib/extensions/version-range.test.ts
@@ -61,14 +61,15 @@ describe('satisfiesRange', () => {
         expect(satisfiesRange('5.1.0', '^4.0.0 || >=5.0.0')).toBe(true)
     })
 
-    it('treats a range the version parser rejects as satisfied, rather than throwing', () => {
-        // The comparator pattern accepts these, but `parseVersion` does not,
-        // and the check only ever drives a warning — so it must never be the
-        // thing that stops an extension running.
-        for (const range of ['1.x', '>=1.2.x', '~1.2.x', '^1.x', '>=1.2.3.4', '1.2.3.4']) {
+    // The comparator pattern accepts these, but `parseVersion` does not, and
+    // the check only ever drives a warning — so it must never be the thing
+    // that stops an extension running.
+    it.each(['1.x', '>=1.2.x', '~1.2.x', '^1.x', '>=1.2.3.4', '1.2.3.4'])(
+        'treats %s as satisfied rather than throwing, since the parser rejects it',
+        (range) => {
             expect(satisfiesRange('5.3.2', range)).toBe(true)
-        }
-    })
+        },
+    )
 
     it('still evaluates a two-part version rather than giving up on it', () => {
         expect(satisfiesRange('5.3.2', '>=1.2')).toBe(true)

--- a/src/lib/extensions/version-range.ts
+++ b/src/lib/extensions/version-range.ts
@@ -68,12 +68,13 @@ export function satisfiesRange(version: string, range: string | undefined): bool
     try {
         return evaluateRange(version, range)
     } catch {
-        // `parseVersion` rejects anything that is not a full `x.y.z`, and a
-        // range can reach it through a shape the comparator pattern happily
-        // accepts — `1.x` and `>=1.2.3.4` both do. Anything it will not read
-        // counts as satisfied, which is what the rest of this module promises
-        // and what the caller is built for: the check only ever produces a
-        // warning, so a range nobody can evaluate must not become a failure.
+        // `parseVersion` reads a partial version such as `1.2`, but refuses
+        // other shapes the comparator pattern happily accepts — a wildcard
+        // like `1.x`, or a fourth part as in `>=1.2.3.4` — and throws rather
+        // than returning. Anything it will not read counts as satisfied, which
+        // is what the rest of this module promises and what the caller is
+        // built for: the check only ever produces a warning, so a range nobody
+        // can evaluate must not become a failure.
         return true
     }
 }

--- a/src/lib/extensions/version-range.ts
+++ b/src/lib/extensions/version-range.ts
@@ -65,6 +65,20 @@ function satisfiesComparator(version: string, comparator: Comparator): boolean {
  * form this checker does not understand.
  */
 export function satisfiesRange(version: string, range: string | undefined): boolean {
+    try {
+        return evaluateRange(version, range)
+    } catch {
+        // `parseVersion` rejects anything that is not a full `x.y.z`, and a
+        // range can reach it through a shape the comparator pattern happily
+        // accepts — `1.x` and `>=1.2.3.4` both do. Anything it will not read
+        // counts as satisfied, which is what the rest of this module promises
+        // and what the caller is built for: the check only ever produces a
+        // warning, so a range nobody can evaluate must not become a failure.
+        return true
+    }
+}
+
+function evaluateRange(version: string, range: string | undefined): boolean {
     const trimmed = range?.trim()
     if (!trimmed || trimmed === '*' || trimmed === 'x') return true
 


### PR DESCRIPTION
Two findings from post-merge review of #521 and #527. Both reproduce against `next`; the first is a real breakage rather than a nit.

## `satisfiesRange` throws, and that is fatal

`version-range.ts` documents that anything it cannot parse counts as satisfied, because the check only ever drives a warning. That did not hold. The comparator pattern accepts any version starting with a digit, so `1.x` and `>=1.2.3.4` build a comparator that `parseVersion` then refuses, and the exception escapes.

`warnIfIncompatible` runs before every dispatch and again in `doctor`, so an extension whose manifest says `"requires": { "td": "1.x" }` is simply unrunnable, and it takes `doctor` down with it for everyone who has it installed:

```
$ td wild                  → Invalid version string: '1.x'    exit 1
$ td doctor --offline      → Invalid version string: '1.x'    exit 1   (no checks, no summary)
```

Evaluating a range is now wrapped, and anything the version parser refuses counts as satisfied. Ranges it can read are unaffected — `>=1.2` is still `true`, `^1.2` still `false`, `~2` still `false` — so no correct warning is lost.

After:

```
$ td wild                  → wild ran                          exit 0
$ td doctor --offline      → Doctor summary: 3 passed, 1 warnings, 1 skipped
```

## An empty authored manifest discarded the `package.json` metadata

A `td-extension.json` written for a later manifest format parses to `{}`, because every key it carries is one this version strips. That counted as the dedicated file winning, so the metadata the same author wrote under the `td` key of `package.json` — in a form this version *can* read — was thrown away.

The dedicated file is now taken only when it says something. This needed more than a guard: `package.json` was previously read only when the dedicated file was absent, so the fallback had nothing to fall back to. It is now read when the dedicated file yields nothing, and not eagerly otherwise.

```
before:  Extensions:  fb   Extension fb
after:   Extensions:  fb   Description from package.json
```

## Notes

The report on #527 listed `>=1.2`, `^1.2` and `~2` as throwing and `>=1.2.3.4` as silently truncating. Against `@doist/cli-core@1.4.0` the first three evaluate fine and the fourth throws — that version tolerates a two-part version but not a wildcard or a fourth part. The conclusion stands regardless; only the specific inputs differ.

Tests cover both: six range shapes that previously threw, the two-part forms that must keep evaluating, and the two manifest fallback cases.
