### PR TITLE
fix: omit status suffixes from abbreviated user names

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -180,11 +180,9 @@ New subcommand? Copy a sibling in the target group, wire it in that group's
 - **`pagination.ts`** — `paginate()`, `LIMITS` (tasks: 300, projects: 50, …)
 - **`completion.ts`** — `parseCompLine`, `getCompletions`,
   `withCaseInsensitiveChoices`, `withUnvalidatedChoices` (Commander tree-walker)
-- **`text.ts`** — `firstCodePoint`, `truncateForDisplay`. Code-point-safe
-  indexing and truncation. Reach for these rather than `name[0]` or
-  `text.slice(0, n)` on anything user-supplied: those cut by UTF-16 code unit
-  and split an emoji into a lone surrogate, which has no UTF-8 form and is
-  rejected by anything requiring well-formed text.
+- **`text.ts`** — `truncateForDisplay`: code-point-safe truncation. Use it
+  instead of `text.slice(0, n)` on user-supplied text to avoid splitting a
+  surrogate pair. Name initials use grapheme segmentation in `collaborators.ts`.
 - **`spinner.ts`** — `startEarlySpinner`, `LoadingSpinner` class
   (yocto-spinner wrapper)
 - **`markdown.ts`** — `preloadMarkdown`, markdown → terminal renderer

--- a/src/commands/completed/completed.test.ts
+++ b/src/commands/completed/completed.test.ts
@@ -297,34 +297,37 @@ describe('completed command', () => {
         )
     })
 
-    it('displays assignee for shared project tasks', async () => {
-        const program = createProgram()
+    it.each(['Alice Smith', 'Alice Smith (OOO until Friday)', 'Alice Smith | 🌴'])(
+        'displays assignee for shared project tasks with display name %j',
+        async (name) => {
+            const program = createProgram()
 
-        mockApi.getCompletedTasksByCompletionDate.mockResolvedValue({
-            items: [
-                {
-                    id: 'task-1',
-                    content: 'Assigned task',
-                    projectId: 'proj-shared',
-                    priority: 1,
-                    responsibleUid: 'user-123',
-                },
-            ],
-            nextCursor: null,
-        })
-        mockApi.getProjects.mockResolvedValue({
-            results: [{ id: 'proj-shared', name: 'Shared Project', isShared: true }],
-            nextCursor: null,
-        })
-        mockApi.getProjectCollaborators.mockResolvedValue({
-            results: [{ id: 'user-123', name: 'Alice Smith', email: 'alice@example.com' }],
-            nextCursor: null,
-        })
+            mockApi.getCompletedTasksByCompletionDate.mockResolvedValue({
+                items: [
+                    {
+                        id: 'task-1',
+                        content: 'Assigned task',
+                        projectId: 'proj-shared',
+                        priority: 1,
+                        responsibleUid: 'user-123',
+                    },
+                ],
+                nextCursor: null,
+            })
+            mockApi.getProjects.mockResolvedValue({
+                results: [{ id: 'proj-shared', name: 'Shared Project', isShared: true }],
+                nextCursor: null,
+            })
+            mockApi.getProjectCollaborators.mockResolvedValue({
+                results: [{ id: 'user-123', name, email: 'alice@example.com' }],
+                nextCursor: null,
+            })
 
-        await program.parseAsync(['node', 'td', 'completed'])
+            await program.parseAsync(['node', 'td', 'completed'])
 
-        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('+Alice S.'))
-    })
+            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('+Alice S.'))
+        },
+    )
 
     it('displays assignee for workspace project tasks', async () => {
         const program = createProgram()

--- a/src/lib/collaborators.test.ts
+++ b/src/lib/collaborators.test.ts
@@ -1,32 +1,53 @@
-/**
- * Unit tests for `formatUserShortName`.
- *
- * The emoji case is the regression: abbreviating by UTF-16 code unit took the
- * first half of 🌴 and returned `"Omar \ud83c."`, a lone surrogate that has no
- * UTF-8 form and is rejected by anything requiring well-formed text. The other
- * three names are the control and must be byte-identical to the old behaviour.
- */
 import { describe, expect, it } from 'vitest'
 
 import { formatUserShortName } from './collaborators.js'
 
 describe('formatUserShortName', () => {
     it.each([
-        ['Omar | 🌴', 'Omar 🌴.'],
-        ['Ada Lovelace', 'Ada L.'],
-        ['Rui', 'Rui'],
-        ['Yuki 🎌 Tanaka', 'Yuki T.'],
-    ])('abbreviates %j to %j', (input, expected) => {
+        ['Name | 🌴', 'Name'],
+        ['name (OOO Friday)', 'name'],
+        ['Firstname Surname (OOO Sept 4-7)', 'Firstname S.'],
+        ['Firstname Surname (OOO until Tuesday, Sept 8)', 'Firstname S.'],
+        ['Firstname Surname (working half days sept 1-4)', 'Firstname S.'],
+        ['Firstname Surname - OOO back Tue', 'Firstname S.'],
+        ['Firstname OOO - Back on September 8', 'Firstname'],
+        ['Firstname Surname (Back 7 Sept)', 'Firstname S.'],
+        ['Firstname 🏖️ (🔙 31 Aug)', 'Firstname'],
+        ['Firstname Surname', 'Firstname S.'],
+        // Different initials ensure that a status month cannot pass as a surname.
+        ['Ada Lovelace (Back 7 Sept)', 'Ada L.'],
+        ['Ada Lovelace – away', 'Ada L.'],
+        ['Ada Lovelace — away', 'Ada L.'],
+        ['Ada Lovelace | away', 'Ada L.'],
+        ['Ada ooo', 'Ada'],
+        ['Ada Lovelace OOO', 'Ada L.'],
+        ['Ada (nickname) (OOO Friday)', 'Ada'],
+    ])('omits status text in %j, returning %j', (input, expected) => {
         expect(formatUserShortName(input)).toBe(expected)
     })
 
-    it('always returns well-formed output', () => {
-        for (const name of ['Omar | 🌴', 'Ada Lovelace', 'Rui', 'Yuki 🎌 Tanaka', 'A 👨‍👩‍👧']) {
-            expect(formatUserShortName(name).isWellFormed()).toBe(true)
-        }
-    })
-
-    it('collapses surrounding and repeated whitespace as before', () => {
-        expect(formatUserShortName('  Ada   Lovelace  ')).toBe('Ada L.')
+    it.each([
+        ['', ''],
+        ['   ', ''],
+        ['Rui', 'Rui'],
+        ['Ada Lovelace', 'Ada L.'],
+        ['Steven Kao Smith', 'Steven K.'],
+        ['Anne-Marie Smith-Jones', 'Anne-Marie S.'],
+        ['Ada O’Connor', 'Ada O.'],
+        ['Ada Ooolander', 'Ada O.'],
+        ['  Ada \t Lovelace  ', 'Ada L.'],
+        ['José García', 'José G.'],
+        ['李 小明', '李 小.'],
+        ['محمد علي', 'محمد ع.'],
+        ['Ada E\u0301clair', 'Ada E\u0301.'],
+        ['Ada 𐐀name', 'Ada 𐐀.'],
+        ['Yuki 🎌 Tanaka', 'Yuki'],
+        ['Omar | 🌴', 'Omar'],
+        ['A 👨‍👩‍👧', 'A'],
+        ['Ada 123', 'Ada'],
+    ])('abbreviates %j to %j without splitting graphemes', (input, expected) => {
+        const result = formatUserShortName(input)
+        expect(result).toBe(expected)
+        expect(result.isWellFormed()).toBe(true)
     })
 })

--- a/src/lib/collaborators.test.ts
+++ b/src/lib/collaborators.test.ts
@@ -22,6 +22,9 @@ describe('formatUserShortName', () => {
         ['Ada ooo', 'Ada'],
         ['Ada Lovelace OOO', 'Ada L.'],
         ['Ada (nickname) (OOO Friday)', 'Ada'],
+        ['Ada (nickname) OOO', 'Ada'],
+        ['Ada OOO (nickname)', 'Ada'],
+        ['Ada OOO (nickname) OOO', 'Ada'],
     ])('omits status text in %j, returning %j', (input, expected) => {
         expect(formatUserShortName(input)).toBe(expected)
     })
@@ -45,6 +48,9 @@ describe('formatUserShortName', () => {
         ['Omar | 🌴', 'Omar'],
         ['A 👨‍👩‍👧', 'A'],
         ['Ada 123', 'Ada'],
+        ['Ada (nickname) Lovelace', 'Ada'],
+        ['Ada 🎌Lovelace', 'Ada'],
+        ['Ada 1Lovelace', 'Ada'],
     ])('abbreviates %j to %j without splitting graphemes', (input, expected) => {
         const result = formatUserShortName(input)
         expect(result).toBe(expected)

--- a/src/lib/collaborators.ts
+++ b/src/lib/collaborators.ts
@@ -132,18 +132,18 @@ const nameSegmenter = new Intl.Segmenter('en', { granularity: 'grapheme' })
 export function formatUserShortName(fullName: string): string {
     // Require spaces around separators so hyphenated names stay intact.
     let name = fullName.trim().split(/\s+[|–—-]\s+/)[0]
-    // A display name can carry more than one trailing parenthesized suffix.
-    while (/\s+\([^()]*\)$/.test(name)) {
-        name = name.replace(/\s+\([^()]*\)$/, '').trimEnd()
+    // Remove mixed suffixes repeatedly, regardless of their order.
+    const statusSuffix = /\s+(?:\([^()]*\)|OOO)$/i
+    while (statusSuffix.test(name)) {
+        name = name.replace(statusSuffix, '').trimEnd()
     }
-    name = name.replace(/\s+OOO$/i, '')
 
     // Match the web client's first/second-token rule after removing statuses.
     const [firstName, secondName] = name.split(/\s+/)
-    if (!secondName || !/\p{L}/u.test(secondName)) return firstName
+    if (!secondName) return firstName
 
     const initial = nameSegmenter.segment(secondName)[Symbol.iterator]().next().value?.segment
-    return initial ? `${firstName} ${initial}.` : firstName
+    return initial && /\p{L}/u.test(initial) ? `${firstName} ${initial}.` : firstName
 }
 
 export interface FormatAssigneeOptions {

--- a/src/lib/collaborators.ts
+++ b/src/lib/collaborators.ts
@@ -2,7 +2,6 @@ import { isWorkspaceProject, type TodoistApi } from '@doist/todoist-sdk'
 import { getCurrentUserId, type Project, type Task } from './api/core.js'
 import { CliError } from './errors.js'
 import { extractId, isIdRef } from './refs.js'
-import { firstCodePoint } from './text.js'
 
 export interface CollaboratorInfo {
     id: string
@@ -127,16 +126,24 @@ export class CollaboratorCache {
     }
 }
 
+const nameSegmenter = new Intl.Segmenter('en', { granularity: 'grapheme' })
+
+/** Abbreviate a display name without treating common status suffixes as names. */
 export function formatUserShortName(fullName: string): string {
-    const parts = fullName.trim().split(/\s+/)
-    if (parts.length === 1) {
-        return parts[0]
+    // Require spaces around separators so hyphenated names stay intact.
+    let name = fullName.trim().split(/\s+[|–—-]\s+/)[0]
+    // A display name can carry more than one trailing parenthesized suffix.
+    while (/\s+\([^()]*\)$/.test(name)) {
+        name = name.replace(/\s+\([^()]*\)$/, '').trimEnd()
     }
-    const firstName = parts[0]
-    // By code point, not `[0]`: indexing by code unit takes half of an astral
-    // character, so a last name starting with an emoji yields a lone surrogate.
-    const lastInitial = firstCodePoint(parts[parts.length - 1])
-    return `${firstName} ${lastInitial}.`
+    name = name.replace(/\s+OOO$/i, '')
+
+    // Match the web client's first/second-token rule after removing statuses.
+    const [firstName, secondName] = name.split(/\s+/)
+    if (!secondName || !/\p{L}/u.test(secondName)) return firstName
+
+    const initial = nameSegmenter.segment(secondName)[Symbol.iterator]().next().value?.segment
+    return initial ? `${firstName} ${initial}.` : firstName
 }
 
 export interface FormatAssigneeOptions {

--- a/src/lib/text.test.ts
+++ b/src/lib/text.test.ts
@@ -7,25 +7,7 @@
  */
 import { describe, expect, it } from 'vitest'
 
-import { firstCodePoint, truncateForDisplay } from './text.js'
-
-describe('firstCodePoint', () => {
-    it('keeps an astral character whole', () => {
-        expect(firstCodePoint('🌴')).toBe('🌴')
-        expect(firstCodePoint('🌴 tail')).toBe('🌴')
-    })
-
-    it('returns the same character as [0] for ordinary text', () => {
-        // The control: for BMP text the two agree, so the fix only moves the broken case.
-        for (const s of ['Lovelace', 'ada', 'Álvarez', 'здраво', '123']) {
-            expect(firstCodePoint(s)).toBe(s[0])
-        }
-    })
-
-    it('returns an empty string for empty input rather than undefined', () => {
-        expect(firstCodePoint('')).toBe('')
-    })
-})
+import { truncateForDisplay } from './text.js'
 
 describe('truncateForDisplay', () => {
     it('leaves a string that already fits completely untouched', () => {

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -22,14 +22,6 @@
  * fix. Reach for `Intl.Segmenter` if that ever matters.
  */
 
-/** The first code point of `text`, or `''` when empty. Never half a surrogate pair. */
-export function firstCodePoint(text: string): string {
-    // String iteration steps by code point, so this reads one character rather
-    // than materialising every code point in the string to discard all but one.
-    for (const character of text) return character
-    return ''
-}
-
 /**
  * `text` shortened to `maxCodePoints` with a trailing ellipsis, or unchanged
  * when it already fits.


### PR DESCRIPTION
## Overview

Abbreviated assignee names currently take their initial from the final word, so `Ada Lovelace (OOO Friday)` appears as `Ada F.`. This removes common status suffixes before using the first name and the second token’s initial, following the web client’s token order.

Trailing parenthesized text, suffixes separated by spaced pipes or dashes, and a trailing standalone `OOO` are omitted. When the second token’s first grapheme has no letters, only the first name is shown: `Name | 🌴` becomes `Name`. Hyphenated names stay intact, and initials retain complete Unicode graphemes, including combining accents. These rules affect abbreviations only; parenthesized nicknames and decorative second tokens are intentionally omitted.

Closes #508.

## Verification

- All 1,930 tests pass, including all reported name shapes, accented initials, mixed suffixes, punctuation initials, and completed-task assignee output.
- Type-check, build, and formatting pass. Lint reports only the existing whitespace warning in `src/commands/user/aliases.ts`.
- Verified on Node 24.20.0.
