### PR TITLE
feat(extensions): scaffold a new extension with `td extension create`

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -60,6 +60,11 @@ src/
                           #  from @doist/cli-core/testing)
 ```
 
+Scaffold templates for `td extension create` are real files under
+`templates/extension/<kind>/`, shipped via the `files` field rather than
+compiled in, and resolved relative to `import.meta.url` so the same path works
+from `src/` under vitest and from `dist/` in an install.
+
 ## Architecture flow
 
 1. `src/index.ts` sets `program.name('td')`, registers global flags
@@ -150,8 +155,8 @@ New subcommand? Copy a sibling in the target group, wire it in that group's
   (`createExtensionManager`, the only entry point a host needs), `commands.ts`
   (`registerExtensionGroup` for `td extension …`, `registerExtensionPassThrough`
   for the per-extension commands), plus `discover`, `install`, `upgrade`,
-  `remove`, `dispatch`, `github`, `git`, `npm`, `manifest`, `schemas`,
-  `state`, `source`, `version-range`, `run`, `fs-utils`.
+  `remove`, `dispatch`, `create`, `github`, `git`, `npm`, `manifest`,
+  `schemas`, `state`, `source`, `version-range`, `run`, `fs-utils`.
   Host-agnostic by design: the binary name, directories, version, reserved
   command names and first-party source all arrive through the manager's
   options, and nothing in the directory imports from the rest of the repo, so

--- a/docs/specs/extensions.md
+++ b/docs/specs/extensions.md
@@ -334,7 +334,7 @@ An unknown command that is not an extension keeps Commander's current message, w
 6. Compiled authors: publish release assets named `td-<name>_<tag>_<platform>-<arch>[.exe]` for at least `linux-x64`, `darwin-arm64`, `darwin-x64`, `win32-x64`, plus a `checksums.txt`.
 7. Test locally with `td extension install .` from a directory named `td-<name>` and iterate; the symlink means every edit is live.
 
-`td extension create <name> [--template node|bash|compiled]` (phase 2) scaffolds all of this, including the release workflow for compiled extensions.
+`td extension create <name> [--template bash|node]` scaffolds all of this. The templates are real files under `templates/extension/`, shipped with the package rather than compiled in, so they can be read, linted and run as what they are; a CLI adopting this directory brings its own. A `compiled` template carrying the release workflow is still to come.
 
 ## Phasing
 
@@ -350,7 +350,7 @@ An unknown command that is not an extension keeps Commander's current message, w
 
 ### Phase 2 — ergonomics
 
-- `td extension create` scaffolding with three templates and a release workflow for compiled extensions.
+- `td extension create` scaffolding. The `bash` and `node` templates are done; the `compiled` one, with the release workflow that names assets so `pickAsset` can find them, is not.
 - `td extension search` over the `td-extension` topic.
 - Non-blocking update notice after an extension runs, at most once per 24 hours, suppressed in CI and non-TTY. Same rules as `gh`.
 - `TD_EXTENSION` handling in `td` itself: skip the `td update` nag when running as a nested call.

--- a/package.json
+++ b/package.json
@@ -1,80 +1,81 @@
 {
-  "name": "@doist/todoist-cli",
-  "version": "5.3.2",
-  "description": "TypeScript CLI for Todoist",
-  "type": "module",
-  "main": "dist/index.js",
-  "bin": {
-    "td": "dist/index.js"
-  },
-  "scripts": {
-    "build": "tsc -p tsconfig.build.json",
-    "dev": "tsc -p tsconfig.build.json --watch",
-    "start": "node dist/index.js",
-    "type-check": "tsc --noEmit",
-    "check": "oxlint src && oxfmt --check",
-    "fix": "oxlint src --fix && oxfmt",
-    "postinstall": "node scripts/postinstall.js",
-    "check:skill-sync": "node scripts/check-skill-sync.js",
-    "sync:skill": "npm run build && node scripts/sync-skill.js",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "prepublishOnly": "npm run build && npm test"
-  },
-  "keywords": [
-    "todoist",
-    "cli",
-    "todo",
-    "tasks"
-  ],
-  "author": "Ernesto García <ernesto@ernesto.dev>",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Doist/todoist-cli.git"
-  },
-  "homepage": "https://github.com/Doist/todoist-cli#readme",
-  "bugs": {
-    "url": "https://github.com/Doist/todoist-cli/issues"
-  },
-  "preferGlobal": true,
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  },
-  "engines": {
-    "node": ">=24",
-    "npm": ">=11"
-  },
-  "files": [
-    "dist",
-    "scripts",
-    "CHANGELOG.md"
-  ],
-  "dependencies": {
-    "@doist/cli-core": "1.4.0",
-    "@doist/todoist-sdk": "15.2.0",
-    "@napi-rs/keyring": "2.0.0",
-    "@pnpm/tabtab": "0.5.4",
-    "chalk": "6.0.0",
-    "commander": "15.0.0",
-    "date-fns": "4.4.0",
-    "marked": "18.0.11",
-    "marked-terminal-renderer": "2.2.0",
-    "oauth4webapi": "3.8.8",
-    "open": "11.0.2",
-    "zod": "4.3.6"
-  },
-  "devDependencies": {
-    "@semantic-release/changelog": "7.0.0",
-    "@semantic-release/git": "11.0.1",
-    "@types/node": "25.9.5",
-    "conventional-changelog-conventionalcommits": "9.3.1",
-    "lefthook": "2.1.12",
-    "oxfmt": "0.66.0",
-    "oxlint": "1.81.0",
-    "semantic-release": "25.0.9",
-    "typescript": "7.0.2",
-    "vitest": "5.0.0"
-  }
+    "name": "@doist/todoist-cli",
+    "version": "5.3.2",
+    "description": "TypeScript CLI for Todoist",
+    "type": "module",
+    "main": "dist/index.js",
+    "bin": {
+        "td": "dist/index.js"
+    },
+    "scripts": {
+        "build": "tsc -p tsconfig.build.json",
+        "dev": "tsc -p tsconfig.build.json --watch",
+        "start": "node dist/index.js",
+        "type-check": "tsc --noEmit",
+        "check": "oxlint src && oxfmt --check",
+        "fix": "oxlint src --fix && oxfmt",
+        "postinstall": "node scripts/postinstall.js",
+        "check:skill-sync": "node scripts/check-skill-sync.js",
+        "sync:skill": "npm run build && node scripts/sync-skill.js",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "prepublishOnly": "npm run build && npm test"
+    },
+    "keywords": [
+        "todoist",
+        "cli",
+        "todo",
+        "tasks"
+    ],
+    "author": "Ernesto Garc\u00eda <ernesto@ernesto.dev>",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Doist/todoist-cli.git"
+    },
+    "homepage": "https://github.com/Doist/todoist-cli#readme",
+    "bugs": {
+        "url": "https://github.com/Doist/todoist-cli/issues"
+    },
+    "preferGlobal": true,
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
+    },
+    "engines": {
+        "node": ">=24",
+        "npm": ">=11"
+    },
+    "files": [
+        "CHANGELOG.md",
+        "dist",
+        "scripts",
+        "templates"
+    ],
+    "dependencies": {
+        "@doist/cli-core": "1.4.0",
+        "@doist/todoist-sdk": "15.2.0",
+        "@napi-rs/keyring": "2.0.0",
+        "@pnpm/tabtab": "0.5.4",
+        "chalk": "6.0.0",
+        "commander": "15.0.0",
+        "date-fns": "4.4.0",
+        "marked": "18.0.11",
+        "marked-terminal-renderer": "2.2.0",
+        "oauth4webapi": "3.8.8",
+        "open": "11.0.2",
+        "zod": "4.3.6"
+    },
+    "devDependencies": {
+        "@semantic-release/changelog": "7.0.0",
+        "@semantic-release/git": "11.0.1",
+        "@types/node": "25.9.5",
+        "conventional-changelog-conventionalcommits": "9.3.1",
+        "lefthook": "2.1.12",
+        "oxfmt": "0.66.0",
+        "oxlint": "1.81.0",
+        "semantic-release": "25.0.9",
+        "typescript": "7.0.2",
+        "vitest": "5.0.0"
+    }
 }

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -101,7 +101,7 @@ Resolution order: `--user <ref>` > `TD_USER` > `user.defaultUser` from config > 
 - Templates and files: `td template ...`, `td attachment view <file-url>`, `td backup ...`
 - Help Center: `td hc locales/search/view`
 - Account and tooling: `td stats`, `td settings ...`, `td config view`, `td accounts ...`, `td completion ...`, `td view <todoist-url>`, `td doctor`, `td update`, `td changelog`
-- Extensions: `td extension install/list/upgrade/remove/exec` (alias: `td ext`)
+- Extensions: `td extension create/install/list/upgrade/remove/exec` (alias: `td ext`)
 - Developer apps: `td apps list/view` (requires `td auth login --additional-scopes=app-management`)
 - Backups: `td backup list/download` (requires `td auth login --additional-scopes=backups`)
 - Billing: `td billing subscription/plan/prices/pricing` (requires `td auth login --additional-scopes=billing`)
@@ -399,6 +399,7 @@ The `billing` command surface is **read-only** and requires the `billing` OAuth 
 An extension is an executable named `td-<name>` that td runs as `td <name> ...`. It can be written in any language; the contract is the process boundary, not a JavaScript API.
 
 ```bash
+td extension create goals              # scaffold one (--template bash|node)
 td extension install owner/td-goals    # from a GitHub release or a clone
 td extension install --pin v0.3.0 owner/td-goals
 td extension install ./td-scratch      # a local directory, symlinked, for development

--- a/src/commands/extension/index.test.ts
+++ b/src/commands/extension/index.test.ts
@@ -4,8 +4,9 @@ import { join } from 'node:path'
 import { captureConsole, createTestProgram } from '@doist/cli-core/testing'
 import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { listTemplates } from '../../lib/extensions/create.js'
 import { writeFixtureExtension } from '../../test-support/extension-fixture.js'
-import { buildExtensionManager, registerExtensionCommand } from './index.js'
+import { buildExtensionManager, registerExtensionCommand, templatesDir } from './index.js'
 
 describe('buildExtensionManager', () => {
     let root: string
@@ -63,6 +64,15 @@ describe('buildExtensionManager', () => {
 
         const [entry] = await manager.list()
         expect(entry.shadowed).toBe(false)
+    })
+})
+
+describe('templatesDir', () => {
+    it('resolves to the templates the package actually ships', async () => {
+        // The path is relative to this module's own location, so moving the
+        // command file would break `extension create` at runtime while every
+        // test that recomputes the URL itself still passed.
+        await expect(listTemplates(templatesDir())).resolves.toEqual(['bash', 'node'])
     })
 })
 

--- a/src/commands/extension/index.test.ts
+++ b/src/commands/extension/index.test.ts
@@ -77,6 +77,7 @@ describe('registerExtensionCommand', () => {
         expect(group).toBeDefined()
         expect(group?.aliases()).toContain('ext')
         expect(group?.commands.map((command) => command.name()).sort()).toEqual([
+            'create',
             'exec',
             'install',
             'list',

--- a/src/commands/extension/index.ts
+++ b/src/commands/extension/index.ts
@@ -8,6 +8,7 @@
  */
 
 import { realpathSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import chalk from 'chalk'
 import type { Command } from 'commander'
 import packageJson from '../../../package.json' with { type: 'json' }
@@ -77,6 +78,21 @@ export function buildExtensionManager(program: Command): ExtensionManager {
     })
 }
 
+/**
+ * Where the scaffold templates live, resolved from this module rather than
+ * from the working directory.
+ *
+ * Three levels up lands on the package root from `dist/commands/extension/`
+ * and on the repository root from `src/commands/extension/`, so the same path
+ * works whether td is running from a build or from source under vitest. The
+ * directory ships because `templates` is listed in `files`.
+ */
+export function templatesDir(): string {
+    return fileURLToPath(new URL('../../../templates/extension/', import.meta.url))
+}
+
 export function registerExtensionCommand(program: Command): void {
-    registerExtensionGroup(program, buildExtensionManager(program))
+    registerExtensionGroup(program, buildExtensionManager(program), {
+        templatesDir: templatesDir(),
+    })
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -104,6 +104,7 @@ export type ErrorCode =
     | 'PROJECT_FROZEN'
     | 'SHARE_FORBIDDEN'
     // Extensions
+    | 'EXTENSION_ALREADY_EXISTS'
     | 'EXTENSION_ALREADY_INSTALLED'
     | 'EXTENSION_CHECKSUM_MISMATCH'
     | 'EXTENSION_DIRTY'
@@ -116,6 +117,7 @@ export type ErrorCode =
     | 'EXTENSION_NOT_INSTALLABLE'
     | 'EXTENSION_NPM_MISSING'
     | 'EXTENSION_PINNED'
+    | 'EXTENSION_TEMPLATE_INVALID'
     // Escape hatch for dynamic codes
     | (string & {})
 

--- a/src/lib/extensions/commands.test.ts
+++ b/src/lib/extensions/commands.test.ts
@@ -306,6 +306,34 @@ describe('registerExtensionGroup', () => {
         })
     })
 
+    it('reports what it made as JSON', async () => {
+        const templatesDir = join(root, 'templates', 'plain')
+        await mkdir(templatesDir, { recursive: true })
+        await writeFile(join(templatesDir, 'executable'), '#!/bin/sh\necho {{NAME}}\n')
+
+        const manager = makeManager()
+        const program = createTestProgram((p) => {
+            registerExtensionGroup(p, manager, { templatesDir: join(root, 'templates') })
+        })
+        const argv = ['node', 'td', 'extension', 'create', 'goals', '--json']
+        vi.spyOn(process, 'argv', 'get').mockReturnValue(argv)
+        const cwd = process.cwd()
+        process.chdir(root)
+        try {
+            await program.parseAsync(argv)
+        } finally {
+            process.chdir(cwd)
+        }
+
+        expect(JSON.parse(lines().join(''))).toEqual({
+            name: 'goals',
+            dirName: 'td-goals',
+            dir: join(root, 'td-goals'),
+            template: 'plain',
+            files: ['td-goals'],
+        })
+    })
+
     describe('install', () => {
         /** A directory the user is developing in, outside the extensions dir. */
         async function localSource(name: string): Promise<string> {

--- a/src/lib/extensions/commands.test.ts
+++ b/src/lib/extensions/commands.test.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink } from 'node:fs/promises'
+import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { captureConsole, captureStream, createTestProgram } from '@doist/cli-core/testing'
@@ -266,6 +266,43 @@ describe('registerExtensionGroup', () => {
             expect(entry).not.toHaveProperty('description')
             expect(entry).not.toHaveProperty('version')
             expect(entry).toMatchObject({ name: 'goals', executable: true, shadowed: false })
+        })
+    })
+
+    describe('create', () => {
+        it('is not offered when the host ships no templates', () => {
+            const program = makeProgram(makeManager())
+            const group = program.commands.find((command) => command.name() === 'extension')
+            expect(group?.commands.map((command) => command.name())).not.toContain('create')
+        })
+
+        it('scaffolds and says what to do next', async () => {
+            const templatesDir = join(root, 'templates', 'plain')
+            await mkdir(templatesDir, { recursive: true })
+            await writeFile(join(templatesDir, 'executable'), '#!/bin/sh\necho {{NAME}}\n')
+
+            const manager = makeManager()
+            const program = createTestProgram((p) => {
+                registerExtensionGroup(p, manager, { templatesDir: join(root, 'templates') })
+            })
+            const argv = ['node', 'td', 'extension', 'create', 'goals']
+            vi.spyOn(process, 'argv', 'get').mockReturnValue(argv)
+            // `create` writes into the working directory, so move there and
+            // put it back — vitest shares one process across this file.
+            const cwd = process.cwd()
+            process.chdir(root)
+            try {
+                await program.parseAsync(argv)
+            } finally {
+                process.chdir(cwd)
+            }
+
+            const rendered = lines().join('\n')
+            expect(rendered).toContain('Created td-goals from the plain template')
+            expect(rendered).toContain('td extension install .')
+            await expect(readFile(join(root, 'td-goals', 'td-goals'), 'utf8')).resolves.toContain(
+                'echo goals',
+            )
         })
     })
 

--- a/src/lib/extensions/commands.ts
+++ b/src/lib/extensions/commands.ts
@@ -15,6 +15,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { CliError, formatJson, printEmpty } from '@doist/cli-core'
 import type { Command } from 'commander'
+import { createExtension } from './create.js'
 import type { ExtensionManager } from './manager.js'
 import type { ExtensionListing, RemoveResult, UpgradeResult } from './types.js'
 
@@ -164,6 +165,40 @@ function count(n: number, noun: string): string {
     return `${n} ${noun}${n === 1 ? '' : 's'}`
 }
 
+async function createScaffold(
+    manager: ExtensionManager,
+    templatesDir: string,
+    name: string,
+    options: { template?: string; description?: string; json?: boolean },
+): Promise<void> {
+    const result = await createExtension(
+        name,
+        { template: options.template, description: options.description },
+        {
+            binName: manager.binName,
+            version: manager.version,
+            templatesDir,
+            reservedNames: () => manager.reservedNames(),
+        },
+    )
+
+    if (options.json) {
+        console.log(formatJson(result))
+        return
+    }
+
+    const { binName } = manager
+    console.log(`Created ${result.dirName} from the ${result.template} template:`)
+    for (const file of result.files) console.log(manager.theme.dim(`  ${file}`))
+    console.log(`
+Next:
+  cd ${result.dirName}
+  ${binName} extension install .   ${manager.theme.dim('# links it here, so every edit is live')}
+  ${binName} ${result.name}
+
+Publish it as a repository named ${result.dirName} with the \`${binName}-extension\` topic.`)
+}
+
 async function installExtension(
     manager: ExtensionManager,
     source: string,
@@ -269,7 +304,7 @@ async function removeExtension(
 export function registerExtensionGroup(
     program: Command,
     manager: ExtensionManager,
-    options: PassThroughOptions = {},
+    options: ExtensionCommandOptions = {},
 ): Command {
     const { binName } = manager
     const dispatch = options.dispatch ?? ((name, args) => manager.dispatch(name, args))
@@ -300,6 +335,19 @@ Examples:
         .description('List installed extensions')
         .option('--json', 'Output as JSON')
         .action((options) => listExtensions(manager, options))
+
+    if (options.templatesDir) {
+        const templatesDir = options.templatesDir
+        extension
+            .command('create <name>')
+            .description('Scaffold a new extension in the current directory')
+            .option('--template <name>', 'Which template to start from')
+            .option('--description <text>', 'Description for the manifest and README')
+            .option('--json', 'Output as JSON')
+            .action((name, createOptions) =>
+                createScaffold(manager, templatesDir, name, createOptions),
+            )
+    }
 
     extension
         .command('install <source>')
@@ -369,7 +417,10 @@ export type ExtensionCommands = {
     dispatch: ExtensionDispatch
 }
 
-export type PassThroughOptions = {
+export type ExtensionCommandOptions = {
+    /** Where the scaffold templates live. `create` is not offered without it. */
+    templatesDir?: string
+
     /**
      * How to run an extension. Supplied by the host so that one definition
      * serves both the command registered here and a host that dispatches
@@ -432,7 +483,7 @@ function addInstallHint(program: Command, binName: string): void {
 export async function registerExtensionPassThrough(
     program: Command,
     manager: ExtensionManager,
-    options: PassThroughOptions = {},
+    options: ExtensionCommandOptions = {},
 ): Promise<ExtensionCommands> {
     const dispatch = options.dispatch ?? ((name, args) => manager.dispatch(name, args))
     const extensions = await manager.discover()
@@ -477,7 +528,7 @@ export async function registerExtensionPassThrough(
 export async function registerExtensionCommands(
     program: Command,
     manager: ExtensionManager,
-    options: PassThroughOptions = {},
+    options: ExtensionCommandOptions = {},
 ): Promise<ExtensionCommands> {
     registerExtensionGroup(program, manager, options)
     return registerExtensionPassThrough(program, manager, options)

--- a/src/lib/extensions/commands.ts
+++ b/src/lib/extensions/commands.ts
@@ -178,7 +178,7 @@ async function createScaffold(
             binName: manager.binName,
             version: manager.version,
             templatesDir,
-            reservedNames: () => manager.reservedNames(),
+            reservedNames: manager.reservedNames,
         },
     )
 

--- a/src/lib/extensions/create.test.ts
+++ b/src/lib/extensions/create.test.ts
@@ -1,0 +1,183 @@
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createExtension, listTemplates } from './create.js'
+
+/** The templates td actually ships, so the tests cover the real files. */
+const SHIPPED = fileURLToPath(new URL('../../../templates/extension/', import.meta.url))
+
+describe('createExtension', () => {
+    let root: string
+    let templatesDir: string
+
+    function context(overrides: { templatesDir?: string; reserved?: string[] } = {}) {
+        return {
+            binName: 'td',
+            version: '5.3.2',
+            templatesDir: overrides.templatesDir ?? templatesDir,
+            reservedNames: () => overrides.reserved ?? [],
+        }
+    }
+
+    /** A template of our own, so these tests do not move when the real ones do. */
+    async function writeTemplate(name: string, files: Record<string, string>) {
+        for (const [file, contents] of Object.entries(files)) {
+            const path = join(templatesDir, name, file)
+            await mkdir(join(path, '..'), { recursive: true })
+            await writeFile(path, contents)
+        }
+    }
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-create-'))
+        templatesDir = join(root, 'templates')
+        await writeTemplate('basic', {
+            executable: '#!/bin/sh\necho {{NAME}} under {{BIN}} {{VERSION}}\n',
+            'td-extension.json': '{"description":"{{DESCRIPTION}}"}',
+            gitignore: 'node_modules/\n',
+            '.github/workflows/release.yml': 'name: release {{DIRNAME}}\n',
+        })
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('writes the template into a directory named after the extension', async () => {
+        const result = await createExtension('goals', { directory: root }, context())
+
+        expect(result).toMatchObject({ name: 'goals', dirName: 'td-goals', template: 'basic' })
+        expect((await readdir(join(root, 'td-goals'))).sort()).toEqual([
+            '.github',
+            '.gitignore',
+            'td-extension.json',
+            'td-goals',
+        ])
+    })
+
+    it('names the executable after the extension and makes it runnable', async () => {
+        await createExtension('goals', { directory: root }, context())
+
+        const executable = join(root, 'td-goals', 'td-goals')
+        // Owner-executable at least; the rest of the mode is the umask's business.
+        expect((await stat(executable)).mode & 0o100).toBe(0o100)
+        expect(await readFile(executable, 'utf8')).toContain('echo goals under td 5.3.2')
+    })
+
+    it('restores a dotfile carried under a name npm leaves alone', async () => {
+        await createExtension('goals', { directory: root }, context())
+        await expect(readFile(join(root, 'td-goals', '.gitignore'), 'utf8')).resolves.toContain(
+            'node_modules/',
+        )
+    })
+
+    it('keeps the shape of a nested path', async () => {
+        await createExtension('goals', { directory: root }, context())
+        await expect(
+            readFile(join(root, 'td-goals', '.github/workflows/release.yml'), 'utf8'),
+        ).resolves.toBe('name: release td-goals\n')
+    })
+
+    it('uses the description it is given, and a default when it is not', async () => {
+        await createExtension('goals', { directory: root, description: 'Mine' }, context())
+        await expect(
+            readFile(join(root, 'td-goals', 'td-extension.json'), 'utf8'),
+        ).resolves.toContain('Mine')
+
+        await createExtension('other', { directory: root }, context())
+        await expect(
+            readFile(join(root, 'td-other', 'td-extension.json'), 'utf8'),
+        ).resolves.toContain('A td extension')
+    })
+
+    it('accepts the command name or the directory name', async () => {
+        const bare = await createExtension('goals', { directory: root }, context())
+        const prefixed = await createExtension('td-other', { directory: root }, context())
+
+        expect(bare.dirName).toBe('td-goals')
+        expect(prefixed).toMatchObject({ name: 'other', dirName: 'td-other' })
+    })
+
+    it('refuses a name that could never be installed', async () => {
+        await expect(
+            createExtension('Not Valid', { directory: root }, context()),
+        ).rejects.toMatchObject({ code: 'EXTENSION_NAME_INVALID' })
+    })
+
+    it('refuses a name a built-in command already uses', async () => {
+        await expect(
+            createExtension('task', { directory: root }, context({ reserved: ['task'] })),
+        ).rejects.toMatchObject({ code: 'EXTENSION_NAME_RESERVED' })
+        expect(await readdir(root)).not.toContain('td-task')
+    })
+
+    it('refuses to write over something that is already there', async () => {
+        await mkdir(join(root, 'td-goals'))
+        await expect(
+            createExtension('goals', { directory: root }, context()),
+        ).rejects.toMatchObject({ code: 'EXTENSION_ALREADY_EXISTS' })
+    })
+
+    it('names the templates there are when asked for one there is not', async () => {
+        await writeTemplate('other', { executable: 'x' })
+        await expect(
+            createExtension('goals', { directory: root, template: 'nope' }, context()),
+        ).rejects.toMatchObject({
+            code: 'EXTENSION_TEMPLATE_INVALID',
+            hints: ['Available templates: basic, other.'],
+        })
+    })
+
+    it('refuses a template with a placeholder nothing fills', async () => {
+        await writeTemplate('broken', { executable: 'echo {{NOT_A_VALUE}}\n' })
+        await expect(
+            createExtension('goals', { directory: root, template: 'broken' }, context()),
+        ).rejects.toMatchObject({ code: 'EXTENSION_TEMPLATE_INVALID' })
+    })
+})
+
+describe('the templates td ships', () => {
+    let root: string
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), 'td-ext-shipped-'))
+    })
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true })
+    })
+
+    it('offers bash and node', async () => {
+        expect(await listTemplates(SHIPPED)).toEqual(['bash', 'node'])
+    })
+
+    it.each(['bash', 'node'])('scaffolds a complete %s extension', async (template) => {
+        const result = await createExtension(
+            'goals',
+            { directory: root, template },
+            {
+                binName: 'td',
+                version: '5.3.2',
+                templatesDir: SHIPPED,
+                reservedNames: () => [],
+            },
+        )
+
+        // The executable and the manifest are what make it an extension at all.
+        expect(result.files).toContain('td-goals')
+        expect(result.files).toContain('td-extension.json')
+        expect(result.files).toContain('README.md')
+
+        for (const file of result.files) {
+            const contents = await readFile(join(result.dir, file), 'utf8')
+            // `fill` refuses a placeholder it cannot resolve, so anything left
+            // here would be a literal brace pair the template meant to keep.
+            expect(contents).not.toMatch(/\{\{\w+\}\}/)
+        }
+
+        const manifest = JSON.parse(await readFile(join(result.dir, 'td-extension.json'), 'utf8'))
+        expect(manifest).toMatchObject({ manifestVersion: 1, requires: { td: '>=5.3.2' } })
+    })
+})

--- a/src/lib/extensions/create.test.ts
+++ b/src/lib/extensions/create.test.ts
@@ -92,6 +92,74 @@ describe('createExtension', () => {
         ).resolves.toContain('A td extension')
     })
 
+    it('escapes a description for the JSON file it lands in', async () => {
+        // Unescaped, this is invalid JSON — and an unreadable manifest is
+        // silently ignored, so the starting `requires` range goes too.
+        await createExtension(
+            'goals',
+            { directory: root, description: 'He said "hi"\\ and left\nabruptly' },
+            context(),
+        )
+
+        const manifest = JSON.parse(
+            await readFile(join(root, 'td-goals', 'td-extension.json'), 'utf8'),
+        )
+        expect(manifest.description).toBe('He said "hi"\\ and left\nabruptly')
+    })
+
+    it('leaves a description alone in a file that is not JSON', async () => {
+        await writeTemplate('prose', { 'README.md': 'About: {{DESCRIPTION}}\n' })
+        await createExtension(
+            'goals',
+            { directory: root, template: 'prose', description: 'He said "hi"' },
+            context(),
+        )
+
+        await expect(readFile(join(root, 'td-goals', 'README.md'), 'utf8')).resolves.toBe(
+            'About: He said "hi"\n',
+        )
+    })
+
+    it('does not read a placeholder in the description as one of its own', async () => {
+        // The check runs on the template, not on the result, so a description
+        // that looks like a placeholder is just text.
+        await createExtension(
+            'goals',
+            { directory: root, description: 'uses {{NAME}} internally' },
+            context(),
+        )
+
+        const manifest = JSON.parse(
+            await readFile(join(root, 'td-goals', 'td-extension.json'), 'utf8'),
+        )
+        expect(manifest.description).toBe('uses {{NAME}} internally')
+    })
+
+    it('writes nothing at all when a template cannot be rendered', async () => {
+        await writeTemplate('broken', {
+            'fine.txt': 'ok\n',
+            executable: 'echo {{NOT_A_VALUE}}\n',
+        })
+
+        await expect(
+            createExtension('goals', { directory: root, template: 'broken' }, context()),
+        ).rejects.toMatchObject({ code: 'EXTENSION_TEMPLATE_INVALID' })
+
+        // Not even a half-made directory, so retrying does not hit
+        // "already exists" for a failure that was the template's.
+        expect(await readdir(root)).not.toContain('td-goals')
+    })
+
+    it('reports a templates directory it cannot read, rather than claiming it is empty', async () => {
+        await expect(
+            createExtension(
+                'goals',
+                { directory: root },
+                context({ templatesDir: join(root, 'nope') }),
+            ),
+        ).rejects.toMatchObject({ code: 'ENOENT' })
+    })
+
     it('accepts the command name or the directory name', async () => {
         const bare = await createExtension('goals', { directory: root }, context())
         const prefixed = await createExtension('td-other', { directory: root }, context())
@@ -172,9 +240,10 @@ describe('the templates td ships', () => {
 
         for (const file of result.files) {
             const contents = await readFile(join(result.dir, file), 'utf8')
-            // `fill` refuses a placeholder it cannot resolve, so anything left
-            // here would be a literal brace pair the template meant to keep.
-            expect(contents).not.toMatch(/\{\{\w+\}\}/)
+            // Broader than what `fill` enforces, which only knows `{{WORD}}`:
+            // this also catches a placeholder written with a space or a dash
+            // that would otherwise ship verbatim.
+            expect(contents).not.toContain('{{')
         }
 
         const manifest = JSON.parse(await readFile(join(result.dir, 'td-extension.json'), 'utf8'))

--- a/src/lib/extensions/create.ts
+++ b/src/lib/extensions/create.ts
@@ -1,0 +1,164 @@
+/**
+ * Scaffolding a new extension.
+ *
+ * The templates are real files rather than strings in this module, so they can
+ * be read, linted and run as what they are. They belong to the host — a CLI
+ * adopting this directory brings its own — and arrive through `templatesDir`.
+ */
+
+import { chmod, mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { CliError } from '@doist/cli-core'
+import { exists } from './fs-utils.js'
+import { toCommandName, toDirName, validateExtensionName } from './source.js'
+
+export type CreateOptions = {
+    /** Template to scaffold from. Defaults to the first one available. */
+    template?: string
+    /** Where to create the directory. Defaults to the working directory. */
+    directory?: string
+    description?: string
+}
+
+export type CreateResult = {
+    name: string
+    dirName: string
+    dir: string
+    template: string
+    /** Paths written, relative to the new directory. */
+    files: string[]
+}
+
+export type CreateContext = {
+    binName: string
+    /** Host version, for the `requires` range the manifest starts with. */
+    version: string
+    /** Directory holding one subdirectory per template. */
+    templatesDir: string
+    reservedNames: () => Iterable<string>
+}
+
+/**
+ * Two names cannot be taken literally from the template directory.
+ *
+ * The executable is named after the extension, which is only known here. And
+ * npm rewrites a `.gitignore` inside a published package, so it is carried
+ * under a name npm leaves alone and restored on the way out.
+ */
+function targetName(templateFile: string, dirName: string): string {
+    if (templateFile === 'executable') return dirName
+    if (templateFile === 'gitignore') return '.gitignore'
+    return templateFile
+}
+
+export async function listTemplates(templatesDir: string): Promise<string[]> {
+    const entries = await readdir(templatesDir, { withFileTypes: true }).catch(() => [])
+    return entries
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+        .sort()
+}
+
+function fill(content: string, values: Record<string, string>): string {
+    const filled = content.replace(/\{\{(\w+)\}\}/g, (whole, key: string) =>
+        key in values ? values[key] : whole,
+    )
+
+    // A placeholder nothing replaced is a typo in the template, and shipping it
+    // verbatim into someone's new repository is worse than refusing.
+    const leftover = filled.match(/\{\{\w+\}\}/)
+    if (leftover) {
+        throw new CliError(
+            'EXTENSION_TEMPLATE_INVALID',
+            `The template refers to ${leftover[0]}, which is not a value this command supplies.`,
+        )
+    }
+    return filled
+}
+
+export async function createExtension(
+    rawName: string,
+    options: CreateOptions,
+    context: CreateContext,
+): Promise<CreateResult> {
+    const { binName } = context
+
+    // Accept `goals` or `td-goals`, and hold both to the rules install uses, so
+    // a name that could never be installed is never scaffolded either.
+    const dirName = toDirName(binName, toCommandName(binName, rawName))
+    validateExtensionName(binName, dirName)
+
+    const name = toCommandName(binName, dirName)
+    if (new Set(context.reservedNames()).has(name)) {
+        throw new CliError(
+            'EXTENSION_NAME_RESERVED',
+            `"${name}" is the name of a built-in ${binName} command.`,
+            {
+                hints: [
+                    `An extension called ${name} could never be run as \`${binName} ${name}\`.`,
+                ],
+            },
+        )
+    }
+
+    const available = await listTemplates(context.templatesDir)
+    if (available.length === 0) {
+        throw new CliError(
+            'EXTENSION_TEMPLATE_INVALID',
+            `No templates found in ${context.templatesDir}.`,
+        )
+    }
+
+    const template = options.template ?? available[0]
+    if (!available.includes(template)) {
+        throw new CliError('EXTENSION_TEMPLATE_INVALID', `There is no "${template}" template.`, {
+            hints: [`Available templates: ${available.join(', ')}.`],
+        })
+    }
+
+    const dir = join(options.directory ?? process.cwd(), dirName)
+    if (await exists(dir)) {
+        throw new CliError('EXTENSION_ALREADY_EXISTS', `${dir} already exists.`, {
+            hints: ['Choose another name, or remove the directory first.'],
+        })
+    }
+
+    const values = {
+        NAME: name,
+        DIRNAME: dirName,
+        BIN: binName,
+        VERSION: context.version,
+        DESCRIPTION: options.description ?? `A ${binName} extension`,
+        OWNER: '<owner>',
+    }
+
+    const templateDir = join(context.templatesDir, template)
+    const templateFiles = (await readdir(templateDir, { recursive: true, withFileTypes: true }))
+        .filter((entry) => entry.isFile())
+        .map((entry) => join(entry.parentPath, entry.name).slice(templateDir.length + 1))
+        .sort()
+
+    const written: string[] = []
+    for (const templateFile of templateFiles) {
+        // Only the last segment is renamed: a nested path such as
+        // `.github/workflows/release.yml` keeps its shape.
+        const segments = templateFile.split(/[\\/]/)
+        const relative = [
+            ...segments.slice(0, -1),
+            targetName(segments.at(-1) ?? '', dirName),
+        ].join('/')
+        const destination = join(dir, relative)
+
+        await mkdir(dirname(destination), { recursive: true })
+        await writeFile(
+            destination,
+            fill(await readFile(join(templateDir, templateFile), 'utf8'), values),
+        )
+        // The one file that has to be runnable, since that is what td spawns.
+        if (relative === dirName) await chmod(destination, 0o755)
+
+        written.push(relative)
+    }
+
+    return { name, dirName, dir, template, files: written }
+}

--- a/src/lib/extensions/create.ts
+++ b/src/lib/extensions/create.ts
@@ -7,10 +7,9 @@
  */
 
 import { chmod, mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { dirname, join, relative } from 'node:path'
 import { CliError } from '@doist/cli-core'
-import { exists } from './fs-utils.js'
-import { toCommandName, toDirName, validateExtensionName } from './source.js'
+import { requireUsableName, toCommandName, toDirName } from './source.js'
 
 export type CreateOptions = {
     /** Template to scaffold from. Defaults to the first one available. */
@@ -52,28 +51,43 @@ function targetName(templateFile: string, dirName: string): string {
 }
 
 export async function listTemplates(templatesDir: string): Promise<string[]> {
-    const entries = await readdir(templatesDir, { withFileTypes: true }).catch(() => [])
+    // Errors are not swallowed: a host that points this somewhere unreadable
+    // should hear why, rather than being told there are no templates.
+    const entries = await readdir(templatesDir, { withFileTypes: true })
     return entries
         .filter((entry) => entry.isDirectory())
         .map((entry) => entry.name)
         .sort()
 }
 
-function fill(content: string, values: Record<string, string>): string {
-    const filled = content.replace(/\{\{(\w+)\}\}/g, (whole, key: string) =>
-        key in values ? values[key] : whole,
-    )
+const PLACEHOLDER = /\{\{(\w+)\}\}/g
 
-    // A placeholder nothing replaced is a typo in the template, and shipping it
-    // verbatim into someone's new repository is worse than refusing.
-    const leftover = filled.match(/\{\{\w+\}\}/)
-    if (leftover) {
-        throw new CliError(
-            'EXTENSION_TEMPLATE_INVALID',
-            `The template refers to ${leftover[0]}, which is not a value this command supplies.`,
-        )
+/**
+ * Fill a template, checking it before substituting rather than after.
+ *
+ * The difference matters because one of the values is the description the user
+ * typed. Checking the result would let `--description 'uses {{NAME}}'` fail as
+ * though the template were broken, and the message would blame the wrong
+ * thing entirely.
+ */
+function fill(templateFile: string, content: string, values: Record<string, string>): string {
+    for (const [whole, key] of content.matchAll(PLACEHOLDER)) {
+        if (!(key in values)) {
+            throw new CliError(
+                'EXTENSION_TEMPLATE_INVALID',
+                `The template file ${templateFile} refers to ${whole}, which is not a value this command supplies.`,
+            )
+        }
     }
-    return filled
+
+    // Escaped for where it is going: a description holding a quote, a
+    // backslash or a newline would otherwise make the manifest invalid JSON,
+    // and an unreadable manifest is silently ignored rather than reported.
+    const escape = templateFile.endsWith('.json')
+        ? (value: string) => JSON.stringify(value).slice(1, -1)
+        : (value: string) => value
+
+    return content.replace(PLACEHOLDER, (_whole, key: string) => escape(values[key]))
 }
 
 export async function createExtension(
@@ -86,20 +100,12 @@ export async function createExtension(
     // Accept `goals` or `td-goals`, and hold both to the rules install uses, so
     // a name that could never be installed is never scaffolded either.
     const dirName = toDirName(binName, toCommandName(binName, rawName))
-    validateExtensionName(binName, dirName)
-
-    const name = toCommandName(binName, dirName)
-    if (new Set(context.reservedNames()).has(name)) {
-        throw new CliError(
-            'EXTENSION_NAME_RESERVED',
-            `"${name}" is the name of a built-in ${binName} command.`,
-            {
-                hints: [
-                    `An extension called ${name} could never be run as \`${binName} ${name}\`.`,
-                ],
-            },
-        )
-    }
+    const name = requireUsableName(
+        binName,
+        dirName,
+        context.reservedNames,
+        (taken) => `An extension called ${taken} could never be run as \`${binName} ${taken}\`.`,
+    )
 
     const available = await listTemplates(context.templatesDir)
     if (available.length === 0) {
@@ -116,13 +122,6 @@ export async function createExtension(
         })
     }
 
-    const dir = join(options.directory ?? process.cwd(), dirName)
-    if (await exists(dir)) {
-        throw new CliError('EXTENSION_ALREADY_EXISTS', `${dir} already exists.`, {
-            hints: ['Choose another name, or remove the directory first.'],
-        })
-    }
-
     const values = {
         NAME: name,
         DIRNAME: dirName,
@@ -135,30 +134,50 @@ export async function createExtension(
     const templateDir = join(context.templatesDir, template)
     const templateFiles = (await readdir(templateDir, { recursive: true, withFileTypes: true }))
         .filter((entry) => entry.isFile())
-        .map((entry) => join(entry.parentPath, entry.name).slice(templateDir.length + 1))
+        .map((entry) => relative(templateDir, join(entry.parentPath, entry.name)))
         .sort()
 
-    const written: string[] = []
-    for (const templateFile of templateFiles) {
-        // Only the last segment is renamed: a nested path such as
-        // `.github/workflows/release.yml` keeps its shape.
-        const segments = templateFile.split(/[\\/]/)
-        const relative = [
-            ...segments.slice(0, -1),
-            targetName(segments.at(-1) ?? '', dirName),
-        ].join('/')
-        const destination = join(dir, relative)
+    // Everything is read and filled before anything is written, so a template
+    // this command cannot render leaves no half-made directory behind for the
+    // user to clear up before trying again.
+    const rendered = await Promise.all(
+        templateFiles.map(async (templateFile) => {
+            // Only the last segment is renamed: a nested path such as
+            // `.github/workflows/release.yml` keeps its shape.
+            const segments = templateFile.split(/[\\/]/)
+            const path = [
+                ...segments.slice(0, -1),
+                targetName(segments.at(-1) ?? '', dirName),
+            ].join('/')
+            const content = await readFile(join(templateDir, templateFile), 'utf8')
+            return { path, content: fill(path, content, values) }
+        }),
+    )
 
-        await mkdir(dirname(destination), { recursive: true })
-        await writeFile(
-            destination,
-            fill(await readFile(join(templateDir, templateFile), 'utf8'), values),
-        )
-        // The one file that has to be runnable, since that is what td spawns.
-        if (relative === dirName) await chmod(destination, 0o755)
+    const dir = join(options.directory ?? process.cwd(), dirName)
 
-        written.push(relative)
+    // The directory is claimed by creating it, not by asking whether it is
+    // there and creating it afterwards. In a shared directory those are not
+    // the same: between the question and the answer, someone else can put a
+    // symlink where this is about to write.
+    try {
+        await mkdir(dir)
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+            throw new CliError('EXTENSION_ALREADY_EXISTS', `${dir} already exists.`, {
+                hints: ['Choose another name, or remove the directory first.'],
+            })
+        }
+        throw error
     }
 
-    return { name, dirName, dir, template, files: written }
+    for (const { path, content } of rendered) {
+        const destination = join(dir, path)
+        await mkdir(dirname(destination), { recursive: true })
+        await writeFile(destination, content)
+        // The one file that has to be runnable, since that is what td spawns.
+        if (path === dirName) await chmod(destination, 0o755)
+    }
+
+    return { name, dirName, dir, template, files: rendered.map(({ path }) => path) }
 }

--- a/src/lib/extensions/install.ts
+++ b/src/lib/extensions/install.ts
@@ -39,8 +39,8 @@ import { installDependencies } from './npm.js'
 import {
     authoredManifestFileName,
     parseSource,
+    requireUsableName,
     toCommandName,
-    validateExtensionName,
 } from './source.js'
 import { removeState, writeState } from './state.js'
 import type { AuthoredManifest, Extension, InstallOptions, InstallResult } from './types.js'
@@ -70,21 +70,13 @@ async function preflight(
     context: InstallContext,
     options: InstallOptions,
 ): Promise<Extension | undefined> {
-    validateExtensionName(context.binName, dirName)
-    const name = toCommandName(context.binName, dirName)
-
-    const reserved = new Set(context.reservedNames())
-    if (reserved.has(name)) {
-        throw new CliError(
-            'EXTENSION_NAME_RESERVED',
-            `"${name}" is the name of a built-in ${context.binName} command.`,
-            {
-                hints: [
-                    `An extension cannot take that name. It would only be reachable as \`${context.binName} extension exec ${name}\`.`,
-                ],
-            },
-        )
-    }
+    const name = requireUsableName(
+        context.binName,
+        dirName,
+        context.reservedNames,
+        (taken) =>
+            `An extension cannot take that name. It would only be reachable as \`${context.binName} extension exec ${taken}\`.`,
+    )
 
     // Only the entry that could collide, rather than describing every
     // installed extension to find out about one.

--- a/src/lib/extensions/manager.ts
+++ b/src/lib/extensions/manager.ts
@@ -40,6 +40,8 @@ import { satisfiesRange } from './version-range.js'
 export type ExtensionManager = {
     readonly binName: string
     readonly envPrefix: string
+    /** Host version, as reported to extensions and used for `requires` checks. */
+    readonly version: string
     readonly extensionsDir: string
     readonly officialLabel: string
     readonly theme: ExtensionTheme
@@ -175,6 +177,7 @@ export function createExtensionManager(options: ExtensionManagerOptions): Extens
     return {
         binName,
         envPrefix,
+        version,
         extensionsDir,
         officialLabel,
         theme,

--- a/src/lib/extensions/source.ts
+++ b/src/lib/extensions/source.ts
@@ -59,6 +59,33 @@ export function validateExtensionName(binName: string, dirName: string): void {
  * scp-like form. Both `parseSource` and extension discovery route through
  * this, so the two cannot drift apart.
  */
+/**
+ * The command name for a directory, once it is known to be a name this host
+ * can actually run: well formed, and not one a built-in command already
+ * answers to. `install` and `create` both ask, and must agree.
+ *
+ * The hint differs between them — one is about an extension that exists, the
+ * other about one that would be born unreachable — so the caller supplies it.
+ */
+export function requireUsableName(
+    binName: string,
+    dirName: string,
+    reservedNames: () => Iterable<string>,
+    hint: (name: string) => string,
+): string {
+    validateExtensionName(binName, dirName)
+    const name = toCommandName(binName, dirName)
+
+    if (new Set(reservedNames()).has(name)) {
+        throw new CliError(
+            'EXTENSION_NAME_RESERVED',
+            `"${name}" is the name of a built-in ${binName} command.`,
+            { hints: [hint(name)] },
+        )
+    }
+    return name
+}
+
 export function parseRepoRef(
     url: string,
 ): { host: string; owner: string; repo: string } | undefined {

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -98,7 +98,7 @@ Resolution order: \`--user <ref>\` > \`TD_USER\` > \`user.defaultUser\` from con
 - Templates and files: \`td template ...\`, \`td attachment view <file-url>\`, \`td backup ...\`
 - Help Center: \`td hc locales/search/view\`
 - Account and tooling: \`td stats\`, \`td settings ...\`, \`td config view\`, \`td accounts ...\`, \`td completion ...\`, \`td view <todoist-url>\`, \`td doctor\`, \`td update\`, \`td changelog\`
-- Extensions: \`td extension install/list/upgrade/remove/exec\` (alias: \`td ext\`)
+- Extensions: \`td extension create/install/list/upgrade/remove/exec\` (alias: \`td ext\`)
 - Developer apps: \`td apps list/view\` (requires \`td auth login --additional-scopes=app-management\`)
 - Backups: \`td backup list/download\` (requires \`td auth login --additional-scopes=backups\`)
 - Billing: \`td billing subscription/plan/prices/pricing\` (requires \`td auth login --additional-scopes=billing\`)
@@ -396,6 +396,7 @@ The \`billing\` command surface is **read-only** and requires the \`billing\` OA
 An extension is an executable named \`td-<name>\` that td runs as \`td <name> ...\`. It can be written in any language; the contract is the process boundary, not a JavaScript API.
 
 \`\`\`bash
+td extension create goals              # scaffold one (--template bash|node)
 td extension install owner/td-goals    # from a GitHub release or a clone
 td extension install --pin v0.3.0 owner/td-goals
 td extension install ./td-scratch      # a local directory, symlinked, for development

--- a/templates/extension/bash/README.md
+++ b/templates/extension/bash/README.md
@@ -1,0 +1,31 @@
+# td-{{NAME}}
+
+{{DESCRIPTION}}
+
+## Install
+
+```bash
+td extension install {{OWNER}}/td-{{NAME}}
+```
+
+## Develop
+
+```bash
+td extension install .   # symlinks this directory, so every edit is live
+td {{NAME}}
+```
+
+## Publishing
+
+Push this to a repository named `td-{{NAME}}` and add the `td-extension`
+topic, which is how `td extension search` finds it.
+
+## Notes
+
+- Everything after `td {{NAME}}` reaches this script untouched, `--help`
+  included. Global flags belong before the name: `td --user you@example.com
+{{NAME}}`.
+- Write data to stdout and diagnostics to stderr, and exit non-zero on
+  failure. td exits with whatever this script exits with.
+- Do not prompt when stdin is not a TTY — td is non-interactive by design and
+  agents call extensions.

--- a/templates/extension/bash/executable
+++ b/templates/extension/bash/executable
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# A td extension. Everything after `td {{NAME}}` arrives here untouched, this
+# script owns stdout and stderr, and td exits with whatever this script exits
+# with.
+set -euo pipefail
+
+# How to call td back. TD_NODE and TD_PATH are set by td and work on every
+# platform, including Windows, where the `td` on PATH is a .cmd shim that
+# cannot be spawned directly. Falling back to `td` keeps this runnable when
+# the script is executed by hand.
+td=(td)
+if [[ -n "${TD_NODE:-}" && -n "${TD_PATH:-}" ]]; then
+    td=("$TD_NODE" "$TD_PATH")
+fi
+
+usage() {
+    cat <<'USAGE'
+Usage: td {{NAME}} [options]
+
+{{DESCRIPTION}}
+
+Options:
+  --json      Output as JSON
+  --help      Show this message
+USAGE
+}
+
+json=false
+for arg in "$@"; do
+    case "$arg" in
+        --help | -h)
+            usage
+            exit 0
+            ;;
+        --json) json=true ;;
+    esac
+done
+
+# Calling td for something that needs no account, to show the mechanism.
+# For real data, ask td rather than the API — `"${td[@]}" task list --filter
+# today --json` — so authentication, account selection and output shape stay
+# td's job.
+host_version=$("${td[@]}" --version)
+
+if [[ "$json" == true ]]; then
+    printf '{"extension":"%s","hostVersion":"%s"}\n' "${TD_EXTENSION_NAME:-{{NAME}}}" "$host_version"
+else
+    printf 'Hello from td-{{NAME}}, running under td %s.\n' "$host_version"
+    printf 'Edit %s/td-{{NAME}} and run it again.\n' "${TD_EXTENSION_DIR:-.}"
+fi

--- a/templates/extension/bash/executable
+++ b/templates/extension/bash/executable
@@ -18,8 +18,6 @@ usage() {
     cat <<'USAGE'
 Usage: td {{NAME}} [options]
 
-{{DESCRIPTION}}
-
 Options:
   --json      Output as JSON
   --help      Show this message

--- a/templates/extension/bash/td-extension.json
+++ b/templates/extension/bash/td-extension.json
@@ -1,0 +1,7 @@
+{
+    "manifestVersion": 1,
+    "description": "{{DESCRIPTION}}",
+    "requires": {
+        "td": ">={{VERSION}}"
+    }
+}

--- a/templates/extension/node/README.md
+++ b/templates/extension/node/README.md
@@ -1,0 +1,33 @@
+# td-{{NAME}}
+
+{{DESCRIPTION}}
+
+## Install
+
+```bash
+td extension install {{OWNER}}/td-{{NAME}}
+```
+
+## Develop
+
+```bash
+td extension install .   # symlinks this directory, so every edit is live
+td {{NAME}}
+```
+
+## Publishing
+
+Push this to a repository named `td-{{NAME}}` and add the `td-extension`
+topic, which is how `td extension search` finds it.
+
+## Notes
+
+- Everything after `td {{NAME}}` reaches this script untouched, `--help`
+  included. Global flags belong before the name: `td --user you@example.com
+{{NAME}}`.
+- Write data to stdout and diagnostics to stderr, and exit non-zero on
+  failure. td exits with whatever this script exits with.
+- Do not prompt when stdin is not a TTY — td is non-interactive by design and
+  agents call extensions.
+- Dependencies go in `package.json`; td runs `npm ci --omit=dev` when it
+  installs the extension, so they do not need vendoring.

--- a/templates/extension/node/README.md
+++ b/templates/extension/node/README.md
@@ -29,5 +29,6 @@ topic, which is how `td extension search` finds it.
   failure. td exits with whatever this script exits with.
 - Do not prompt when stdin is not a TTY — td is non-interactive by design and
   agents call extensions.
-- Dependencies go in `package.json`; td runs `npm ci --omit=dev` when it
-  installs the extension, so they do not need vendoring.
+- Dependencies go in `package.json`; td installs them when it installs the
+  extension, so they do not need vendoring. It runs `npm ci --omit=dev` once
+  you commit a `package-lock.json`, and `npm install --omit=dev` until then.

--- a/templates/extension/node/executable
+++ b/templates/extension/node/executable
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+//
+// A td extension. Everything after `td {{NAME}}` arrives here untouched, this
+// script owns stdout and stderr, and td exits with whatever this script exits
+// with.
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const run = promisify(execFile)
+
+// How to call td back. TD_NODE and TD_PATH are set by td and work on every
+// platform, including Windows, where the `td` on PATH is a .cmd shim that
+// cannot be spawned directly.
+const { TD_NODE, TD_PATH, TD_EXTENSION_NAME, TD_EXTENSION_DIR } = process.env
+const [command, prefix] = TD_NODE && TD_PATH ? [TD_NODE, [TD_PATH]] : ['td', []]
+
+/**
+ * Ask td rather than the API: authentication, account selection and output
+ * shape stay td's job, and `--json` is a contract it keeps.
+ */
+async function td(...args) {
+    const { stdout } = await run(command, [...prefix, ...args])
+    return stdout.trim()
+}
+
+const args = process.argv.slice(2)
+
+if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(`Usage: td {{NAME}} [options]
+
+{{DESCRIPTION}}
+
+Options:
+  --json      Output as JSON
+  --help      Show this message
+`)
+    process.exit(0)
+}
+
+try {
+    // Something that needs no account, to show the mechanism. For real data:
+    // JSON.parse(await td('task', 'list', '--filter', 'today', '--json'))
+    const hostVersion = await td('--version')
+
+    if (args.includes('--json')) {
+        console.log(
+            JSON.stringify({ extension: TD_EXTENSION_NAME ?? '{{NAME}}', hostVersion }, null, 2),
+        )
+    } else {
+        console.log(`Hello from td-{{NAME}}, running under td ${hostVersion}.`)
+        console.log(`Edit ${TD_EXTENSION_DIR ?? '.'}/td-{{NAME}} and run it again.`)
+    }
+} catch (error) {
+    // Diagnostics to stderr, non-zero exit: td passes both straight through.
+    process.stderr.write(`td-{{NAME}}: ${error.message}\n`)
+    process.exitCode = 1
+}

--- a/templates/extension/node/executable
+++ b/templates/extension/node/executable
@@ -29,8 +29,6 @@ const args = process.argv.slice(2)
 if (args.includes('--help') || args.includes('-h')) {
     process.stdout.write(`Usage: td {{NAME}} [options]
 
-{{DESCRIPTION}}
-
 Options:
   --json      Output as JSON
   --help      Show this message

--- a/templates/extension/node/gitignore
+++ b/templates/extension/node/gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/templates/extension/node/package.json
+++ b/templates/extension/node/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "td-{{NAME}}",
+    "version": "0.1.0",
+    "description": "{{DESCRIPTION}}",
+    "private": true,
+    "type": "module",
+    "license": "MIT"
+}

--- a/templates/extension/node/td-extension.json
+++ b/templates/extension/node/td-extension.json
@@ -1,0 +1,7 @@
+{
+    "manifestVersion": 1,
+    "description": "{{DESCRIPTION}}",
+    "requires": {
+        "td": ">={{VERSION}}"
+    }
+}


### PR DESCRIPTION
First half of `td extension create`, the phase 2 scaffolding command. `bash` and `node` templates are here; `compiled`, with the release workflow, follows separately.

## What it does

```
$ td extension create goals
Created td-goals from the bash template:
  README.md
  td-goals
  td-extension.json

Next:
  cd td-goals
  td extension install .   # links it here, so every edit is live
  td goals

Publish it as a repository named td-goals with the `td-extension` topic.
```

`--template bash|node`, `--description <text>`, `--json`.

## The bar

This works with nothing edited, for both templates — verified end to end against a build:

```bash
td extension create goals
cd td-goals
td extension install .
td goals          # Hello from td-goals, running under td 5.3.2.
td goals --json   # {"extension":"goals","hostVersion":"5.3.2"}
td goals --help   # the extension's own usage, not td's
```

That is why neither template calls the API. They demonstrate calling td back through `TD_NODE`/`TD_PATH` — the part worth teaching, since it is what works on Windows, where the `td` on PATH is a `.cmd` shim that cannot be spawned directly — but against `td --version`, so a fresh scaffold runs before anyone has logged in. The line that fetches real data is there, commented, one edit away.

## Templates are real files

Under `templates/extension/<kind>/`, so they can be read, linted and run as what they are rather than escaped inside template literals.

They ship through the `files` field and resolve with `new URL('../../../templates/extension/', import.meta.url)`, which lands on the same directory from `src/commands/extension/` under vitest and from `dist/commands/extension/` in an install — so there is no copy step in the build that can quietly not happen. `npm pack --dry-run` confirms all eight files are in the tarball.

Two names cannot be taken literally from the template directory: the executable is named after the extension, and npm rewrites a `.gitignore` inside a published package, so it travels as `gitignore` and is restored on the way out.

A placeholder nothing fills is refused rather than written through, so a typo in a template fails a test here instead of landing in someone's new repository. One test scaffolds each shipped template and asserts no `{{…}}` survives anywhere.

## Notes

- Names go through the same `validateExtensionName` and reserved-name check as `install`, so a name that could never be installed is never scaffolded.
- `create` is only registered when the host supplies `templatesDir`, so a CLI adopting `src/lib/extensions/` without templates simply does not offer it.
- `ExtensionManager` gains `version`, which the manifest's starting `requires` range needs. `PassThroughOptions` is renamed `ExtensionCommandOptions` now that it carries more than `dispatch` — no external consumers.
